### PR TITLE
feat(processing): two-pass streaming for FEAT_* operators (closes #12)

### DIFF
--- a/processing/feature/bucketize.go
+++ b/processing/feature/bucketize.go
@@ -32,6 +32,11 @@ type bucketize struct {
 	label      string
 	boundaries []float64
 	quantiles  int
+	// quantileVals accumulates non-null inputs during PrePass when the
+	// operator is in quantile mode. Finalize sorts and reduces it to N-1
+	// boundary cutpoints stored back on boundaries; EmitRow then uses
+	// boundaries the same way it does in explicit mode.
+	quantileVals []float64
 }
 
 func newBucketize(feat *types.Feature, _ *encoding.Schema) (Computer, error) {
@@ -85,6 +90,41 @@ func (c *bucketize) Compute(records []Record, field string) (map[string]Output, 
 	return map[string]Output{c.label: {Values: values, Nulls: nulls}}, nil
 }
 
+// PrePass collects non-null inputs in quantile mode so Finalize can derive
+// boundaries. Explicit mode is stateless: the boundaries are already
+// fixed at construction time.
+func (c *bucketize) PrePass(r Record, field string) error {
+	if c.quantiles <= 0 {
+		return nil
+	}
+	if v, ok := r.NumericValue(field); ok {
+		c.quantileVals = append(c.quantileVals, v)
+	}
+	return nil
+}
+
+// Finalize converts accumulated quantile inputs into N-1 boundary
+// cutpoints. In explicit mode it is a no-op.
+func (c *bucketize) Finalize() error {
+	if c.quantiles <= 0 {
+		return nil
+	}
+	c.boundaries = quantileBoundariesFromValues(c.quantileVals, c.quantiles)
+	c.quantileVals = nil
+	return nil
+}
+
+// EmitRow returns the bucket index for the current record using the
+// boundaries fixed at construction (explicit) or computed in Finalize
+// (quantile).
+func (c *bucketize) EmitRow(r Record, field string) (map[string]Output, error) {
+	v, ok := r.NumericValue(field)
+	if !ok {
+		return map[string]Output{c.label: {Values: []float64{0}, Nulls: []bool{true}}}, nil
+	}
+	return map[string]Output{c.label: {Values: []float64{float64(bucketIndex(v, c.boundaries))}}}, nil
+}
+
 // bucketIndex returns the index of the bucket v belongs to, given sorted
 // boundaries. A value v lands at index i when bounds[i-1] < v <= bounds[i]
 // (treating bounds[-1] as -inf and bounds[len] as +inf).
@@ -108,7 +148,15 @@ func quantileBoundaries(records []Record, field string, n int) []float64 {
 			vals = append(vals, v)
 		}
 	}
-	if len(vals) < 2 {
+	return quantileBoundariesFromValues(vals, n)
+}
+
+// quantileBoundariesFromValues returns N-1 quantile cutpoints from a
+// pre-collected slice of non-null inputs. Shared between Compute (which
+// scans records) and Finalize (which consumes the streaming PrePass
+// accumulator). Returns nil when there are fewer than 2 inputs.
+func quantileBoundariesFromValues(vals []float64, n int) []float64 {
+	if n < 2 || len(vals) < 2 {
 		return nil
 	}
 	sort.Float64s(vals)

--- a/processing/feature/date_features.go
+++ b/processing/feature/date_features.go
@@ -42,10 +42,11 @@ func newDateFeatures(feat *types.Feature, schema *encoding.Schema) (Computer, er
 	return &dateFeatures{prefix: prefix}, nil
 }
 
+var dateFeatureParts = []string{"year", "month", "day", "dow", "quarter"}
+
 func (c *dateFeatures) Compute(records []Record, field string) (map[string]Output, error) {
-	parts := []string{"year", "month", "day", "dow", "quarter"}
-	out := make(map[string]Output, len(parts))
-	for _, p := range parts {
+	out := make(map[string]Output, len(dateFeatureParts))
+	for _, p := range dateFeatureParts {
 		out[c.columnName(p)] = Output{
 			Values: make([]float64, len(records)),
 			Nulls:  make([]bool, len(records)),
@@ -55,21 +56,50 @@ func (c *dateFeatures) Compute(records []Record, field string) (map[string]Outpu
 	for i, r := range records {
 		v, ok := r.NumericValue(field)
 		if !ok {
-			for _, p := range parts {
+			for _, p := range dateFeatureParts {
 				out[c.columnName(p)].Nulls[i] = true
 			}
 			continue
 		}
-		t := time.Unix(int64(v)*86400, 0).UTC()
-		year, month, day := t.Date()
-
-		out[c.columnName("year")].Values[i] = float64(year)
-		out[c.columnName("month")].Values[i] = float64(month)
-		out[c.columnName("day")].Values[i] = float64(day)
-		out[c.columnName("dow")].Values[i] = float64(t.Weekday())
-		out[c.columnName("quarter")].Values[i] = float64((int(month)-1)/3 + 1)
+		y, m, d, dow, q := decodeDateParts(v)
+		out[c.columnName("year")].Values[i] = y
+		out[c.columnName("month")].Values[i] = m
+		out[c.columnName("day")].Values[i] = d
+		out[c.columnName("dow")].Values[i] = dow
+		out[c.columnName("quarter")].Values[i] = q
 	}
 	return out, nil
+}
+
+func (c *dateFeatures) PrePass(_ Record, _ string) error { return nil }
+
+func (c *dateFeatures) Finalize() error { return nil }
+
+func (c *dateFeatures) EmitRow(r Record, field string) (map[string]Output, error) {
+	out := make(map[string]Output, len(dateFeatureParts))
+	v, ok := r.NumericValue(field)
+	if !ok {
+		for _, p := range dateFeatureParts {
+			out[c.columnName(p)] = Output{Values: []float64{0}, Nulls: []bool{true}}
+		}
+		return out, nil
+	}
+	y, m, d, dow, q := decodeDateParts(v)
+	out[c.columnName("year")] = Output{Values: []float64{y}}
+	out[c.columnName("month")] = Output{Values: []float64{m}}
+	out[c.columnName("day")] = Output{Values: []float64{d}}
+	out[c.columnName("dow")] = Output{Values: []float64{dow}}
+	out[c.columnName("quarter")] = Output{Values: []float64{q}}
+	return out, nil
+}
+
+// decodeDateParts converts a days-since-Unix-epoch value into the five
+// derived parts (year, month, day, day-of-week, quarter) that
+// FEAT_DATE_FEATURES emits. Shared between Compute and EmitRow.
+func decodeDateParts(v float64) (year, month, day, dow, quarter float64) {
+	t := time.Unix(int64(v)*86400, 0).UTC()
+	yy, mm, dd := t.Date()
+	return float64(yy), float64(mm), float64(dd), float64(t.Weekday()), float64((int(mm)-1)/3 + 1)
 }
 
 func (c *dateFeatures) columnName(part string) string {

--- a/processing/feature/feature.go
+++ b/processing/feature/feature.go
@@ -50,6 +50,28 @@ type Computer interface {
 	Compute(records []Record, field string) (map[string]Output, error)
 }
 
+// StreamingComputer is the streaming sibling of Computer. Operators that
+// implement it can run on the streaming execution path; operators that do
+// not force a buffered fallback even on otherwise stream-eligible requests.
+//
+// Lifecycle: PrePass is called once per record on pass 1. Finalize closes
+// the precompute sweep; per-row outputs become deterministic from this
+// point. EmitRow is called once per record on pass 2 (in iteration order)
+// and returns the derived column values for that record. Each Output's
+// Values slice has length 1; if the row's output is null, Output.Nulls is
+// length 1 with a true entry and the orchestrator writes a null marker
+// instead of the value.
+//
+// Stateless per-row operators (LOG, SQRT, ONE_HOT, BUCKETIZE-explicit,
+// DATE_FEATURES) implement PrePass and Finalize as no-ops. Global-pass
+// operators accumulate state in PrePass, materialize derived state in
+// Finalize, and look it up in EmitRow.
+type StreamingComputer interface {
+	PrePass(record Record, field string) error
+	Finalize() error
+	EmitRow(record Record, field string) (map[string]Output, error)
+}
+
 // Factory constructs a Computer from a feature specification. The schema is
 // the cohort schema before any feature output is added; Computers consult it
 // to validate field types and resolve dictionaries.

--- a/processing/feature/frequency_encode.go
+++ b/processing/feature/frequency_encode.go
@@ -17,7 +17,16 @@ func init() {
 // counts per category; pass two writes the per-row encoded value. Rows
 // whose category does not appear in the count pass (only possible if the
 // record set changes between passes — which it does not here) get null.
-type frequencyEncode struct{ label string }
+type frequencyEncode struct {
+	label string
+	// Streaming state. PrePass populates counts and total; Finalize
+	// captures denom (or marks empty=true when total is zero) so EmitRow
+	// can serve per-row lookups without re-scanning.
+	counts map[string]int
+	total  int
+	denom  float64
+	empty  bool
+}
 
 func newFrequencyEncode(feat *types.Feature, schema *encoding.Schema) (Computer, error) {
 	if feat.Field == "" {
@@ -36,6 +45,44 @@ func newFrequencyEncode(feat *types.Feature, schema *encoding.Schema) (Computer,
 		label = fmt.Sprintf("FREQ_%s", feat.Field)
 	}
 	return &frequencyEncode{label: label}, nil
+}
+
+// PrePass tallies the category for one record into the operator's
+// running counts. Records whose target field is null contribute nothing.
+func (c *frequencyEncode) PrePass(r Record, field string) error {
+	if c.counts == nil {
+		c.counts = make(map[string]int, 16)
+	}
+	if s, ok := r.StringValue(field); ok {
+		c.counts[s]++
+		c.total++
+	}
+	return nil
+}
+
+// Finalize freezes the denominator so EmitRow is O(1) per row. When no
+// non-null categories were observed, every emitted row is null.
+func (c *frequencyEncode) Finalize() error {
+	if c.total == 0 {
+		c.empty = true
+		return nil
+	}
+	c.denom = float64(c.total)
+	return nil
+}
+
+// EmitRow returns the proportion (count[s]/total) for the record's
+// category, or null if the category is missing on this record or the
+// cohort had no non-null categories at all.
+func (c *frequencyEncode) EmitRow(r Record, field string) (map[string]Output, error) {
+	if c.empty {
+		return map[string]Output{c.label: {Values: []float64{0}, Nulls: []bool{true}}}, nil
+	}
+	s, ok := r.StringValue(field)
+	if !ok {
+		return map[string]Output{c.label: {Values: []float64{0}, Nulls: []bool{true}}}, nil
+	}
+	return map[string]Output{c.label: {Values: []float64{float64(c.counts[s]) / c.denom}}}, nil
 }
 
 func (c *frequencyEncode) Compute(records []Record, field string) (map[string]Output, error) {

--- a/processing/feature/log.go
+++ b/processing/feature/log.go
@@ -36,12 +36,30 @@ func (c *log) Compute(records []Record, field string) (map[string]Output, error)
 	values := make([]float64, len(records))
 	nulls := make([]bool, len(records))
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
-		if !ok || v <= -1 {
-			nulls[i] = true
-			continue
-		}
-		values[i] = math.Log1p(v)
+		values[i], nulls[i] = logValue(r, field)
 	}
 	return map[string]Output{c.label: {Values: values, Nulls: nulls}}, nil
+}
+
+// PrePass is a no-op: LOG is stateless and per-row.
+func (c *log) PrePass(_ Record, _ string) error { return nil }
+
+// Finalize is a no-op: nothing to materialize.
+func (c *log) Finalize() error { return nil }
+
+// EmitRow returns log1p(field) for the current record, mirroring Compute's
+// per-row semantics.
+func (c *log) EmitRow(r Record, field string) (map[string]Output, error) {
+	v, isNull := logValue(r, field)
+	return map[string]Output{c.label: {Values: []float64{v}, Nulls: []bool{isNull}}}, nil
+}
+
+// logValue is the shared inner math: log1p with null propagation for
+// missing values and v <= -1.
+func logValue(r Record, field string) (float64, bool) {
+	v, ok := r.NumericValue(field)
+	if !ok || v <= -1 {
+		return 0, true
+	}
+	return math.Log1p(v), false
 }

--- a/processing/feature/one_hot.go
+++ b/processing/feature/one_hot.go
@@ -74,6 +74,28 @@ func (c *oneHot) Compute(records []Record, field string) (map[string]Output, err
 	return out, nil
 }
 
+func (c *oneHot) PrePass(_ Record, _ string) error { return nil }
+
+func (c *oneHot) Finalize() error { return nil }
+
+// EmitRow returns one column per known category; the column matching the
+// record's category is 1, the rest are 0. Unknown / null categories
+// produce all-zero columns (mirrors Compute's behavior).
+func (c *oneHot) EmitRow(r Record, field string) (map[string]Output, error) {
+	out := make(map[string]Output, len(c.categories))
+	for _, cat := range c.categories {
+		out[c.columnName(cat)] = Output{Values: []float64{0}}
+	}
+	s, ok := r.StringValue(field)
+	if !ok {
+		return out, nil
+	}
+	if o, exists := out[c.columnName(s)]; exists {
+		o.Values[0] = 1
+	}
+	return out, nil
+}
+
 func (c *oneHot) columnName(category string) string {
 	// Sanitize whitespace and reserved separators so labels stay
 	// addressable as field references downstream. Replace spaces with

--- a/processing/feature/registry.go
+++ b/processing/feature/registry.go
@@ -37,6 +37,63 @@ func RegisteredTypes() []types.FeatureType {
 	return out
 }
 
+// StreamingHandle pairs a feature spec with its constructed
+// StreamingComputer. processStreaming holds a slice of these for the
+// duration of a request; PrePass / Finalize / EmitRow drive each handle.
+type StreamingHandle struct {
+	Feature  *types.Feature
+	Computer StreamingComputer
+}
+
+// IsStreamable reports whether every feature's Computer implements
+// StreamingComputer. Returns false on any unknown type or factory error
+// so the buffered path can surface the canonical error.
+func IsStreamable(features []*types.Feature, schema *encoding.Schema) bool {
+	for _, feat := range features {
+		factory, ok := Lookup(feat.Type)
+		if !ok {
+			return false
+		}
+		c, err := factory(feat, schema)
+		if err != nil {
+			return false
+		}
+		if _, ok := c.(StreamingComputer); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// BuildStreaming constructs StreamingComputer instances for each feature
+// in order. Caller should verify streamability via IsStreamable first;
+// PROCESSING_INTERNAL is returned when an operator lacks streaming
+// support, PROCESSING_CONFIG for unknown types or factory failures.
+func BuildStreaming(features []*types.Feature, schema *encoding.Schema) ([]StreamingHandle, error) {
+	if len(features) == 0 {
+		return nil, nil
+	}
+	out := make([]StreamingHandle, 0, len(features))
+	for _, feat := range features {
+		factory, ok := Lookup(feat.Type)
+		if !ok {
+			return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+				fmt.Sprintf("unknown feature type: %s", feat.Type))
+		}
+		c, err := factory(feat, schema)
+		if err != nil {
+			return nil, err
+		}
+		sc, ok := c.(StreamingComputer)
+		if !ok {
+			return nil, errors.NewCodedError(errors.PROCESSING_INTERNAL,
+				fmt.Sprintf("feature %s does not implement StreamingComputer", feat.Type))
+		}
+		out = append(out, StreamingHandle{Feature: feat, Computer: sc})
+	}
+	return out, nil
+}
+
 // Apply runs every feature in features against the record set, mutating
 // records in place to add derived columns. Failures return coded errors:
 // PROCESSING_CONFIG for unknown types or factory errors, PROCESSING_RUNTIME

--- a/processing/feature/sqrt.go
+++ b/processing/feature/sqrt.go
@@ -34,12 +34,24 @@ func (c *sqrt) Compute(records []Record, field string) (map[string]Output, error
 	values := make([]float64, len(records))
 	nulls := make([]bool, len(records))
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
-		if !ok || v < 0 {
-			nulls[i] = true
-			continue
-		}
-		values[i] = math.Sqrt(v)
+		values[i], nulls[i] = sqrtValue(r, field)
 	}
 	return map[string]Output{c.label: {Values: values, Nulls: nulls}}, nil
+}
+
+func (c *sqrt) PrePass(_ Record, _ string) error { return nil }
+
+func (c *sqrt) Finalize() error { return nil }
+
+func (c *sqrt) EmitRow(r Record, field string) (map[string]Output, error) {
+	v, isNull := sqrtValue(r, field)
+	return map[string]Output{c.label: {Values: []float64{v}, Nulls: []bool{isNull}}}, nil
+}
+
+func sqrtValue(r Record, field string) (float64, bool) {
+	v, ok := r.NumericValue(field)
+	if !ok || v < 0 {
+		return 0, true
+	}
+	return math.Sqrt(v), false
 }

--- a/processing/feature/streaming_parity_test.go
+++ b/processing/feature/streaming_parity_test.go
@@ -1,0 +1,397 @@
+package feature
+
+import (
+	"encoding/json"
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/types"
+)
+
+// streamCompute drives a StreamingComputer across the records in
+// iteration order and assembles the per-row outputs into the same
+// map[label]Output shape Compute returns. Used for buffered/streaming
+// parity assertions.
+func streamCompute(t *testing.T, sc StreamingComputer, records []Record, field string) map[string]Output {
+	t.Helper()
+	for _, r := range records {
+		if err := sc.PrePass(r, field); err != nil {
+			t.Fatalf("PrePass: %v", err)
+		}
+	}
+	if err := sc.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	out := make(map[string]Output)
+	for i, r := range records {
+		row, err := sc.EmitRow(r, field)
+		if err != nil {
+			t.Fatalf("EmitRow row %d: %v", i, err)
+		}
+		for label, o := range row {
+			cur, ok := out[label]
+			if !ok {
+				cur = Output{
+					Values: make([]float64, len(records)),
+					Nulls:  make([]bool, len(records)),
+				}
+				out[label] = cur
+			}
+			if len(o.Nulls) > 0 && o.Nulls[0] {
+				cur.Nulls[i] = true
+			} else {
+				cur.Values[i] = o.Values[0]
+			}
+		}
+	}
+	return out
+}
+
+// assertOutputsEqual compares two map[label]Output payloads. Treats a
+// missing or all-false Nulls slice as equivalent. Used to compare
+// buffered Compute output against streamCompute output.
+func assertOutputsEqual(t *testing.T, label string, want, got map[string]Output) {
+	t.Helper()
+	wantKeys := keysOf(want)
+	gotKeys := keysOf(got)
+	if !equalStrings(wantKeys, gotKeys) {
+		t.Fatalf("%s: column sets differ\nwant=%v\ngot=%v", label, wantKeys, gotKeys)
+	}
+	for _, k := range wantKeys {
+		w := want[k]
+		g := got[k]
+		if len(w.Values) != len(g.Values) {
+			t.Fatalf("%s[%s]: length differs want=%d got=%d", label, k, len(w.Values), len(g.Values))
+		}
+		for i := range w.Values {
+			wn := i < len(w.Nulls) && w.Nulls[i]
+			gn := i < len(g.Nulls) && g.Nulls[i]
+			if wn != gn {
+				t.Errorf("%s[%s][%d]: null bit want=%v got=%v", label, k, i, wn, gn)
+				continue
+			}
+			if wn {
+				continue // both null; values undefined
+			}
+			if math.Abs(w.Values[i]-g.Values[i]) > 1e-9 {
+				t.Errorf("%s[%s][%d]: value want=%f got=%f", label, k, i, w.Values[i], g.Values[i])
+			}
+		}
+	}
+}
+
+func keysOf(m map[string]Output) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func mkNumeric(field string, values []float64, nulls []bool) []Record {
+	out := make([]Record, len(values))
+	for i := range values {
+		r := newFakeRecord()
+		if nulls != nil && nulls[i] {
+			r.nulls[field] = true
+		} else {
+			r.num[field] = values[i]
+		}
+		out[i] = r
+	}
+	return out
+}
+
+func mkCategorical(field string, values []string, nulls []bool) []Record {
+	out := make([]Record, len(values))
+	for i := range values {
+		r := newFakeRecord()
+		if nulls != nil && nulls[i] {
+			r.nulls[field] = true
+		} else {
+			r.str[field] = values[i]
+		}
+		out[i] = r
+	}
+	return out
+}
+
+func TestStreamingParity_Log(t *testing.T) {
+	records := mkNumeric("x", []float64{0, math.E - 1, 99, -2, 0}, []bool{false, false, false, false, true})
+	feat := &types.Feature{Type: types.FEAT_LOG, Field: "x"}
+
+	buffered, err := newLog(feat, nil)
+	if err != nil {
+		t.Fatalf("buffered factory: %v", err)
+	}
+	wantOut, err := buffered.Compute(records, "x")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	stream, _ := newLog(feat, nil)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "x")
+	assertOutputsEqual(t, "LOG", wantOut, gotOut)
+}
+
+func TestStreamingParity_Sqrt(t *testing.T) {
+	records := mkNumeric("x", []float64{0, 4, 9, -1, 0}, []bool{false, false, false, false, true})
+	feat := &types.Feature{Type: types.FEAT_SQRT, Field: "x"}
+
+	buffered, _ := newSqrt(feat, nil)
+	wantOut, err := buffered.Compute(records, "x")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newSqrt(feat, nil)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "x")
+	assertOutputsEqual(t, "SQRT", wantOut, gotOut)
+}
+
+func TestStreamingParity_BucketizeExplicit(t *testing.T) {
+	records := mkNumeric("x", []float64{1, 11, 25, 0, 100}, []bool{false, false, false, true, false})
+	feat := &types.Feature{
+		Type:   types.FEAT_BUCKETIZE,
+		Field:  "x",
+		Params: json.RawMessage(`{"boundaries":[10,20,30]}`),
+	}
+	buffered, _ := newBucketize(feat, nil)
+	wantOut, err := buffered.Compute(records, "x")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newBucketize(feat, nil)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "x")
+	assertOutputsEqual(t, "BUCKETIZE-explicit", wantOut, gotOut)
+}
+
+func TestStreamingParity_BucketizeQuantile(t *testing.T) {
+	records := mkNumeric("x",
+		[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0},
+		[]bool{false, false, false, false, false, false, false, false, false, false, true},
+	)
+	feat := &types.Feature{
+		Type:   types.FEAT_BUCKETIZE,
+		Field:  "x",
+		Params: json.RawMessage(`{"quantiles":4}`),
+	}
+	buffered, _ := newBucketize(feat, nil)
+	wantOut, err := buffered.Compute(records, "x")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newBucketize(feat, nil)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "x")
+	assertOutputsEqual(t, "BUCKETIZE-quantile", wantOut, gotOut)
+}
+
+func TestStreamingParity_OneHot(t *testing.T) {
+	schema := makeCategoricalSchema(t, "region", "north", "south", "east")
+	records := []Record{
+		newStringRecord("region", "north"),
+		newStringRecord("region", "south"),
+		newStringRecord("region", "north"),
+	}
+	null := newFakeRecord()
+	null.nulls["region"] = true
+	records = append(records, null)
+
+	feat := &types.Feature{Type: types.FEAT_ONE_HOT, Field: "region"}
+	buffered, err := newOneHot(feat, schema)
+	if err != nil {
+		t.Fatalf("buffered factory: %v", err)
+	}
+	wantOut, err := buffered.Compute(records, "region")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newOneHot(feat, schema)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "region")
+	assertOutputsEqual(t, "ONE_HOT", wantOut, gotOut)
+}
+
+func TestStreamingParity_DateFeatures(t *testing.T) {
+	// Days since Unix epoch — the encoding.FieldTypeDate convention.
+	records := mkNumeric("d", []float64{0, 365, 18262, 0}, []bool{false, false, false, true})
+	feat := &types.Feature{Type: types.FEAT_DATE_FEATURES, Field: "d"}
+
+	buffered, err := newDateFeatures(feat, nil)
+	if err != nil {
+		t.Fatalf("buffered factory: %v", err)
+	}
+	wantOut, err := buffered.Compute(records, "d")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newDateFeatures(feat, nil)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "d")
+	assertOutputsEqual(t, "DATE_FEATURES", wantOut, gotOut)
+}
+
+func TestStreamingParity_FrequencyEncode(t *testing.T) {
+	records := mkCategorical("region",
+		[]string{"north", "north", "north", "south", ""},
+		[]bool{false, false, false, false, true},
+	)
+	feat := &types.Feature{Type: types.FEAT_FREQUENCY_ENCODE, Field: "region"}
+
+	buffered, _ := newFrequencyEncode(feat, nil)
+	wantOut, err := buffered.Compute(records, "region")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newFrequencyEncode(feat, nil)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "region")
+	assertOutputsEqual(t, "FREQUENCY_ENCODE", wantOut, gotOut)
+}
+
+func TestStreamingParity_TargetEncode(t *testing.T) {
+	mk := func(region string, target float64, regionNull, targetNull bool) Record {
+		r := newFakeRecord()
+		if regionNull {
+			r.nulls["region"] = true
+		} else {
+			r.str["region"] = region
+		}
+		if targetNull {
+			r.nulls["price"] = true
+		} else {
+			r.num["price"] = target
+		}
+		return r
+	}
+	records := []Record{
+		mk("north", 10, false, false),
+		mk("north", 20, false, false),
+		mk("south", 4, false, false),
+		mk("south", 6, false, false),
+		mk("", 0, true, false),
+		mk("east", 0, false, true),
+	}
+	feat := &types.Feature{
+		Type:   types.FEAT_TARGET_ENCODE,
+		Field:  "region",
+		Params: json.RawMessage(`{"target":"price","smoothing":2.0}`),
+	}
+
+	buffered, err := newTargetEncode(feat, nil)
+	if err != nil {
+		t.Fatalf("buffered factory: %v", err)
+	}
+	wantOut, err := buffered.Compute(records, "region")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newTargetEncode(feat, nil)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "region")
+	assertOutputsEqual(t, "TARGET_ENCODE", wantOut, gotOut)
+}
+
+func TestStreamingParity_TrainTestSplit(t *testing.T) {
+	records := make([]Record, 100)
+	for i := range records {
+		records[i] = newFakeRecord()
+	}
+	feat := &types.Feature{
+		Type:   types.FEAT_TRAIN_TEST_SPLIT,
+		Params: json.RawMessage(`{"ratios":[0.7,0.15,0.15],"seed":42}`),
+	}
+	buffered, err := newTrainTestSplit(feat, nil)
+	if err != nil {
+		t.Fatalf("buffered factory: %v", err)
+	}
+	wantOut, err := buffered.Compute(records, "")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newTrainTestSplit(feat, nil)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "")
+	assertOutputsEqual(t, "TRAIN_TEST_SPLIT", wantOut, gotOut)
+}
+
+func TestStreamingParity_TrainTestSplit_Stratified(t *testing.T) {
+	schema := &encoding.Schema{Fields: []encoding.Field{
+		{Name: "label", Type: encoding.FieldTypeCategoricalU8, Dictionary: encoding.NewDictionary()},
+	}}
+	records := make([]Record, 60)
+	for i := range records {
+		r := newFakeRecord()
+		if i%2 == 0 {
+			r.str["label"] = "A"
+		} else {
+			r.str["label"] = "B"
+		}
+		records[i] = r
+	}
+	feat := &types.Feature{
+		Type:   types.FEAT_TRAIN_TEST_SPLIT,
+		Params: json.RawMessage(`{"ratios":[0.6,0.2,0.2],"seed":7,"stratify":"label"}`),
+	}
+	buffered, err := newTrainTestSplit(feat, schema)
+	if err != nil {
+		t.Fatalf("buffered factory: %v", err)
+	}
+	wantOut, err := buffered.Compute(records, "")
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	stream, _ := newTrainTestSplit(feat, schema)
+	gotOut := streamCompute(t, stream.(StreamingComputer), records, "")
+	assertOutputsEqual(t, "TRAIN_TEST_SPLIT-stratified", wantOut, gotOut)
+}
+
+func TestIsStreamable_UnknownType(t *testing.T) {
+	if IsStreamable([]*types.Feature{{Type: "FEAT_UNREGISTERED_TEST"}}, nil) {
+		t.Error("unknown feature type should not be streamable")
+	}
+}
+
+func TestIsStreamable_FactoryError(t *testing.T) {
+	// FEAT_LOG without a Field is a PROCESSING_CONFIG error from its
+	// factory; IsStreamable must surface that as not-streamable so the
+	// buffered path can re-run and produce the canonical error.
+	if IsStreamable([]*types.Feature{{Type: types.FEAT_LOG}}, nil) {
+		t.Error("factory error should mark feature as not streamable")
+	}
+}
+
+func TestIsStreamable_AllRegisteredOperators(t *testing.T) {
+	schema := &encoding.Schema{Fields: []encoding.Field{
+		{Name: "x", Type: encoding.FieldTypeF64, Description: "numeric for log/sqrt/bucketize"},
+		{Name: "d", Type: encoding.FieldTypeDate, Description: "date for date_features"},
+		{Name: "region", Type: encoding.FieldTypeCategoricalU8,
+			Dictionary: encoding.NewDictionary(), Description: "category for one_hot/freq/target"},
+		{Name: "price", Type: encoding.FieldTypeF64, Description: "target for target_encode"},
+	}}
+
+	cases := []*types.Feature{
+		{Type: types.FEAT_LOG, Field: "x"},
+		{Type: types.FEAT_SQRT, Field: "x"},
+		{Type: types.FEAT_BUCKETIZE, Field: "x", Params: json.RawMessage(`{"boundaries":[1,2,3]}`)},
+		{Type: types.FEAT_ONE_HOT, Field: "region"},
+		{Type: types.FEAT_DATE_FEATURES, Field: "d"},
+		{Type: types.FEAT_FREQUENCY_ENCODE, Field: "region"},
+		{Type: types.FEAT_TARGET_ENCODE, Field: "region", Params: json.RawMessage(`{"target":"price"}`)},
+		{Type: types.FEAT_TRAIN_TEST_SPLIT, Params: json.RawMessage(`{"ratios":[0.5,0.5],"seed":1}`)},
+	}
+	for _, c := range cases {
+		if !IsStreamable([]*types.Feature{c}, schema) {
+			t.Errorf("%s: expected IsStreamable=true", c.Type)
+		}
+	}
+}

--- a/processing/feature/target_encode.go
+++ b/processing/feature/target_encode.go
@@ -35,10 +35,26 @@ type targetEncodeParams struct {
 // validation/test rows leaks into the training feature. The skill flags
 // this loudly; the warning gate (PULSE_FEAT_TARGET_LEAKAGE_RISK) lands in a
 // follow-up commit and runs at orchestration time.
+// targetStat tallies sum and count for one category during PrePass.
+// Promoted to a package-level type so per-record streaming state has a
+// stable place to live alongside Compute's local-only equivalent.
+type targetStat struct {
+	sum   float64
+	count int
+}
+
 type targetEncode struct {
 	label     string
 	target    string
 	smoothing float64
+	// Streaming state. per is populated during PrePass; Finalize
+	// captures globalMean (or marks empty=true when no non-null target
+	// rows were observed) so EmitRow is O(1) per row.
+	per         map[string]*targetStat
+	globalSum   float64
+	globalCount int
+	globalMean  float64
+	empty       bool
 }
 
 func newTargetEncode(feat *types.Feature, schema *encoding.Schema) (Computer, error) {
@@ -88,11 +104,7 @@ func (c *targetEncode) Compute(records []Record, field string) (map[string]Outpu
 		return map[string]Output{c.label: {Values: []float64{}}}, nil
 	}
 
-	type stat struct {
-		sum   float64
-		count int
-	}
-	per := make(map[string]*stat, 16)
+	per := make(map[string]*targetStat, 16)
 	var globalSum float64
 	var globalCount int
 
@@ -104,7 +116,7 @@ func (c *targetEncode) Compute(records []Record, field string) (map[string]Outpu
 		}
 		st := per[s]
 		if st == nil {
-			st = &stat{}
+			st = &targetStat{}
 			per[s] = st
 		}
 		st.sum += t
@@ -130,18 +142,70 @@ func (c *targetEncode) Compute(records []Record, field string) (map[string]Outpu
 			nulls[i] = true
 			continue
 		}
-		st, found := per[s]
-		if !found || st.count == 0 {
-			values[i] = globalMean
-			continue
-		}
-		mean := st.sum / float64(st.count)
-		if c.smoothing > 0 {
-			values[i] = (float64(st.count)*mean + c.smoothing*globalMean) /
-				(float64(st.count) + c.smoothing)
-		} else {
-			values[i] = mean
-		}
+		values[i] = encodedValue(per, s, globalMean, c.smoothing)
 	}
 	return map[string]Output{c.label: {Values: values, Nulls: nulls}}, nil
+}
+
+// PrePass folds the record's (category, target) pair into the running
+// per-category and global stats. Rows with a null category or null
+// target contribute nothing — same as Compute.
+func (c *targetEncode) PrePass(r Record, field string) error {
+	if c.per == nil {
+		c.per = make(map[string]*targetStat, 16)
+	}
+	s, sOk := r.StringValue(field)
+	t, tOk := r.NumericValue(c.target)
+	if !sOk || !tOk {
+		return nil
+	}
+	st := c.per[s]
+	if st == nil {
+		st = &targetStat{}
+		c.per[s] = st
+	}
+	st.sum += t
+	st.count++
+	c.globalSum += t
+	c.globalCount++
+	return nil
+}
+
+// Finalize freezes globalMean. When no non-null target rows were
+// observed every emitted row is null.
+func (c *targetEncode) Finalize() error {
+	if c.globalCount == 0 {
+		c.empty = true
+		return nil
+	}
+	c.globalMean = c.globalSum / float64(c.globalCount)
+	return nil
+}
+
+// EmitRow returns the encoded mean for the record's category, applying
+// smoothing when configured. Mirrors Compute's per-row branch.
+func (c *targetEncode) EmitRow(r Record, field string) (map[string]Output, error) {
+	if c.empty {
+		return map[string]Output{c.label: {Values: []float64{0}, Nulls: []bool{true}}}, nil
+	}
+	s, ok := r.StringValue(field)
+	if !ok {
+		return map[string]Output{c.label: {Values: []float64{0}, Nulls: []bool{true}}}, nil
+	}
+	return map[string]Output{c.label: {Values: []float64{encodedValue(c.per, s, c.globalMean, c.smoothing)}}}, nil
+}
+
+// encodedValue is the shared smoothing math: returns globalMean for an
+// unseen category, the per-cat mean otherwise, with optional additive
+// smoothing toward globalMean. Used by both Compute and EmitRow.
+func encodedValue(per map[string]*targetStat, s string, globalMean, smoothing float64) float64 {
+	st, found := per[s]
+	if !found || st.count == 0 {
+		return globalMean
+	}
+	mean := st.sum / float64(st.count)
+	if smoothing > 0 {
+		return (float64(st.count)*mean + smoothing*globalMean) / (float64(st.count) + smoothing)
+	}
+	return mean
 }

--- a/processing/feature/train_test_split.go
+++ b/processing/feature/train_test_split.go
@@ -45,6 +45,13 @@ type trainTestSplit struct {
 	ratios   []float64
 	seed     int64
 	stratify string
+	// Streaming state. PrePass records either the row count alone (no
+	// stratify) or the per-row stratify key in iteration order. Finalize
+	// materializes the assignment table so EmitRow can index by emitIdx.
+	rowCount     int
+	stratifyKeys []string
+	assignments  []float64
+	emitIdx      int
 }
 
 func newTrainTestSplit(feat *types.Feature, schema *encoding.Schema) (Computer, error) {
@@ -124,6 +131,64 @@ func (c *trainTestSplit) Compute(records []Record, _ string) (map[string]Output,
 		c.assignBucket(groups[k], values)
 	}
 	return map[string]Output{c.label: {Values: values}}, nil
+}
+
+// PrePass records the row's stratify key (when configured) or just
+// counts the row. The stratifyKeys slice grows with iteration order so
+// Finalize can rebuild the same per-group index lists Compute uses.
+func (c *trainTestSplit) PrePass(r Record, _ string) error {
+	c.rowCount++
+	if c.stratify == "" {
+		return nil
+	}
+	s, ok := r.StringValue(c.stratify)
+	if !ok {
+		s = ""
+	}
+	c.stratifyKeys = append(c.stratifyKeys, s)
+	return nil
+}
+
+// Finalize materializes the per-row split assignment, mirroring the
+// buffered Compute branch. Memory is O(rows) — same as the buffered
+// path's output slice.
+func (c *trainTestSplit) Finalize() error {
+	c.assignments = make([]float64, c.rowCount)
+	if c.rowCount == 0 {
+		return nil
+	}
+	if c.stratify == "" {
+		c.assignBucket(rangeIndices(c.rowCount), c.assignments)
+		return nil
+	}
+	groups := make(map[string][]int, 16)
+	for i, k := range c.stratifyKeys {
+		groups[k] = append(groups[k], i)
+	}
+	c.stratifyKeys = nil
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		c.assignBucket(groups[k], c.assignments)
+	}
+	return nil
+}
+
+// EmitRow returns the precomputed split assignment for the next record
+// in iteration order. Records must be consumed in the same order as
+// PrePass observed them; the streaming dispatcher guarantees this via
+// iter.Reset().
+func (c *trainTestSplit) EmitRow(_ Record, _ string) (map[string]Output, error) {
+	if c.emitIdx >= len(c.assignments) {
+		return nil, errors.NewCodedError(errors.PROCESSING_INTERNAL,
+			"FEAT_TRAIN_TEST_SPLIT: EmitRow called more times than PrePass observed")
+	}
+	v := c.assignments[c.emitIdx]
+	c.emitIdx++
+	return map[string]Output{c.label: {Values: []float64{v}}}, nil
 }
 
 // assignBucket shuffles indices using the operator's seed (each call adds a

--- a/processing/feature_integration_test.go
+++ b/processing/feature_integration_test.go
@@ -57,10 +57,10 @@ func TestFeaturePipeline_LogThenAggregate(t *testing.T) {
 	}
 }
 
-// TestFeaturePipeline_FeatureForcesBufferedPath verifies the streaming
-// path is bypassed when features are present, even with online-capable
-// aggregators.
-func TestFeaturePipeline_FeatureForcesBufferedPath(t *testing.T) {
+// TestFeaturePipeline_StreamableFeaturePicksStreamingPath verifies that
+// requests whose every feature implements StreamingComputer flow
+// through the streaming path with online-capable aggregators.
+func TestFeaturePipeline_StreamableFeaturePicksStreamingPath(t *testing.T) {
 	schema := &encoding.Schema{
 		Fields: []encoding.Field{
 			{Name: "x", Type: encoding.FieldTypeF64, Description: "stream-eligible numeric field"},
@@ -96,8 +96,8 @@ func TestFeaturePipeline_FeatureForcesBufferedPath(t *testing.T) {
 	if _, err := p.Process(context.Background(), featReq, NewSliceIterator(records)); err != nil {
 		t.Fatalf("Process (with features): %v", err)
 	}
-	if p.lastPath != PathBuffered {
-		t.Errorf("with features expected buffered, got %s", p.lastPath)
+	if p.lastPath != PathStreaming {
+		t.Errorf("with stream-eligible features expected streaming, got %s", p.lastPath)
 	}
 }
 

--- a/processing/processor.go
+++ b/processing/processor.go
@@ -112,16 +112,19 @@ func (p *Processor) Process(ctx context.Context, req *types.Request, iter Record
 //   - no attributes (ZSCORE/PERCENTILE/RANK/NORMALIZED need a first
 //     pass to compute population stats; FORMULA is row-local but is
 //     bundled in for simplicity — every attribute today is buffered)
-//   - no features (every FEAT_* operator runs over the full record set —
-//     global-pass operators need stats before per-row emit, and per-row
-//     operators inject derived columns that downstream stages reference)
+//   - no windows (window operators run over the post-aggregate row set)
+//   - features either empty or every operator implements
+//     feature.StreamingComputer (PrePass + Finalize + EmitRow)
 //   - every aggregation type supports OnlineAggregator
 //   - filters are row-level only (every registered filter today is)
 //
 // Returns false on any unknown component type so the buffered path can
 // surface the canonical error message.
 func (p *Processor) canStream(req *types.Request) bool {
-	if len(req.Groups) > 0 || len(req.Attributes) > 0 || len(req.Windows) > 0 || len(req.Features) > 0 {
+	if len(req.Groups) > 0 || len(req.Attributes) > 0 || len(req.Windows) > 0 {
+		return false
+	}
+	if len(req.Features) > 0 && !feature.IsStreamable(req.Features, p.schema) {
 		return false
 	}
 	if len(req.Aggregations) == 0 {
@@ -146,10 +149,42 @@ func (p *Processor) canStream(req *types.Request) bool {
 	return true
 }
 
-// processStreaming runs the streaming execution path. The iterator is
-// consumed exactly once. Filters are applied row-by-row before each
-// aggregator's UpdateRow is called.
+// processStreaming runs the streaming execution path. With no features
+// the iterator is consumed exactly once: filters apply row-by-row, then
+// each aggregator's UpdateRow is called. With features, the iterator is
+// consumed twice: pass 1 drives feature.StreamingComputer.PrePass, then
+// Finalize captures any global state, iter.Reset() rewinds, and pass 2
+// emits derived columns into each record before filters and online
+// aggregators see it.
 func (p *Processor) processStreaming(ctx context.Context, req *types.Request, iter RecordIterator) (*types.Response, error) {
+	// Build streaming feature handles, if any. canStream verified that
+	// every operator supports streaming, so factory failures here are
+	// PROCESSING_CONFIG bubbling up the canonical error.
+	var streamingFeatures []feature.StreamingHandle
+	if len(req.Features) > 0 {
+		handles, err := feature.BuildStreaming(req.Features, p.schema)
+		if err != nil {
+			return nil, err
+		}
+		streamingFeatures = handles
+
+		// Pass 1: feed every record through each computer's PrePass.
+		for iter.Next() {
+			rec := iter.Record()
+			for _, h := range streamingFeatures {
+				if err := h.Computer.PrePass(rec, h.Feature.Field); err != nil {
+					return nil, err
+				}
+			}
+		}
+		for _, h := range streamingFeatures {
+			if err := h.Computer.Finalize(); err != nil {
+				return nil, err
+			}
+		}
+		iter.Reset()
+	}
+
 	// Build filter functions once.
 	filterFns, err := p.buildFilterFuncs(req.Filterers)
 	if err != nil {
@@ -183,6 +218,25 @@ func (p *Processor) processStreaming(ctx context.Context, req *types.Request, it
 	for iter.Next() {
 		totalRows++
 		r := iter.Record()
+
+		// Inject derived feature columns onto the record so filters and
+		// online aggregators see them. EmitRow is called once per record
+		// in iteration order; operators that need positional state
+		// (e.g., FEAT_TRAIN_TEST_SPLIT) rely on that ordering.
+		for _, h := range streamingFeatures {
+			outputs, err := h.Computer.EmitRow(r, h.Feature.Field)
+			if err != nil {
+				return nil, err
+			}
+			for label, out := range outputs {
+				if len(out.Nulls) > 0 && out.Nulls[0] {
+					r.SetNull(label)
+				} else {
+					r.Set(label, out.Values[0])
+				}
+			}
+		}
+
 		pass := true
 		for _, fn := range filterFns {
 			ok, err := fn(r)

--- a/skills/feature-engineering.md
+++ b/skills/feature-engineering.md
@@ -24,9 +24,13 @@ A feature's output column is addressable by every stage that follows. This is wh
 </reference>
 
 <reference>
-## Why features are buffered
+## Streaming eligibility
 
-Features force the buffered execution path. Global-pass operators (`FEAT_FREQUENCY_ENCODE`, `FEAT_TARGET_ENCODE`) need a stats sweep before per-row write; per-row operators (`FEAT_LOG`, `FEAT_SQRT`) could stream but are bundled in for consistency. If your request has only stream-eligible aggregations and no features, processing stays on the streaming path; adding any feature switches to buffered.
+Feature requests run on the streaming path when every requested operator implements `feature.StreamingComputer` and the rest of the request is stream-eligible (online-capable aggregators, no groups, no attributes, no windows). Per-row operators (`FEAT_LOG`, `FEAT_SQRT`, `FEAT_BUCKETIZE` with explicit boundaries, `FEAT_ONE_HOT`, `FEAT_DATE_FEATURES`) emit derived columns one record at a time. Global-pass operators (`FEAT_FREQUENCY_ENCODE`, `FEAT_TARGET_ENCODE`, `FEAT_BUCKETIZE` with quantiles, `FEAT_TRAIN_TEST_SPLIT`) run a precompute sweep, then the iterator is rewound and per-row emit drives filters and online aggregators.
+
+The streaming path requires the iterator to support `Reset()`. The slice iterator resets in O(1); the file-backed streaming iterator re-reads the file from disk, which doubles I/O cost for global-pass operators. The buffered path remains the fallback whenever streaming is unsafe — and is selected automatically.
+
+`FEAT_TRAIN_TEST_SPLIT` materializes its assignment table during the precompute sweep, so streaming mode pays the same `O(rows)` memory as buffered for the split column. Per-row operators add no extra allocations beyond the derived column.
 </reference>
 
 <reference>


### PR DESCRIPTION
## Summary

- Adds `feature.StreamingComputer` (`PrePass` + `Finalize` + `EmitRow`) so every registered FEAT_* operator can run on the streaming execution path.
- `processing.canStream` accepts feature requests when every operator is streamable; `processStreaming` runs a precompute sweep, calls `Finalize`, rewinds the iterator, then emits derived columns into each record before filters and online aggregators see it.
- Per-row operators (LOG, SQRT, BUCKETIZE-explicit, ONE_HOT, DATE_FEATURES) keep `PrePass` / `Finalize` as no-ops and share inner math with `Compute`. Global-pass operators (FREQUENCY_ENCODE, TARGET_ENCODE, BUCKETIZE-quantile) accumulate state in `PrePass`, freeze it in `Finalize`, and serve O(1) lookups in `EmitRow`. TRAIN_TEST_SPLIT materializes its assignment table during the precompute sweep — same `O(rows)` memory as the buffered path.
- Buffered remains the fallback for any operator that does not implement `StreamingComputer` (today every registered FEAT_* does, but the gate guards future stateful operators).

Closes #12.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `processing/feature/streaming_parity_test.go` — bit-for-bit parity between Compute (buffered) and `PrePass`+`Finalize`+`EmitRow` (streaming) on every registered FEAT_* operator, including stratified TRAIN_TEST_SPLIT
- [x] `IsStreamable` covered for unknown-type and factory-error fallbacks plus the all-positive case across every registered operator
- [x] `TestFeaturePipeline_StreamableFeaturePicksStreamingPath` confirms the orchestrator picks the streaming path now (replaces the obsolete "features force buffered" assertion)
- [x] Skill coverage gates pass (`go test ./skills/`)

## Docs

- `skills/feature-engineering.md` "Why features are buffered" replaced with a streaming-eligibility section that calls out the iterator-reset cost on file-backed iterators and notes the buffered-style memory cost for TRAIN_TEST_SPLIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)