### PR TITLE
feat: streaming + parallel compose (closes #?)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,21 +259,22 @@ CLI: `pulse api process --stream` and `pulse api compose --stream` emit NDJSON o
 
 ### What streams today
 
-The streaming Process path covers:
+The streaming Process path covers four orchestrator modes:
 
-- **No-group requests** with online aggregators (COUNT, SUM, AVG, STDDEV, VARIANCE, RANGE, FREQUENCY, MODE, SKEWNESS, KURTOSIS, DISTINCT_COUNT) on numeric (non-decimal) fields.
-- **Grouped requests** when every grouper is one of CATEGORY, RANGE, ROUNDED, H3_CELL (each implements `processing.StreamingGrouper.KeyForRow`). Per-key online aggregator buckets emit one row per distinct key on stream exhaustion. Memory is O(distinct_groups × per-aggregator-state).
-- **Row-local attributes** ATTR_FORMULA and ATTR_DATE_PART (each implements `processing.RowLocalAttribute.Row`). Computed inline; aggregations referencing the attribute label resolve identically to the buffered path.
-- **Streaming features** (every registered FEAT_* implements `feature.StreamingComputer`).
+- **Single-pass streaming** (`processStreaming`): no-group requests with online aggregators (COUNT, SUM, AVG, STDDEV, VARIANCE, RANGE, FREQUENCY, MODE, SKEWNESS, KURTOSIS, DISTINCT_COUNT) on numeric (non-decimal) fields. Row-local attributes (FORMULA, DATE_PART, via `RowLocalAttribute.Row`) apply inline.
+- **Grouped streaming** (`processStreamingGrouped`): groupers implementing `StreamingGrouper.KeyForRow` (CATEGORY, RANGE, ROUNDED, H3_CELL) drive per-key online aggregator buckets. Memory is O(distinct_groups × per-aggregator-state). One row per distinct key on stream exhaustion.
+- **Two-pass streaming** (`processStreamingTwoPass`): attributes implementing `TwoPassAttribute` (ZSCORE, TSCORE, NORMALIZED) compute population stats via Welford-Pébaÿ pass 1, then emit per-row values in pass 2 after `iter.Reset()`. Mirrors the streaming feature pattern (`feature.StreamingComputer.PrePass + Finalize + EmitRow`). Memory is O(per-attribute-state); cost is 2× iter scan (typically OS-page-cached).
+- **Streaming features** (every registered FEAT_* implements `feature.StreamingComputer`) compose with single-pass and grouped streaming.
 
 Forced buffered:
 
-- Median, percentile, ZScore aggregators (need sort/population stats).
-- ATTR_ZSCORE / ATTR_TSCORE / ATTR_NORMALIZED / ATTR_PERCENTILE (population stats).
-- GROUP_QUANTILE / GROUP_DATE (finalize-time work over full set).
+- Median, percentile, ZScore *aggregators* (sort or summed deviations).
+- `ATTR_PERCENTILE` (sorted view of every value — no streaming algorithm preserves exact rank).
+- `GROUP_QUANTILE` / `GROUP_DATE` (finalize-time work over full set).
 - Window operators (sorted post-aggregate row set).
 - Decimal-typed field aggregations (precision-preserving path).
 - Geo aggregations (typed buffered path).
+- Two-pass attributes combined with features or groups (orchestration matrix not yet extended; tracked separately).
 
 ### CI gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Any change to Pulse code, configuration, file format, or public surface MUST upd
 | An environment variable | `CLAUDE.md` "Build / Dev / Test Workflow" + `skills/getting-started.md` | `TestClaudeMdMentionsAllEnvVars` |
 | A registered MCP tool (added/removed) | `skills/mcp-integration.md` (Tool surface table) | `TestSkillsCoverAllMCPTools` |
 | A registered feature operator | `skills/feature-engineering.md` (operator catalog) | `TestSkillsCoverAllComponents` |
+| A new operator's streaming capability | `types/streamability.go` (case for the new type) + table in `types/streamability_test.go` | `TestRegistryStreamabilityMatchesTypes`, `TestStreamability_*Known` |
 
 **The Update Demand applies recursively to itself:** when a new trigger row is added (e.g., a new component category, a new contract), this table MUST be updated in the same PR. `TestUpdateDemandTableCovers` (non-skippable) parses this table and asserts every registered component category and contract type has a row.
 
@@ -231,6 +232,31 @@ Fields without stored descriptions get a synthesized fallback (`"Categorical fie
 
 `descriptor.BuildManifest()` returns a deterministic `Manifest` struct. All component lists (aggregators, attributes, filterers, groupers) are sorted alphabetically. The manifest includes: commands (7 CLI leaves), components, cohort field types (all 15), and skills metadata. `format_version` is `"1.0"`.
 
+### Predict: streamability flag
+
+`PredictResult.Streamable bool` reports whether the request can execute via the streaming Process path (no buffered intermediate row set). `PredictResult.StreamableReasons []string` lists every gate that forced buffering — empty when `Streamable=true`.
+
+Source of truth is per-type `Streamable() bool` methods on `types.AggregationType`, `types.AttributeType`, `types.FiltererType`, `types.GroupType`, `types.WindowType`, `types.FeatureType` (in `types/streamability.go`). Predict reads these methods plus schema-aware gates (decimal fields, geo aggregations) to compute the flag without importing `processing/`.
+
+`processing.CanStreamRequest(req, schema) bool` is the exported runtime parity hook that descriptor tests use to confirm predict's flag matches the actual streaming gate. Drift between the two surfaces breaks `TestPredict_Streamable_MatchesRuntime` and `TestRegistryStreamabilityMatchesTypes`.
+
+### Parallel compose
+
+`pulse.ComposeParallel(ctx, req, opts)` fans out a `ComposedRequest` over a bounded worker pool. Order-preserving (slot-by-index) regardless of completion order. Workers share the engine's read-only registries; each `Process` call constructs fresh stateful operators per request.
+
+`ComposeOptions`:
+- `MaxWorkers` — defaults to `runtime.GOMAXPROCS(0)`; negatives clamp to 1.
+- `PerRequestTimeout` — optional per-request deadline derived via `context.WithTimeout`.
+- `FailFast` — defaults to `true` (cancel siblings on first error). Set `false` to aggregate every error into a single `SERVICE_INTERNAL` with `failed_indices`.
+
+CLI: `pulse api compose --parallel N [--no-fail-fast]`.
+
+### Streaming iterator
+
+`pulse.ProcessStream(ctx, req) (RowIter, error)` returns a pull-based iterator over result rows. `RowIter.Next(ctx) (Row, bool, error)` / `Close() error` / `Metadata() *ResponseMetadata`. Today the iterator wraps `Process` and walks the materialized `Data` slice; consumers that adopt the API now will pick up true incremental emission without code changes when groupers/aggregators stream natively.
+
+CLI: `pulse api process --stream` and `pulse api compose --stream` emit NDJSON one row per line.
+
 ### CI gates
 
 - `TestPredictNoExecutionImports` — grep gate enforcing the no-execute ban on `predict.go`
@@ -244,6 +270,10 @@ Fields without stored descriptions get a synthesized fallback (`"Categorical fie
 - `TestNoOrbitPrefixes` — verifies no error code string contains predecessor project references
 - `TestNoOrbitPrefix` — verifies no type constant string contains predecessor project references
 - `TestSkillsCoverAllMCPTools` — asserts every MCP tool registered in `internal/mcp` appears in `skills/mcp-integration.md`
+- `TestRegistryStreamabilityMatchesTypes` — for every registered aggregator, asserts `types.AggregationType.Streamable()` matches the runtime `OnlineAggregator` capability of the constructed instance
+- `TestPredict_Streamable_MatchesRuntime` — cross-package parity gate: `PredictResult.Streamable` must equal `processing.CanStreamRequest(req, schema)` for every (request, schema) in the matrix
+- `TestStreamability_AggregationsKnown`, `TestStreamability_AttributesKnown`, `TestStreamability_FilterersKnown`, `TestStreamability_GroupsKnown`, `TestStreamability_WindowsKnown`, `TestStreamability_FeaturesKnown` — exhaustiveness gates: every type listed in `All*Types()` must have an explicit entry in the per-type streamability table
+- `TestCanStreamRequest_RegressionMatrix` — regression matrix on the exported `processing.CanStreamRequest` helper used by predict's parity gate
 
 ## Skill Pack Maintenance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,24 @@ CLI: `pulse api compose --parallel N [--no-fail-fast]`.
 
 CLI: `pulse api process --stream` and `pulse api compose --stream` emit NDJSON one row per line.
 
+### What streams today
+
+The streaming Process path covers:
+
+- **No-group requests** with online aggregators (COUNT, SUM, AVG, STDDEV, VARIANCE, RANGE, FREQUENCY, MODE, SKEWNESS, KURTOSIS, DISTINCT_COUNT) on numeric (non-decimal) fields.
+- **Grouped requests** when every grouper is one of CATEGORY, RANGE, ROUNDED, H3_CELL (each implements `processing.StreamingGrouper.KeyForRow`). Per-key online aggregator buckets emit one row per distinct key on stream exhaustion. Memory is O(distinct_groups × per-aggregator-state).
+- **Row-local attributes** ATTR_FORMULA and ATTR_DATE_PART (each implements `processing.RowLocalAttribute.Row`). Computed inline; aggregations referencing the attribute label resolve identically to the buffered path.
+- **Streaming features** (every registered FEAT_* implements `feature.StreamingComputer`).
+
+Forced buffered:
+
+- Median, percentile, ZScore aggregators (need sort/population stats).
+- ATTR_ZSCORE / ATTR_TSCORE / ATTR_NORMALIZED / ATTR_PERCENTILE (population stats).
+- GROUP_QUANTILE / GROUP_DATE (finalize-time work over full set).
+- Window operators (sorted post-aggregate row set).
+- Decimal-typed field aggregations (precision-preserving path).
+- Geo aggregations (typed buffered path).
+
 ### CI gates
 
 - `TestPredictNoExecutionImports` — grep gate enforcing the no-execute ban on `predict.go`

--- a/cmd/pulse/main_test.go
+++ b/cmd/pulse/main_test.go
@@ -394,6 +394,102 @@ func TestCliApiCompose(t *testing.T) {
 	}
 }
 
+func TestCliApiProcessStream(t *testing.T) {
+	dir := t.TempDir()
+	pulsePath := createTestPulseFile(t, dir)
+
+	reqJSON := `{
+		"cohort": {"filename": "` + pulsePath + `"},
+		"aggregations": [{"type": "AGG_COUNT", "field": "age", "label": "n"}]
+	}`
+	reqPath := filepath.Join(dir, "request.json")
+	if err := os.WriteFile(reqPath, []byte(reqJSON), 0644); err != nil {
+		t.Fatalf("writing request: %v", err)
+	}
+
+	out, err := runApp(t, "api", "process", "--request", reqPath, "--stream")
+	if err != nil {
+		t.Fatalf("api process --stream: %v\noutput: %s", err, out)
+	}
+
+	// Each line is a single JSON row. AGG_COUNT yields exactly one row.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 NDJSON line, got %d (%q)", len(lines), out)
+	}
+	var row map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &row); err != nil {
+		t.Fatalf("invalid NDJSON line: %v\nline: %s", err, lines[0])
+	}
+	if _, ok := row["n"]; !ok {
+		t.Errorf("missing label n in streamed row: %v", row)
+	}
+}
+
+func TestCliApiComposeParallel(t *testing.T) {
+	dir := t.TempDir()
+	pulsePath := createTestPulseFile(t, dir)
+
+	reqJSON := `{
+		"requests": [
+			{"cohort": {"filename": "` + pulsePath + `"}, "aggregations": [{"type": "AGG_COUNT", "field": "age", "label": "a"}]},
+			{"cohort": {"filename": "` + pulsePath + `"}, "aggregations": [{"type": "AGG_COUNT", "field": "age", "label": "b"}]}
+		]
+	}`
+	reqPath := filepath.Join(dir, "composed.json")
+	if err := os.WriteFile(reqPath, []byte(reqJSON), 0644); err != nil {
+		t.Fatalf("writing request: %v", err)
+	}
+
+	out, err := runApp(t, "api", "compose", "--request", reqPath, "--parallel", "2")
+	if err != nil {
+		t.Fatalf("api compose --parallel: %v\noutput: %s", err, out)
+	}
+
+	var responses []map[string]any
+	if err := json.Unmarshal([]byte(out), &responses); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out)
+	}
+	if len(responses) != 2 {
+		t.Fatalf("expected 2 responses, got %d", len(responses))
+	}
+}
+
+func TestCliApiComposeStream(t *testing.T) {
+	dir := t.TempDir()
+	pulsePath := createTestPulseFile(t, dir)
+
+	reqJSON := `{
+		"requests": [
+			{"cohort": {"filename": "` + pulsePath + `"}, "aggregations": [{"type": "AGG_COUNT", "field": "age", "label": "a"}]},
+			{"cohort": {"filename": "` + pulsePath + `"}, "aggregations": [{"type": "AGG_COUNT", "field": "age", "label": "b"}]}
+		]
+	}`
+	reqPath := filepath.Join(dir, "composed.json")
+	if err := os.WriteFile(reqPath, []byte(reqJSON), 0644); err != nil {
+		t.Fatalf("writing request: %v", err)
+	}
+
+	out, err := runApp(t, "api", "compose", "--request", reqPath, "--stream")
+	if err != nil {
+		t.Fatalf("api compose --stream: %v\noutput: %s", err, out)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 NDJSON lines, got %d (%q)", len(lines), out)
+	}
+	for i, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("line %d invalid JSON: %v\n%s", i, err, line)
+		}
+		if entry["index"] == nil || entry["row"] == nil {
+			t.Errorf("line %d missing index/row: %v", i, entry)
+		}
+	}
+}
+
 func TestCliApiPredict(t *testing.T) {
 	dir := t.TempDir()
 	pulsePath := createTestPulseFile(t, dir)

--- a/descriptor/predict.go
+++ b/descriptor/predict.go
@@ -164,8 +164,10 @@ func computeStreamable(req *types.Request, schema *encoding.Schema) (bool, []str
 	if len(req.Groups) > 0 {
 		reasons = append(reasons, "groups buffer the full record set")
 	}
-	if len(req.Attributes) > 0 {
-		reasons = append(reasons, "attributes require a full pass for population stats")
+	for _, attr := range req.Attributes {
+		if !attr.Type.Streamable() {
+			reasons = append(reasons, "attribute "+string(attr.Type)+" requires a full pass for population stats")
+		}
 	}
 	if len(req.Windows) > 0 {
 		reasons = append(reasons, "windows run over the post-aggregate row set")

--- a/descriptor/predict.go
+++ b/descriptor/predict.go
@@ -161,8 +161,10 @@ func computeStreamable(req *types.Request, schema *encoding.Schema) (bool, []str
 	if len(req.Aggregations) == 0 {
 		reasons = append(reasons, "no aggregations: streaming path requires at least one OnlineAggregator")
 	}
-	if len(req.Groups) > 0 {
-		reasons = append(reasons, "groups buffer the full record set")
+	for _, grp := range req.Groups {
+		if !grp.Type.Streamable() {
+			reasons = append(reasons, "group "+string(grp.Type)+" requires the buffered path")
+		}
 	}
 	for _, attr := range req.Attributes {
 		if !attr.Type.Streamable() {

--- a/descriptor/predict.go
+++ b/descriptor/predict.go
@@ -55,9 +55,19 @@ type PredictOptions struct {
 
 // PredictResult holds the validated request and any diagnostics.
 type PredictResult struct {
-	Valid       bool              `json:"valid"`
-	Request     *types.Request    `json:"request"`
-	SchemaInfo  *PredictSchemaInfo `json:"schema_info,omitempty"`
+	Valid      bool               `json:"valid"`
+	Request    *types.Request     `json:"request"`
+	SchemaInfo *PredictSchemaInfo `json:"schema_info,omitempty"`
+	// Streamable reports whether ProcessStream / process --stream can
+	// emit rows without buffering the entire result. False whenever the
+	// request uses groups, attributes, windows, geo aggregations, decimal
+	// fields, or any non-streamable operator. Computed via per-type
+	// Streamable() methods plus schema-aware checks.
+	Streamable bool `json:"streamable"`
+	// StreamableReasons lists the gates that forced Streamable=false. Empty
+	// when Streamable=true. Useful for users debugging why their request
+	// is buffering.
+	StreamableReasons []string `json:"streamable_reasons,omitempty"`
 }
 
 // PredictSchemaInfo summarizes the schema used for prediction.
@@ -125,12 +135,69 @@ func Predict(fileData io.ReadSeeker, req *types.Request, opts *PredictOptions) *
 	// Check description quality.
 	validateDescriptionQuality(env, schema, opts)
 
+	// Compute streamability — per-type Streamable() methods plus schema-aware
+	// gates (decimal fields force buffered, geo aggs force buffered).
+	result.Streamable, result.StreamableReasons = computeStreamable(req, schema)
+
 	// If any errors were added, mark invalid.
 	if len(env.Errors) > 0 {
 		result.Valid = false
 	}
 
 	return env
+}
+
+// computeStreamable reports whether the request can execute via the
+// streaming Process path. Mirrors processing.canStream's gates but reads
+// from the types.* Streamable() methods instead of constructing operators
+// (predict cannot import processing).
+//
+// Returns (true, nil) when streamable; (false, reasons) listing every
+// gate that blocks streaming. The reasons slice is intentionally
+// human-readable so it can land in the envelope unchanged.
+func computeStreamable(req *types.Request, schema *encoding.Schema) (bool, []string) {
+	var reasons []string
+
+	if len(req.Aggregations) == 0 {
+		reasons = append(reasons, "no aggregations: streaming path requires at least one OnlineAggregator")
+	}
+	if len(req.Groups) > 0 {
+		reasons = append(reasons, "groups buffer the full record set")
+	}
+	if len(req.Attributes) > 0 {
+		reasons = append(reasons, "attributes require a full pass for population stats")
+	}
+	if len(req.Windows) > 0 {
+		reasons = append(reasons, "windows run over the post-aggregate row set")
+	}
+
+	for _, agg := range req.Aggregations {
+		if !agg.Type.Streamable() {
+			reasons = append(reasons, "aggregation "+string(agg.Type)+" is not streamable")
+			continue
+		}
+		// Geo aggregations dispatch through buffered AggregateGeoField even
+		// when their type would otherwise be online.
+		if geoAggregations[agg.Type] && agg.Type != types.AGG_COUNT {
+			reasons = append(reasons, "aggregation "+string(agg.Type)+" uses the buffered geo path")
+			continue
+		}
+		// Decimal field aggregation routes through AggregateDecimalField to
+		// preserve precision; the streaming numeric fold loses it.
+		if schema != nil {
+			if f := schema.Field(agg.Field); f != nil && f.Type.IsDecimal() {
+				reasons = append(reasons, "aggregation on decimal field "+agg.Field+" forces buffered path")
+			}
+		}
+	}
+
+	for _, feat := range req.Features {
+		if !feat.Type.Streamable() {
+			reasons = append(reasons, "feature "+string(feat.Type)+" is not streamable")
+		}
+	}
+
+	return len(reasons) == 0, reasons
 }
 
 // PredictFromBytes is a convenience wrapper that creates a reader from bytes.

--- a/descriptor/predict_streamable_test.go
+++ b/descriptor/predict_streamable_test.go
@@ -106,8 +106,33 @@ func TestPredict_Streamable_AttributesBlock(t *testing.T) {
 	if result.Streamable {
 		t.Error("Streamable = true, want false")
 	}
-	if !containsReason(result.StreamableReasons, "attributes") {
-		t.Errorf("expected reason mentioning attributes, got %v", result.StreamableReasons)
+	if !containsReason(result.StreamableReasons, "ATTR_ZSCORE") {
+		t.Errorf("expected reason mentioning ATTR_ZSCORE, got %v", result.StreamableReasons)
+	}
+}
+
+// TestPredict_Streamable_RowLocalAttributesAllowed: FORMULA + DATE_PART
+// are row-local; predict should report Streamable=true even with them
+// present (provided no other gates fire).
+func TestPredict_Streamable_RowLocalAttributesAllowed(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_FORMULA, Field: "score", Expression: "score * 2", Label: "doubled"},
+		},
+	}
+
+	env := PredictFromBytes(data, req, nil)
+	result := env.Data.(*PredictResult)
+	if !result.Streamable {
+		t.Errorf("Streamable = false, want true. Reasons: %v", result.StreamableReasons)
 	}
 }
 

--- a/descriptor/predict_streamable_test.go
+++ b/descriptor/predict_streamable_test.go
@@ -38,8 +38,9 @@ func TestPredict_Streamable_OnlineAggregations(t *testing.T) {
 	}
 }
 
-// TestPredict_Streamable_GroupBlocksStreaming asserts groups force buffered.
-func TestPredict_Streamable_GroupBlocksStreaming(t *testing.T) {
+// TestPredict_Streamable_StreamableGroupAllowed: GROUP_CATEGORY with
+// online aggregators reports streamable=true.
+func TestPredict_Streamable_StreamableGroupAllowed(t *testing.T) {
 	schema := &encoding.Schema{
 		Fields: []encoding.Field{
 			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
@@ -49,17 +50,38 @@ func TestPredict_Streamable_GroupBlocksStreaming(t *testing.T) {
 	data := buildTestPulseFile(t, schema)
 
 	req := &types.Request{
-		Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
+		Aggregations: []*types.Aggregation{{Type: types.AGG_COUNT, Field: "score"}},
 		Groups:       []*types.Group{{Type: types.GROUP_CATEGORY, Field: "grade"}},
 	}
 
 	env := PredictFromBytes(data, req, nil)
 	result := env.Data.(*PredictResult)
-	if result.Streamable {
-		t.Error("Streamable = true, want false")
+	if !result.Streamable {
+		t.Errorf("Streamable = false, want true. Reasons: %v", result.StreamableReasons)
 	}
-	if !containsReason(result.StreamableReasons, "groups") {
-		t.Errorf("expected reason mentioning groups, got %v", result.StreamableReasons)
+}
+
+// TestPredict_Streamable_NonStreamableGroupBlocks: GROUP_QUANTILE forces
+// buffered.
+func TestPredict_Streamable_NonStreamableGroupBlocks(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{{Type: types.AGG_COUNT, Field: "score"}},
+		Groups:       []*types.Group{{Type: types.GROUP_QUANTILE, Field: "score", Interval: 4}},
+	}
+	env := PredictFromBytes(data, req, nil)
+	result := env.Data.(*PredictResult)
+	if result.Streamable {
+		t.Error("Streamable = true, want false (QUANTILE not streamable)")
+	}
+	if !containsReason(result.StreamableReasons, "GROUP_QUANTILE") {
+		t.Errorf("expected reason mentioning GROUP_QUANTILE, got %v", result.StreamableReasons)
 	}
 }
 

--- a/descriptor/predict_streamable_test.go
+++ b/descriptor/predict_streamable_test.go
@@ -109,8 +109,9 @@ func TestPredict_Streamable_NonOnlineAggBlocksStreaming(t *testing.T) {
 	}
 }
 
-// TestPredict_Streamable_AttributesBlock asserts attributes force buffered.
-func TestPredict_Streamable_AttributesBlock(t *testing.T) {
+// TestPredict_Streamable_PercentileAttributeBlocks asserts ATTR_PERCENTILE
+// (the only remaining buffered-only attribute) forces buffered.
+func TestPredict_Streamable_PercentileAttributeBlocks(t *testing.T) {
 	schema := &encoding.Schema{
 		Fields: []encoding.Field{
 			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
@@ -120,7 +121,7 @@ func TestPredict_Streamable_AttributesBlock(t *testing.T) {
 
 	req := &types.Request{
 		Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
-		Attributes:   []*types.Attribute{{Type: types.ATTR_ZSCORE, Field: "score"}},
+		Attributes:   []*types.Attribute{{Type: types.ATTR_PERCENTILE, Field: "score"}},
 	}
 
 	env := PredictFromBytes(data, req, nil)
@@ -128,8 +129,31 @@ func TestPredict_Streamable_AttributesBlock(t *testing.T) {
 	if result.Streamable {
 		t.Error("Streamable = true, want false")
 	}
-	if !containsReason(result.StreamableReasons, "ATTR_ZSCORE") {
-		t.Errorf("expected reason mentioning ATTR_ZSCORE, got %v", result.StreamableReasons)
+	if !containsReason(result.StreamableReasons, "ATTR_PERCENTILE") {
+		t.Errorf("expected reason mentioning ATTR_PERCENTILE, got %v", result.StreamableReasons)
+	}
+}
+
+// TestPredict_Streamable_TwoPassAttributeAllowed: ZSCORE/TSCORE/NORMALIZED
+// implement TwoPassAttribute and report streamable=true.
+func TestPredict_Streamable_TwoPassAttributeAllowed(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	for _, attrType := range []types.AttributeType{types.ATTR_ZSCORE, types.ATTR_TSCORE, types.ATTR_NORMALIZED} {
+		req := &types.Request{
+			Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
+			Attributes:   []*types.Attribute{{Type: attrType, Field: "score"}},
+		}
+		env := PredictFromBytes(data, req, nil)
+		result := env.Data.(*PredictResult)
+		if !result.Streamable {
+			t.Errorf("%s: Streamable = false, want true. Reasons: %v", attrType, result.StreamableReasons)
+		}
 	}
 }
 

--- a/descriptor/predict_streamable_test.go
+++ b/descriptor/predict_streamable_test.go
@@ -1,0 +1,207 @@
+package descriptor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/processing"
+	"github.com/frankbardon/pulse/types"
+)
+
+// TestPredict_Streamable_OnlineAggregations confirms that a request with
+// only online aggregations on numeric fields reports streamable=true with
+// no reasons.
+func TestPredict_Streamable_OnlineAggregations(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "score"},
+			{Type: types.AGG_AVERAGE, Field: "score"},
+			{Type: types.AGG_COUNT, Field: "score"},
+		},
+	}
+
+	env := PredictFromBytes(data, req, nil)
+	result := env.Data.(*PredictResult)
+	if !result.Streamable {
+		t.Errorf("Streamable = false, want true. Reasons: %v", result.StreamableReasons)
+	}
+	if len(result.StreamableReasons) != 0 {
+		t.Errorf("expected no reasons, got %v", result.StreamableReasons)
+	}
+}
+
+// TestPredict_Streamable_GroupBlocksStreaming asserts groups force buffered.
+func TestPredict_Streamable_GroupBlocksStreaming(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+			{Name: "grade", Type: encoding.FieldTypeCategoricalU8, Description: "Letter grade for the student", Dictionary: makeDictionary(t, "A", "B", "C")},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
+		Groups:       []*types.Group{{Type: types.GROUP_CATEGORY, Field: "grade"}},
+	}
+
+	env := PredictFromBytes(data, req, nil)
+	result := env.Data.(*PredictResult)
+	if result.Streamable {
+		t.Error("Streamable = true, want false")
+	}
+	if !containsReason(result.StreamableReasons, "groups") {
+		t.Errorf("expected reason mentioning groups, got %v", result.StreamableReasons)
+	}
+}
+
+// TestPredict_Streamable_NonOnlineAggBlocksStreaming asserts MEDIAN forces
+// buffered with a per-aggregation reason.
+func TestPredict_Streamable_NonOnlineAggBlocksStreaming(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{{Type: types.AGG_MEDIAN, Field: "score"}},
+	}
+
+	env := PredictFromBytes(data, req, nil)
+	result := env.Data.(*PredictResult)
+	if result.Streamable {
+		t.Error("Streamable = true, want false")
+	}
+	if !containsReason(result.StreamableReasons, "AGG_MEDIAN") {
+		t.Errorf("expected reason mentioning AGG_MEDIAN, got %v", result.StreamableReasons)
+	}
+}
+
+// TestPredict_Streamable_AttributesBlock asserts attributes force buffered.
+func TestPredict_Streamable_AttributesBlock(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
+		Attributes:   []*types.Attribute{{Type: types.ATTR_ZSCORE, Field: "score"}},
+	}
+
+	env := PredictFromBytes(data, req, nil)
+	result := env.Data.(*PredictResult)
+	if result.Streamable {
+		t.Error("Streamable = true, want false")
+	}
+	if !containsReason(result.StreamableReasons, "attributes") {
+		t.Errorf("expected reason mentioning attributes, got %v", result.StreamableReasons)
+	}
+}
+
+// TestPredict_Streamable_DecimalFieldBlocks asserts decimal128 fields
+// force buffered even with online aggregations.
+func TestPredict_Streamable_DecimalFieldBlocks(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "amount", Type: encoding.FieldTypeDecimal128, Precision: 10, Scale: 2, Description: "Transaction amount in USD cents"},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "amount"}},
+	}
+
+	env := PredictFromBytes(data, req, nil)
+	result := env.Data.(*PredictResult)
+	if result.Streamable {
+		t.Error("Streamable = true, want false")
+	}
+	if !containsReason(result.StreamableReasons, "decimal") {
+		t.Errorf("expected reason mentioning decimal, got %v", result.StreamableReasons)
+	}
+}
+
+// TestPredict_Streamable_EmptyAggregationsBlocks asserts that requests
+// with no aggregations are non-streamable (no work to drive UpdateRow).
+func TestPredict_Streamable_EmptyAggregationsBlocks(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	req := &types.Request{}
+	env := PredictFromBytes(data, req, nil)
+	result := env.Data.(*PredictResult)
+	if result.Streamable {
+		t.Error("Streamable = true, want false (no aggregations)")
+	}
+}
+
+// TestPredict_Streamable_MatchesRuntime asserts predict's Streamable flag
+// agrees with processing.CanStreamRequest for a representative matrix.
+// This is the cross-package parity gate: drift in either side breaks it.
+func TestPredict_Streamable_MatchesRuntime(t *testing.T) {
+	numericSchema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "Student test score value"},
+		},
+	}
+	decimalSchema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "amount", Type: encoding.FieldTypeDecimal128, Precision: 10, Scale: 2, Description: "Transaction amount in USD cents"},
+		},
+	}
+	geoSchema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "loc", Type: encoding.FieldTypePointF64, Description: "Latitude/longitude pair (degrees)"},
+		},
+	}
+	cases := []struct {
+		name   string
+		req    *types.Request
+		schema *encoding.Schema
+	}{
+		{"online aggregations on numeric", &types.Request{Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}}}, numericSchema},
+		{"median on numeric", &types.Request{Aggregations: []*types.Aggregation{{Type: types.AGG_MEDIAN, Field: "score"}}}, numericSchema},
+		{"sum on decimal", &types.Request{Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "amount"}}}, decimalSchema},
+		{"empty request", &types.Request{}, numericSchema},
+		{"geo centroid", &types.Request{Aggregations: []*types.Aggregation{{Type: types.AGG_GEO_CENTROID, Field: "loc"}}}, geoSchema},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data := buildTestPulseFile(t, c.schema)
+			env := PredictFromBytes(data, c.req, nil)
+			result := env.Data.(*PredictResult)
+			runtime := processing.CanStreamRequest(c.req, c.schema)
+			if result.Streamable != runtime {
+				t.Errorf("predict.Streamable=%v but runtime CanStreamRequest=%v (reasons: %v)",
+					result.Streamable, runtime, result.StreamableReasons)
+			}
+		})
+	}
+}
+
+func containsReason(reasons []string, needle string) bool {
+	for _, r := range reasons {
+		if strings.Contains(r, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/descriptor/testdata/predict_composed.json
+++ b/descriptor/testdata/predict_composed.json
@@ -29,10 +29,7 @@
         "grade"
       ]
     },
-    "streamable": false,
-    "streamable_reasons": [
-      "groups buffer the full record set"
-    ]
+    "streamable": true
   },
   "errors": [],
   "warnings": [
@@ -46,4 +43,4 @@
     }
   ]
 }
-// golden-hash: 52749ba05c6c8ac098157d2a160c4b91812e5cc88a9a5226032a24fdfa446ee0
+// golden-hash: 5fde7377e4288e6e8e00db749af5323eaff7d95fa5137e75aff0271c291eb0d3

--- a/descriptor/testdata/predict_composed.json
+++ b/descriptor/testdata/predict_composed.json
@@ -28,7 +28,11 @@
         "score",
         "grade"
       ]
-    }
+    },
+    "streamable": false,
+    "streamable_reasons": [
+      "groups buffer the full record set"
+    ]
   },
   "errors": [],
   "warnings": [
@@ -42,4 +46,4 @@
     }
   ]
 }
-// golden-hash: facd33a9a88aedc85f196cd53ae70697599593f8aa725f473ddfd741535a160e
+// golden-hash: 52749ba05c6c8ac098157d2a160c4b91812e5cc88a9a5226032a24fdfa446ee0

--- a/descriptor/testdata/predict_simple.json
+++ b/descriptor/testdata/predict_simple.json
@@ -17,9 +17,10 @@
         "score",
         "age"
       ]
-    }
+    },
+    "streamable": true
   },
   "errors": [],
   "warnings": []
 }
-// golden-hash: 86537aefd2221e0e50feab1440d3366b8800e4ceb79dabb52a415bbe3bfc4400
+// golden-hash: 507de07cef261af4f4b0936df8c00f7ce691ddbe6d7675599c28100a45eda0e1

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/frankbardon/pulse"
 	"github.com/frankbardon/pulse/descriptor"
 	"github.com/frankbardon/pulse/types"
 	cli "github.com/urfave/cli/v3"
@@ -33,10 +34,12 @@ func apiProcessCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "request", Aliases: []string{"r"}, Usage: "Request JSON file path", Required: true},
 			&cli.BoolFlag{Name: "json", Usage: "Output result as JSON envelope"},
+			&cli.BoolFlag{Name: "stream", Usage: "Stream rows as NDJSON (one row per line) instead of buffering"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			reqPath := cmd.String("request")
 			jsonOut := cmd.Bool("json")
+			stream := cmd.Bool("stream")
 
 			req, err := loadRequest(reqPath)
 			if err != nil {
@@ -52,6 +55,30 @@ func apiProcessCmd() *cli.Command {
 					return writeErrorEnvelope(cmd.Writer, "CLI_ERROR", err.Error())
 				}
 				return err
+			}
+
+			if stream {
+				iter, err := p.ProcessStream(ctx, req)
+				if err != nil {
+					if jsonOut {
+						return writeErrorEnvelope(cmd.Writer, "PROCESS_ERROR", err.Error())
+					}
+					return err
+				}
+				defer iter.Close()
+				enc := json.NewEncoder(cmd.Writer)
+				for {
+					row, ok, err := iter.Next(ctx)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						return nil
+					}
+					if err := enc.Encode(row); err != nil {
+						return err
+					}
+				}
 			}
 
 			resp, err := p.Process(ctx, req)
@@ -78,10 +105,16 @@ func apiComposeCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "request", Aliases: []string{"r"}, Usage: "Composed request JSON file path", Required: true},
 			&cli.BoolFlag{Name: "json", Usage: "Output result as JSON envelope"},
+			&cli.BoolFlag{Name: "stream", Usage: "Stream rows as NDJSON; each line is {\"index\":N,\"row\":{...}}"},
+			&cli.IntFlag{Name: "parallel", Usage: "Run requests concurrently with up to N workers (0 = GOMAXPROCS); 1 forces sequential", Value: 1},
+			&cli.BoolFlag{Name: "no-fail-fast", Usage: "Aggregate errors instead of cancelling on first failure (parallel only)"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			reqPath := cmd.String("request")
 			jsonOut := cmd.Bool("json")
+			stream := cmd.Bool("stream")
+			workers := int(cmd.Int("parallel"))
+			noFailFast := cmd.Bool("no-fail-fast")
 
 			composed, err := loadComposedRequest(reqPath)
 			if err != nil {
@@ -99,12 +132,35 @@ func apiComposeCmd() *cli.Command {
 				return err
 			}
 
-			responses, err := p.Compose(ctx, composed)
+			var responses []*types.Response
+			if workers != 1 {
+				responses, err = p.ComposeParallel(ctx, composed, pulse.ComposeOptions{
+					MaxWorkers: workers,
+					FailFast:   !noFailFast,
+				})
+			} else {
+				responses, err = p.Compose(ctx, composed)
+			}
 			if err != nil {
 				if jsonOut {
 					return writeErrorEnvelope(cmd.Writer, "COMPOSE_ERROR", err.Error())
 				}
 				return err
+			}
+
+			if stream {
+				enc := json.NewEncoder(cmd.Writer)
+				for i, resp := range responses {
+					if resp == nil {
+						continue
+					}
+					for _, row := range resp.Data {
+						if err := enc.Encode(map[string]any{"index": i, "row": row}); err != nil {
+							return err
+						}
+					}
+				}
+				return nil
 			}
 
 			if jsonOut {
@@ -115,6 +171,7 @@ func apiComposeCmd() *cli.Command {
 		},
 	}
 }
+
 
 func apiSampleCmd() *cli.Command {
 	return &cli.Command{

--- a/processing/attribute.go
+++ b/processing/attribute.go
@@ -133,40 +133,50 @@ func (a *formulaAttribute) Compute(records []*Record, field string) ([]float64, 
 
 	result := make([]float64, len(records))
 	for i, r := range records {
-		env := r.AllValues()
-		program, err := expr.Compile(a.expression, expr.Env(env))
+		v, err := a.Row(r, field)
 		if err != nil {
-			return nil, errors.WrapCodedError(err, errors.PROCESSING_RUNTIME,
-				fmt.Sprintf("compiling formula expression: %s", a.expression))
+			return nil, err
 		}
-
-		output, err := expr.Run(program, env)
-		if err != nil {
-			return nil, errors.WrapCodedError(err, errors.PROCESSING_RUNTIME,
-				fmt.Sprintf("evaluating formula expression: %s", a.expression))
-		}
-
-		switch v := output.(type) {
-		case float64:
-			result[i] = v
-		case float32:
-			result[i] = float64(v)
-		case int:
-			result[i] = float64(v)
-		case int64:
-			result[i] = float64(v)
-		case bool:
-			if v {
-				result[i] = 1.0
-			} else {
-				result[i] = 0.0
-			}
-		default:
-			return nil, errors.NewCodedError(errors.PROCESSING_RUNTIME,
-				fmt.Sprintf("formula expression returned unsupported type %T", output))
-		}
+		result[i] = v
 	}
 	return result, nil
+}
+
+// Row evaluates the formula expression against a single record. Each
+// invocation re-compiles the expression because the env shape may change
+// when records have different sparse-null populations; predict guarantees
+// the expression typechecks against the schema, so compile failures here
+// are user-visible PROCESSING_RUNTIME errors.
+func (a *formulaAttribute) Row(r *Record, _ string) (float64, error) {
+	env := r.AllValues()
+	program, err := expr.Compile(a.expression, expr.Env(env))
+	if err != nil {
+		return 0, errors.WrapCodedError(err, errors.PROCESSING_RUNTIME,
+			fmt.Sprintf("compiling formula expression: %s", a.expression))
+	}
+	output, err := expr.Run(program, env)
+	if err != nil {
+		return 0, errors.WrapCodedError(err, errors.PROCESSING_RUNTIME,
+			fmt.Sprintf("evaluating formula expression: %s", a.expression))
+	}
+	switch v := output.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case bool:
+		if v {
+			return 1.0, nil
+		}
+		return 0.0, nil
+	default:
+		return 0, errors.NewCodedError(errors.PROCESSING_RUNTIME,
+			fmt.Sprintf("formula expression returned unsupported type %T", output))
+	}
 }
 
 // --- Percentile Attribute ---
@@ -269,29 +279,37 @@ func (a *datePartAttribute) Compute(records []*Record, field string) ([]float64,
 
 	result := make([]float64, len(records))
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
-		if !ok {
-			result[i] = 0
-			continue
+		v, err := a.Row(r, field)
+		if err != nil {
+			return nil, err
 		}
-
-		t := time.Unix(int64(v)*86400, 0).UTC()
-		year, month, day := t.Date()
-
-		switch a.part {
-		case "year":
-			result[i] = float64(year)
-		case "month":
-			result[i] = float64(month)
-		case "day":
-			result[i] = float64(day)
-		case "year_month":
-			result[i] = float64(year*100 + int(month))
-		case "year_month_day":
-			result[i] = float64(year*10000 + int(month)*100 + day)
-		case "month_day":
-			result[i] = float64(int(month)*100 + day)
-		}
+		result[i] = v
 	}
 	return result, nil
+}
+
+// Row extracts the configured date part from a single record. Null date
+// values produce 0 (matches buffered Compute semantics).
+func (a *datePartAttribute) Row(r *Record, field string) (float64, error) {
+	v, ok := r.NumericValue(field)
+	if !ok {
+		return 0, nil
+	}
+	t := time.Unix(int64(v)*86400, 0).UTC()
+	year, month, day := t.Date()
+	switch a.part {
+	case "year":
+		return float64(year), nil
+	case "month":
+		return float64(month), nil
+	case "day":
+		return float64(day), nil
+	case "year_month":
+		return float64(year*100 + int(month)), nil
+	case "year_month_day":
+		return float64(year*10000 + int(month)*100 + day), nil
+	case "month_day":
+		return float64(int(month)*100 + day), nil
+	}
+	return 0, nil
 }

--- a/processing/attribute.go
+++ b/processing/attribute.go
@@ -3,6 +3,7 @@ package processing
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
@@ -14,97 +15,215 @@ import (
 
 // --- ZScore Attribute ---
 
-type zscoreAttribute struct{}
+// zscoreAttribute computes (x - mean) / stddev per row using
+// population mean/stddev derived in pass 1 via Welford-Pébaÿ. Implements
+// TwoPassAttribute so the streaming path can avoid buffering the
+// record set.
+type zscoreAttribute struct {
+	// Welford state (pass 1).
+	count uint64
+	mean  float64
+	m2    float64
+	// Locked at Finalize.
+	finalMean   float64
+	finalStdDev float64
+	finalized   bool
+}
 
 func newZScoreAttribute(_ *types.Attribute, _ *encoding.Schema) (AttributeComputer, error) {
 	return &zscoreAttribute{}, nil
+}
+
+func (a *zscoreAttribute) PrePass(r *Record, field string) error {
+	v, ok := r.NumericValue(field)
+	if !ok {
+		return nil
+	}
+	a.count++
+	delta := v - a.mean
+	a.mean += delta / float64(a.count)
+	a.m2 += delta * (v - a.mean)
+	return nil
+}
+
+func (a *zscoreAttribute) Finalize() error {
+	if a.count == 0 {
+		a.finalMean = 0
+		a.finalStdDev = 0
+	} else {
+		a.finalMean = a.mean
+		a.finalStdDev = math.Sqrt(a.m2 / float64(a.count))
+	}
+	a.finalized = true
+	return nil
+}
+
+func (a *zscoreAttribute) Row(r *Record, field string) (float64, error) {
+	v, ok := r.NumericValue(field)
+	if !ok || a.finalStdDev == 0 {
+		return 0, nil
+	}
+	return (v - a.finalMean) / a.finalStdDev, nil
 }
 
 func (a *zscoreAttribute) Compute(records []*Record, field string) ([]float64, error) {
 	if len(records) == 0 {
 		return []float64{}, nil
 	}
-	vals := collectValues(records, field)
-	m := mean(vals)
-	sd := populationStdDev(vals)
-
+	for _, r := range records {
+		if err := a.PrePass(r, field); err != nil {
+			return nil, err
+		}
+	}
+	if err := a.Finalize(); err != nil {
+		return nil, err
+	}
 	result := make([]float64, len(records))
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
-		if !ok || sd == 0 {
-			result[i] = 0
-			continue
+		val, err := a.Row(r, field)
+		if err != nil {
+			return nil, err
 		}
-		result[i] = (v - m) / sd
+		result[i] = val
 	}
 	return result, nil
 }
 
 // --- TScore Attribute ---
 
-type tscoreAttribute struct{}
+// tscoreAttribute emits z*10+50 per row using population mean/stddev
+// from a Welford pass 1. Implements TwoPassAttribute.
+type tscoreAttribute struct {
+	count       uint64
+	mean        float64
+	m2          float64
+	finalMean   float64
+	finalStdDev float64
+}
 
 func newTScoreAttribute(_ *types.Attribute, _ *encoding.Schema) (AttributeComputer, error) {
 	return &tscoreAttribute{}, nil
+}
+
+func (a *tscoreAttribute) PrePass(r *Record, field string) error {
+	v, ok := r.NumericValue(field)
+	if !ok {
+		return nil
+	}
+	a.count++
+	delta := v - a.mean
+	a.mean += delta / float64(a.count)
+	a.m2 += delta * (v - a.mean)
+	return nil
+}
+
+func (a *tscoreAttribute) Finalize() error {
+	if a.count == 0 {
+		a.finalMean = 0
+		a.finalStdDev = 0
+	} else {
+		a.finalMean = a.mean
+		a.finalStdDev = math.Sqrt(a.m2 / float64(a.count))
+	}
+	return nil
+}
+
+func (a *tscoreAttribute) Row(r *Record, field string) (float64, error) {
+	v, ok := r.NumericValue(field)
+	if !ok || a.finalStdDev == 0 {
+		return 50, nil // T-score of mean when sd=0 or null input
+	}
+	return ((v-a.finalMean)/a.finalStdDev)*10 + 50, nil
 }
 
 func (a *tscoreAttribute) Compute(records []*Record, field string) ([]float64, error) {
 	if len(records) == 0 {
 		return []float64{}, nil
 	}
-	vals := collectValues(records, field)
-	m := mean(vals)
-	sd := populationStdDev(vals)
-
+	for _, r := range records {
+		if err := a.PrePass(r, field); err != nil {
+			return nil, err
+		}
+	}
+	if err := a.Finalize(); err != nil {
+		return nil, err
+	}
 	result := make([]float64, len(records))
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
-		if !ok || sd == 0 {
-			result[i] = 50 // T-score of mean when sd=0
-			continue
+		val, err := a.Row(r, field)
+		if err != nil {
+			return nil, err
 		}
-		z := (v - m) / sd
-		result[i] = z*10 + 50
+		result[i] = val
 	}
 	return result, nil
 }
 
 // --- Normalized Attribute ---
 
-type normalizedAttribute struct{}
+// normalizedAttribute emits (x-min)/(max-min) per row using population
+// min/max from a Welford-shaped pass 1. Implements TwoPassAttribute.
+type normalizedAttribute struct {
+	seen     bool
+	min, max float64
+	rng      float64
+}
 
 func newNormalizedAttribute(_ *types.Attribute, _ *encoding.Schema) (AttributeComputer, error) {
 	return &normalizedAttribute{}, nil
+}
+
+func (a *normalizedAttribute) PrePass(r *Record, field string) error {
+	v, ok := r.NumericValue(field)
+	if !ok {
+		return nil
+	}
+	if !a.seen {
+		a.min, a.max = v, v
+		a.seen = true
+		return nil
+	}
+	if v < a.min {
+		a.min = v
+	}
+	if v > a.max {
+		a.max = v
+	}
+	return nil
+}
+
+func (a *normalizedAttribute) Finalize() error {
+	a.rng = a.max - a.min
+	return nil
+}
+
+func (a *normalizedAttribute) Row(r *Record, field string) (float64, error) {
+	v, ok := r.NumericValue(field)
+	if !ok || a.rng == 0 {
+		return 0, nil
+	}
+	return (v - a.min) / a.rng, nil
 }
 
 func (a *normalizedAttribute) Compute(records []*Record, field string) ([]float64, error) {
 	if len(records) == 0 {
 		return []float64{}, nil
 	}
-	vals := collectValues(records, field)
-	if len(vals) == 0 {
-		return make([]float64, len(records)), nil
-	}
-
-	minV, maxV := vals[0], vals[0]
-	for _, v := range vals[1:] {
-		if v < minV {
-			minV = v
-		}
-		if v > maxV {
-			maxV = v
+	for _, r := range records {
+		if err := a.PrePass(r, field); err != nil {
+			return nil, err
 		}
 	}
-
-	rng := maxV - minV
+	if err := a.Finalize(); err != nil {
+		return nil, err
+	}
 	result := make([]float64, len(records))
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
-		if !ok || rng == 0 {
-			result[i] = 0
-			continue
+		val, err := a.Row(r, field)
+		if err != nil {
+			return nil, err
 		}
-		result[i] = (v - minV) / rng
+		result[i] = val
 	}
 	return result, nil
 }

--- a/processing/attribute_streaming_test.go
+++ b/processing/attribute_streaming_test.go
@@ -51,9 +51,9 @@ func TestAttribute_FormulaStreamingMatchesBuffered(t *testing.T) {
 	}
 }
 
-// TestAttribute_NonRowLocalForcesBuffered confirms ZSCORE attribute
-// still routes through the buffered path.
-func TestAttribute_NonRowLocalForcesBuffered(t *testing.T) {
+// TestAttribute_PercentileForcesBuffered: ATTR_PERCENTILE has no
+// streaming algorithm and remains buffered.
+func TestAttribute_PercentileForcesBuffered(t *testing.T) {
 	schema := &encoding.Schema{
 		Fields: []encoding.Field{
 			{Name: "score", Type: encoding.FieldTypeF64, Description: "input score"},
@@ -68,17 +68,17 @@ func TestAttribute_NonRowLocalForcesBuffered(t *testing.T) {
 	p := NewProcessor(schema)
 	req := &types.Request{
 		Attributes: []*types.Attribute{
-			{Type: types.ATTR_ZSCORE, Field: "score", Label: "z"},
+			{Type: types.ATTR_PERCENTILE, Field: "score", Label: "p"},
 		},
 		Aggregations: []*types.Aggregation{
-			{Type: types.AGG_SUM, Field: "z", Label: "sum_z"},
+			{Type: types.AGG_SUM, Field: "p", Label: "sum_p"},
 		},
 	}
 	if _, err := p.Process(context.Background(), req, NewSliceIterator(records)); err != nil {
 		t.Fatalf("Process: %v", err)
 	}
 	if p.lastPath != PathBuffered {
-		t.Errorf("expected buffered path for ATTR_ZSCORE, got %s", p.lastPath)
+		t.Errorf("expected buffered path for ATTR_PERCENTILE, got %s", p.lastPath)
 	}
 }
 

--- a/processing/attribute_streaming_test.go
+++ b/processing/attribute_streaming_test.go
@@ -1,0 +1,124 @@
+package processing
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/types"
+)
+
+// TestAttribute_FormulaStreamingMatchesBuffered confirms the streaming
+// path applies ATTR_FORMULA inline and produces the same aggregate as
+// the buffered path with the same request.
+func TestAttribute_FormulaStreamingMatchesBuffered(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "input score"},
+		},
+	}
+	records := []*Record{
+		makeNumericRecord(t, schema, "score", 10),
+		makeNumericRecord(t, schema, "score", 20),
+		makeNumericRecord(t, schema, "score", 30),
+	}
+
+	p := NewProcessor(schema)
+	req := &types.Request{
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_FORMULA, Field: "score", Expression: "score * 2", Label: "doubled"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "doubled", Label: "sum_doubled"},
+		},
+	}
+
+	resp, err := p.Process(context.Background(), req, NewSliceIterator(records))
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if p.lastPath != PathStreaming {
+		t.Fatalf("expected streaming path with row-local attribute, got %s", p.lastPath)
+	}
+	got, ok := resp.Data[0]["sum_doubled"].(float64)
+	if !ok {
+		t.Fatalf("sum_doubled type %T", resp.Data[0]["sum_doubled"])
+	}
+	want := 120.0 // (10+20+30)*2
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("sum_doubled = %v, want %v", got, want)
+	}
+}
+
+// TestAttribute_NonRowLocalForcesBuffered confirms ZSCORE attribute
+// still routes through the buffered path.
+func TestAttribute_NonRowLocalForcesBuffered(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "input score"},
+		},
+	}
+	records := []*Record{
+		makeNumericRecord(t, schema, "score", 1),
+		makeNumericRecord(t, schema, "score", 2),
+		makeNumericRecord(t, schema, "score", 3),
+	}
+
+	p := NewProcessor(schema)
+	req := &types.Request{
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_ZSCORE, Field: "score", Label: "z"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "z", Label: "sum_z"},
+		},
+	}
+	if _, err := p.Process(context.Background(), req, NewSliceIterator(records)); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if p.lastPath != PathBuffered {
+		t.Errorf("expected buffered path for ATTR_ZSCORE, got %s", p.lastPath)
+	}
+}
+
+// TestAttribute_DatePartStreamingMatchesBuffered: ATTR_DATE_PART is also
+// row-local and should stream.
+func TestAttribute_DatePartStreamingMatchesBuffered(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "d", Type: encoding.FieldTypeDate, Description: "date as days since epoch"},
+		},
+	}
+	// Days 0, 31, 365 → years all 1970, 1970, 1971 → year sum = 5911.
+	records := []*Record{
+		NewRecord(schema, map[string]float64{"d": 0}),
+		NewRecord(schema, map[string]float64{"d": 31}),
+		NewRecord(schema, map[string]float64{"d": 365}),
+	}
+
+	p := NewProcessor(schema)
+	req := &types.Request{
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_DATE_PART, Field: "d", Params: []byte(`{"part":"year"}`), Label: "yr"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "yr", Label: "sum_yr"},
+		},
+	}
+	resp, err := p.Process(context.Background(), req, NewSliceIterator(records))
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if p.lastPath != PathStreaming {
+		t.Errorf("expected streaming path for ATTR_DATE_PART, got %s", p.lastPath)
+	}
+	got, ok := resp.Data[0]["sum_yr"].(float64)
+	if !ok {
+		t.Fatalf("sum_yr type %T", resp.Data[0]["sum_yr"])
+	}
+	want := 5911.0
+	if got != want {
+		t.Errorf("sum_yr = %v, want %v", got, want)
+	}
+}

--- a/processing/attribute_two_pass_test.go
+++ b/processing/attribute_two_pass_test.go
@@ -1,0 +1,207 @@
+package processing
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/types"
+)
+
+// makeNumericRecords returns N records with the given values for one
+// numeric field. Helper local to two-pass tests.
+func makeNumericRecords(t *testing.T, schema *encoding.Schema, field string, values []float64) []*Record {
+	t.Helper()
+	recs := make([]*Record, len(values))
+	for i, v := range values {
+		recs[i] = NewRecord(schema, map[string]float64{field: v})
+	}
+	return recs
+}
+
+// runStreamingAndBuffered drives the same request through both paths
+// and returns (streamingResp, bufferedResp) for downstream parity
+// assertion. Records are cloned for the buffered run to avoid sharing
+// mutated value maps with the streaming run.
+func runStreamingAndBuffered(t *testing.T, schema *encoding.Schema, records []*Record, req *types.Request) (*types.Response, *types.Response) {
+	t.Helper()
+
+	stream := NewProcessor(schema)
+	streamResp, err := stream.Process(context.Background(), req, NewSliceIterator(records))
+	if err != nil {
+		t.Fatalf("streaming Process: %v", err)
+	}
+
+	// Re-build records to avoid attribute-injected labels from the
+	// streaming run leaking into the buffered comparison.
+	bufRecs := make([]*Record, len(records))
+	for i, r := range records {
+		clone := make(map[string]float64, len(r.values))
+		for k, v := range r.values {
+			clone[k] = v
+		}
+		bufRecs[i] = NewRecord(schema, clone)
+	}
+	buf := NewProcessor(schema)
+	bufResp, err := buf.processRecords(context.Background(), req, bufRecs)
+	if err != nil {
+		t.Fatalf("buffered processRecords: %v", err)
+	}
+	return streamResp, bufResp
+}
+
+// TestTwoPass_ZScoreParity confirms ATTR_ZSCORE streaming output
+// matches the buffered path on a non-trivial distribution.
+func TestTwoPass_ZScoreParity(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "x", Type: encoding.FieldTypeF64, Description: "input"},
+		},
+	}
+	records := makeNumericRecords(t, schema, "x", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+
+	req := &types.Request{
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_ZSCORE, Field: "x", Label: "z"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "z", Label: "sum_z"},
+			{Type: types.AGG_AVERAGE, Field: "z", Label: "avg_z"},
+		},
+	}
+
+	streamResp, bufResp := runStreamingAndBuffered(t, schema, records, req)
+	for _, label := range []string{"sum_z", "avg_z"} {
+		sv, _ := streamResp.Data[0][label].(float64)
+		bv, _ := bufResp.Data[0][label].(float64)
+		if math.Abs(sv-bv) > 1e-9 {
+			t.Errorf("%s: streaming=%v buffered=%v", label, sv, bv)
+		}
+	}
+}
+
+// TestTwoPass_TScoreParity covers ATTR_TSCORE.
+func TestTwoPass_TScoreParity(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "x", Type: encoding.FieldTypeF64, Description: "input"},
+		},
+	}
+	records := makeNumericRecords(t, schema, "x", []float64{2, 4, 6, 8, 10})
+
+	req := &types.Request{
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_TSCORE, Field: "x", Label: "t"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "t", Label: "sum_t"},
+		},
+	}
+
+	streamResp, bufResp := runStreamingAndBuffered(t, schema, records, req)
+	sv, _ := streamResp.Data[0]["sum_t"].(float64)
+	bv, _ := bufResp.Data[0]["sum_t"].(float64)
+	if math.Abs(sv-bv) > 1e-9 {
+		t.Errorf("sum_t: streaming=%v buffered=%v", sv, bv)
+	}
+}
+
+// TestTwoPass_NormalizedParity covers ATTR_NORMALIZED.
+func TestTwoPass_NormalizedParity(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "x", Type: encoding.FieldTypeF64, Description: "input"},
+		},
+	}
+	records := makeNumericRecords(t, schema, "x", []float64{5, 10, 15, 20, 25})
+
+	req := &types.Request{
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_NORMALIZED, Field: "x", Label: "n"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "n", Label: "sum_n"},
+			{Type: types.AGG_AVERAGE, Field: "n", Label: "avg_n"},
+		},
+	}
+
+	streamResp, bufResp := runStreamingAndBuffered(t, schema, records, req)
+	for _, label := range []string{"sum_n", "avg_n"} {
+		sv, _ := streamResp.Data[0][label].(float64)
+		bv, _ := bufResp.Data[0][label].(float64)
+		if math.Abs(sv-bv) > 1e-9 {
+			t.Errorf("%s: streaming=%v buffered=%v", label, sv, bv)
+		}
+	}
+}
+
+// TestTwoPass_RowLocalAttributePresentAlsoStreams confirms a request
+// mixing FORMULA (row-local) and ZSCORE (two-pass) takes the two-pass
+// orchestrator and produces correct values for both.
+func TestTwoPass_RowLocalAttributePresentAlsoStreams(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "x", Type: encoding.FieldTypeF64, Description: "input"},
+		},
+	}
+	records := makeNumericRecords(t, schema, "x", []float64{1, 2, 3, 4, 5})
+
+	req := &types.Request{
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_FORMULA, Field: "x", Expression: "x * 10", Label: "x10"},
+			{Type: types.ATTR_ZSCORE, Field: "x", Label: "z"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "x10", Label: "sum_x10"},
+			{Type: types.AGG_SUM, Field: "z", Label: "sum_z"},
+		},
+	}
+
+	streamResp, bufResp := runStreamingAndBuffered(t, schema, records, req)
+	for _, label := range []string{"sum_x10", "sum_z"} {
+		sv, _ := streamResp.Data[0][label].(float64)
+		bv, _ := bufResp.Data[0][label].(float64)
+		if math.Abs(sv-bv) > 1e-9 {
+			t.Errorf("%s: streaming=%v buffered=%v", label, sv, bv)
+		}
+	}
+}
+
+// TestTwoPass_FilterAppliesToPrePass confirms filter-passing records
+// drive PrePass; rows excluded by filters do not affect the population
+// stats. Mirrors buffered behavior where Compute receives the filtered
+// slice.
+func TestTwoPass_FilterAppliesToPrePass(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "x", Type: encoding.FieldTypeF64, Description: "input"},
+		},
+	}
+	records := makeNumericRecords(t, schema, "x", []float64{1, 2, 3, 100, 200})
+
+	// Filter out the two large outliers; population stats should reflect
+	// only {1, 2, 3}.
+	req := &types.Request{
+		Filterers: []*types.Filterer{
+			{Type: types.FILTER_RANGE, Field: "x", Values: []string{"0", "10"}},
+		},
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_NORMALIZED, Field: "x", Label: "n"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "n", Label: "sum_n"},
+		},
+	}
+
+	streamResp, bufResp := runStreamingAndBuffered(t, schema, records, req)
+	sv, _ := streamResp.Data[0]["sum_n"].(float64)
+	bv, _ := bufResp.Data[0]["sum_n"].(float64)
+	if math.Abs(sv-bv) > 1e-9 {
+		t.Errorf("sum_n: streaming=%v buffered=%v", sv, bv)
+	}
+	// Verify pass 2 also filters: filtered_rows reflects post-filter count.
+	if streamResp.Metadata.FilteredRows != 3 {
+		t.Errorf("FilteredRows = %d, want 3", streamResp.Metadata.FilteredRows)
+	}
+}

--- a/processing/grouped_streaming_test.go
+++ b/processing/grouped_streaming_test.go
@@ -1,0 +1,177 @@
+package processing
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/types"
+)
+
+func makeTestDict(t *testing.T, values ...string) *encoding.Dictionary {
+	t.Helper()
+	d := encoding.NewDictionary()
+	for _, v := range values {
+		if _, err := d.Add(v); err != nil {
+			t.Fatalf("Dictionary.Add(%q): %v", v, err)
+		}
+	}
+	return d
+}
+
+// rowsByKey indexes a Data slice by the named group field's value.
+func rowsByKey(data []map[string]any, groupField string) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(data))
+	for _, row := range data {
+		k, _ := row[groupField].(string)
+		out[k] = row
+	}
+	return out
+}
+
+// TestGroupedStreaming_CategoryParityWithBuffered runs the same request
+// through both paths and asserts identical per-key aggregates.
+func TestGroupedStreaming_CategoryParityWithBuffered(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64, Description: "score"},
+			{Name: "grade", Type: encoding.FieldTypeCategoricalU8, Description: "letter grade",
+				Dictionary: makeTestDict(t, "A", "B", "C")},
+		},
+	}
+	records := []*Record{
+		NewRecord(schema, map[string]float64{"score": 10, "grade": 0}),
+		NewRecord(schema, map[string]float64{"score": 20, "grade": 0}),
+		NewRecord(schema, map[string]float64{"score": 30, "grade": 1}),
+		NewRecord(schema, map[string]float64{"score": 40, "grade": 1}),
+		NewRecord(schema, map[string]float64{"score": 50, "grade": 2}),
+	}
+
+	req := &types.Request{
+		Groups:       []*types.Group{{Type: types.GROUP_CATEGORY, Field: "grade"}},
+		Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score", Label: "s"}},
+	}
+
+	stream := NewProcessor(schema)
+	streamResp, err := stream.Process(context.Background(), req, NewSliceIterator(records))
+	if err != nil {
+		t.Fatalf("streaming Process: %v", err)
+	}
+	if stream.LastPath() != PathStreaming {
+		t.Fatalf("expected streaming path, got %s", stream.LastPath())
+	}
+
+	buf := NewProcessor(schema)
+	bufResp, err := buf.processRecords(context.Background(), req, records)
+	if err != nil {
+		t.Fatalf("buffered processRecords: %v", err)
+	}
+
+	streamRows := rowsByKey(streamResp.Data, "grade")
+	bufRows := rowsByKey(bufResp.Data, "grade")
+	if len(streamRows) != len(bufRows) {
+		t.Fatalf("group count mismatch: streaming=%d buffered=%d", len(streamRows), len(bufRows))
+	}
+	for key, want := range bufRows {
+		got, ok := streamRows[key]
+		if !ok {
+			t.Errorf("streaming missing key %q", key)
+			continue
+		}
+		gw, _ := got["s"].(float64)
+		ww, _ := want["s"].(float64)
+		if math.Abs(gw-ww) > 1e-9 {
+			t.Errorf("key %q: streaming=%v buffered=%v", key, gw, ww)
+		}
+	}
+}
+
+// TestGroupedStreaming_RangeAggMultiple covers GROUP_RANGE × multiple
+// online aggregators for parity with buffered processing.
+func TestGroupedStreaming_RangeAggMultiple(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "x", Type: encoding.FieldTypeF64, Description: "input value"},
+		},
+	}
+	records := []*Record{
+		makeNumericRecord(t, schema, "x", 5),
+		makeNumericRecord(t, schema, "x", 12),
+		makeNumericRecord(t, schema, "x", 18),
+		makeNumericRecord(t, schema, "x", 25),
+		makeNumericRecord(t, schema, "x", 33),
+	}
+
+	req := &types.Request{
+		Groups: []*types.Group{{Type: types.GROUP_RANGE, Field: "x", Interval: 10}},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_COUNT, Field: "x", Label: "n"},
+			{Type: types.AGG_SUM, Field: "x", Label: "s"},
+			{Type: types.AGG_AVERAGE, Field: "x", Label: "a"},
+		},
+	}
+
+	stream := NewProcessor(schema)
+	streamResp, err := stream.Process(context.Background(), req, NewSliceIterator(records))
+	if err != nil {
+		t.Fatalf("streaming: %v", err)
+	}
+	if stream.LastPath() != PathStreaming {
+		t.Fatalf("expected streaming, got %s", stream.LastPath())
+	}
+
+	buf := NewProcessor(schema)
+	bufResp, err := buf.processRecords(context.Background(), req, records)
+	if err != nil {
+		t.Fatalf("buffered: %v", err)
+	}
+
+	streamRows := rowsByKey(streamResp.Data, "x")
+	bufRows := rowsByKey(bufResp.Data, "x")
+	for key, want := range bufRows {
+		got, ok := streamRows[key]
+		if !ok {
+			t.Errorf("streaming missing key %q", key)
+			continue
+		}
+		for _, label := range []string{"n", "s", "a"} {
+			gv, _ := got[label].(float64)
+			wv, _ := want[label].(float64)
+			if math.Abs(gv-wv) > 1e-9 {
+				t.Errorf("key %q label %q: streaming=%v buffered=%v", key, label, gv, wv)
+			}
+		}
+	}
+}
+
+// TestGroupedStreaming_NullKeySkipped: rows with null group values must
+// be excluded from buckets in both paths.
+func TestGroupedStreaming_NullKeySkipped(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "x", Type: encoding.FieldTypeF64, Description: "input value"},
+			{Name: "g", Type: encoding.FieldTypeCategoricalU8, Description: "group",
+				Dictionary: makeTestDict(t, "A", "B")},
+		},
+	}
+	records := []*Record{
+		NewRecord(schema, map[string]float64{"x": 1, "g": 0}),
+		NewRecordWithNulls(schema, map[string]float64{"x": 2}, map[string]bool{"g": true}),
+		NewRecord(schema, map[string]float64{"x": 3, "g": 1}),
+	}
+
+	req := &types.Request{
+		Groups:       []*types.Group{{Type: types.GROUP_CATEGORY, Field: "g"}},
+		Aggregations: []*types.Aggregation{{Type: types.AGG_COUNT, Field: "x", Label: "n"}},
+	}
+
+	stream := NewProcessor(schema)
+	resp, err := stream.Process(context.Background(), req, NewSliceIterator(records))
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 group rows (null group skipped), got %d", len(resp.Data))
+	}
+}

--- a/processing/grouper.go
+++ b/processing/grouper.go
@@ -23,35 +23,38 @@ func newCategoryGrouper(_ *types.Group, schema *encoding.Schema) (Grouper, error
 	return &categoryGrouper{schema: schema}, nil
 }
 
-func (g *categoryGrouper) Group(records []*Record, field string) (map[string][]*Record, error) {
+func (g *categoryGrouper) KeyForRow(r *Record, field string) (string, bool, error) {
+	v, ok := r.NumericValue(field)
+	if !ok {
+		return "", false, nil
+	}
 	f := g.schema.Field(field)
-	isCategorical := f != nil && f.Type.IsCategorical() && f.Dictionary != nil
+	if f != nil && f.Type.IsCategorical() && f.Dictionary != nil {
+		key := f.Dictionary.Resolve(uint32(v))
+		if key == "" {
+			key = fmt.Sprintf("%d", uint32(v))
+		}
+		return key, true, nil
+	}
+	if v == math.Trunc(v) {
+		return strconv.FormatInt(int64(v), 10), true, nil
+	}
+	return strconv.FormatFloat(v, 'f', -1, 64), true, nil
+}
 
+func (g *categoryGrouper) Group(records []*Record, field string) (map[string][]*Record, error) {
 	// Pass 1: compute keys (buffered to avoid recomputation) and per-key counts.
 	keys := make([]string, len(records))
 	used := make([]bool, len(records))
 	counts := make(map[string]int)
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
+		key, ok, err := g.KeyForRow(r, field)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
-			continue // skip null values
+			continue
 		}
-
-		var key string
-		if isCategorical {
-			key = f.Dictionary.Resolve(uint32(v))
-			if key == "" {
-				key = fmt.Sprintf("%d", uint32(v))
-			}
-		} else {
-			// Format numeric value as key
-			if v == math.Trunc(v) {
-				key = strconv.FormatInt(int64(v), 10)
-			} else {
-				key = strconv.FormatFloat(v, 'f', -1, 64)
-			}
-		}
-
 		keys[i] = key
 		used[i] = true
 		counts[key]++
@@ -85,26 +88,31 @@ func newRoundedGrouper(grp *types.Group, _ *encoding.Schema) (Grouper, error) {
 	return &roundedGrouper{interval: grp.Interval}, nil
 }
 
+func (g *roundedGrouper) KeyForRow(r *Record, field string) (string, bool, error) {
+	v, ok := r.NumericValue(field)
+	if !ok {
+		return "", false, nil
+	}
+	rounded := math.Floor(v/g.interval) * g.interval
+	if rounded == math.Trunc(rounded) {
+		return strconv.FormatInt(int64(rounded), 10), true, nil
+	}
+	return strconv.FormatFloat(rounded, 'f', -1, 64), true, nil
+}
+
 func (g *roundedGrouper) Group(records []*Record, field string) (map[string][]*Record, error) {
 	// Pass 1: compute keys (buffered) and per-key counts.
 	keys := make([]string, len(records))
 	used := make([]bool, len(records))
 	counts := make(map[string]int)
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
+		key, ok, err := g.KeyForRow(r, field)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			continue
 		}
-
-		// Round down to nearest interval
-		rounded := math.Floor(v/g.interval) * g.interval
-		var key string
-		if rounded == math.Trunc(rounded) {
-			key = strconv.FormatInt(int64(rounded), 10)
-		} else {
-			key = strconv.FormatFloat(rounded, 'f', -1, 64)
-		}
-
 		keys[i] = key
 		used[i] = true
 		counts[key]++
@@ -138,33 +146,40 @@ func newRangeGrouper(grp *types.Group, _ *encoding.Schema) (Grouper, error) {
 	return &rangeGrouper{interval: grp.Interval}, nil
 }
 
+func (g *rangeGrouper) KeyForRow(r *Record, field string) (string, bool, error) {
+	v, ok := r.NumericValue(field)
+	if !ok {
+		return "", false, nil
+	}
+	low := math.Floor(v/g.interval) * g.interval
+	high := low + g.interval
+	var lowStr, highStr string
+	if low == math.Trunc(low) {
+		lowStr = strconv.FormatInt(int64(low), 10)
+	} else {
+		lowStr = strconv.FormatFloat(low, 'f', -1, 64)
+	}
+	if high == math.Trunc(high) {
+		highStr = strconv.FormatInt(int64(high), 10)
+	} else {
+		highStr = strconv.FormatFloat(high, 'f', -1, 64)
+	}
+	return lowStr + "-" + highStr, true, nil
+}
+
 func (g *rangeGrouper) Group(records []*Record, field string) (map[string][]*Record, error) {
 	// Pass 1: compute keys (buffered) and per-key counts.
 	keys := make([]string, len(records))
 	used := make([]bool, len(records))
 	counts := make(map[string]int)
 	for i, r := range records {
-		v, ok := r.NumericValue(field)
+		key, ok, err := g.KeyForRow(r, field)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			continue
 		}
-
-		low := math.Floor(v/g.interval) * g.interval
-		high := low + g.interval
-
-		var lowStr, highStr string
-		if low == math.Trunc(low) {
-			lowStr = strconv.FormatInt(int64(low), 10)
-		} else {
-			lowStr = strconv.FormatFloat(low, 'f', -1, 64)
-		}
-		if high == math.Trunc(high) {
-			highStr = strconv.FormatInt(int64(high), 10)
-		} else {
-			highStr = strconv.FormatFloat(high, 'f', -1, 64)
-		}
-
-		key := lowStr + "-" + highStr
 		keys[i] = key
 		used[i] = true
 		counts[key]++

--- a/processing/grouper_h3.go
+++ b/processing/grouper_h3.go
@@ -60,53 +60,66 @@ func newH3Grouper(grp *types.Group, schema *encoding.Schema) (Grouper, error) {
 	return &h3Grouper{resolution: params.Resolution, fieldType: ft}, nil
 }
 
+// KeyForRow derives the H3 cell key for a single record. Null-typed
+// rows or rows whose wide value is neither point_f64 nor h3_cell return
+// ok=false to be skipped by callers.
+func (g *h3Grouper) KeyForRow(r *Record, field string) (string, bool, error) {
+	v, ok := r.WideValue(field)
+	if !ok {
+		return "", false, nil
+	}
+	var cell h3.Cell
+	switch x := v.(type) {
+	case encoding.PointF64:
+		if g.resolution == nil {
+			return "", false, errors.NewCodedError(errors.PROCESSING_CONFIG,
+				"GROUP_H3_CELL on point_f64 requires resolution param")
+		}
+		c, err := h3.LatLngToCell(h3.LatLng{Lat: x.Lat, Lng: x.Lon}, *g.resolution)
+		if err != nil {
+			return "", false, errors.WrapCodedError(err, errors.PULSE_GEO_INVALID_POINT,
+				"H3 cell conversion failed")
+		}
+		cell = c
+	case encoding.H3Cell:
+		cell = h3.Cell(x)
+		if !cell.IsValid() {
+			return "", false, nil
+		}
+		if g.resolution != nil {
+			native := cell.Resolution()
+			if *g.resolution > native {
+				return "", false, errors.NewCodedErrorWithDetails(errors.PULSE_GEO_INVALID_RESOLUTION,
+					"requested resolution finer than cell native resolution",
+					map[string]any{"requested": *g.resolution, "native": native})
+			}
+			if *g.resolution < native {
+				p, err := cell.Parent(*g.resolution)
+				if err != nil {
+					return "", false, errors.WrapCodedError(err, errors.PULSE_GEO_INVALID_RESOLUTION,
+						"H3 parent walk failed")
+				}
+				cell = p
+			}
+		}
+	default:
+		return "", false, nil
+	}
+	return cell.String(), true, nil
+}
+
 // Group partitions records into H3-cell buckets keyed by lowercase hex
 // cell strings.
 func (g *h3Grouper) Group(records []*Record, field string) (map[string][]*Record, error) {
 	out := make(map[string][]*Record)
 	for _, r := range records {
-		v, ok := r.WideValue(field)
+		key, ok, err := g.KeyForRow(r, field)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			continue
 		}
-		var cell h3.Cell
-		switch x := v.(type) {
-		case encoding.PointF64:
-			if g.resolution == nil {
-				return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
-					"GROUP_H3_CELL on point_f64 requires resolution param")
-			}
-			c, err := h3.LatLngToCell(h3.LatLng{Lat: x.Lat, Lng: x.Lon}, *g.resolution)
-			if err != nil {
-				return nil, errors.WrapCodedError(err, errors.PULSE_GEO_INVALID_POINT,
-					"H3 cell conversion failed")
-			}
-			cell = c
-		case encoding.H3Cell:
-			cell = h3.Cell(x)
-			if !cell.IsValid() {
-				continue
-			}
-			if g.resolution != nil {
-				native := cell.Resolution()
-				if *g.resolution > native {
-					return nil, errors.NewCodedErrorWithDetails(errors.PULSE_GEO_INVALID_RESOLUTION,
-						"requested resolution finer than cell native resolution",
-						map[string]any{"requested": *g.resolution, "native": native})
-				}
-				if *g.resolution < native {
-					p, err := cell.Parent(*g.resolution)
-					if err != nil {
-						return nil, errors.WrapCodedError(err, errors.PULSE_GEO_INVALID_RESOLUTION,
-							"H3 parent walk failed")
-					}
-					cell = p
-				}
-			}
-		default:
-			continue
-		}
-		key := cell.String()
 		out[key] = append(out[key], r)
 	}
 	return out, nil

--- a/processing/interfaces.go
+++ b/processing/interfaces.go
@@ -82,5 +82,21 @@ type Grouper interface {
 	Group(records []*Record, field string) (map[string][]*Record, error)
 }
 
+// StreamingGrouper is the optional sibling of Grouper for groupers that
+// can derive a partition key from a single record without seeing the
+// full record set. CATEGORY / RANGE / ROUNDED / H3_CELL implement this
+// interface; QUANTILE and DATE require finalize-time work over the
+// full input.
+//
+// Implementations MUST be safe to call repeatedly; the streaming path
+// invokes KeyForRow once per filter-passing record and uses the key to
+// index a per-group online aggregator bucket.
+type StreamingGrouper interface {
+	// KeyForRow returns the group key string for record's value of field.
+	// ok=false signals the row should be skipped (e.g. null value);
+	// ok=true means the key is valid for bucketing.
+	KeyForRow(record *Record, field string) (key string, ok bool, err error)
+}
+
 // GrouperFactory creates a Grouper from a type specification.
 type GrouperFactory func(grp *types.Group, schema *encoding.Schema) (Grouper, error)

--- a/processing/interfaces.go
+++ b/processing/interfaces.go
@@ -45,6 +45,22 @@ type AttributeComputer interface {
 	Compute(records []*Record, field string) ([]float64, error)
 }
 
+// RowLocalAttribute is the optional sibling of AttributeComputer for
+// attributes whose value depends only on the current row (no first-pass
+// population stats needed). Streaming paths drive RowLocalAttribute.Row
+// inline instead of buffering the full record set.
+//
+// FORMULA and DATE_PART implement this interface; ZSCORE / TSCORE /
+// NORMALIZED / PERCENTILE do NOT — they need population mean/stddev or
+// a sorted view of every value, which forces the buffered path.
+type RowLocalAttribute interface {
+	// Row computes this attribute's value for a single record and field.
+	// Implementations MUST NOT depend on any prior call (no streaming
+	// state). A nil error with a returned float64 is treated as a value;
+	// callers using the optional ok pattern should call RowOk instead.
+	Row(record *Record, field string) (float64, error)
+}
+
 // AttributeFactory creates an AttributeComputer from a type specification.
 type AttributeFactory func(attr *types.Attribute, schema *encoding.Schema) (AttributeComputer, error)
 

--- a/processing/interfaces.go
+++ b/processing/interfaces.go
@@ -51,14 +51,37 @@ type AttributeComputer interface {
 // inline instead of buffering the full record set.
 //
 // FORMULA and DATE_PART implement this interface; ZSCORE / TSCORE /
-// NORMALIZED / PERCENTILE do NOT — they need population mean/stddev or
-// a sorted view of every value, which forces the buffered path.
+// NORMALIZED implement TwoPassAttribute (a superset). PERCENTILE does
+// NOT implement either — it needs a sorted view of every value, which
+// forces the buffered path.
 type RowLocalAttribute interface {
 	// Row computes this attribute's value for a single record and field.
-	// Implementations MUST NOT depend on any prior call (no streaming
-	// state). A nil error with a returned float64 is treated as a value;
-	// callers using the optional ok pattern should call RowOk instead.
+	// For a pure RowLocalAttribute, no PrePass call is needed; for a
+	// TwoPassAttribute, Row must be called only after Finalize.
 	Row(record *Record, field string) (float64, error)
+}
+
+// TwoPassAttribute is the streaming-friendly path for attributes that
+// need population statistics (ZSCORE / TSCORE need mean+stddev,
+// NORMALIZED needs min+max). The orchestrator drives PrePass over every
+// filter-passing record, then Finalize locks the global stats, then Row
+// emits per-record values during a second iter pass.
+//
+// Mirrors feature.StreamingComputer.PrePass+Finalize+EmitRow so the
+// streaming infrastructure (iter.Reset(), staged passes) is uniform.
+//
+// Implementations MUST be safe to call PrePass repeatedly; Finalize
+// exactly once between PrePass and Row; and Row only after Finalize.
+// State is per-instance — callers construct a fresh instance per Process
+// call via the AttributeFactory.
+type TwoPassAttribute interface {
+	RowLocalAttribute
+	// PrePass folds a single record's contribution into the running
+	// state used to compute population statistics.
+	PrePass(record *Record, field string) error
+	// Finalize closes the PrePass phase. After Finalize, Row may be
+	// called for each record (typically during iter pass 2).
+	Finalize() error
 }
 
 // AttributeFactory creates an AttributeComputer from a type specification.

--- a/processing/processor.go
+++ b/processing/processor.go
@@ -117,10 +117,12 @@ func CanStreamRequest(req *types.Request, schema *encoding.Schema) bool {
 
 // canStream reports whether the request can be safely executed via the
 // streaming path. Streaming requires:
-//   - no grouping (groups need the full record set partitioned by key)
-//   - no attributes (ZSCORE/PERCENTILE/RANK/NORMALIZED need a first
-//     pass to compute population stats; FORMULA is row-local but is
-//     bundled in for simplicity — every attribute today is buffered)
+//   - groups: empty, OR every grouper.Type.Streamable()=true (CATEGORY,
+//     RANGE, ROUNDED, H3_CELL — partitioned via grouped streaming path).
+//     QUANTILE/DATE require a finalize-time view of the full set.
+//   - attributes: empty, OR every attribute.Type.Streamable()=true
+//     (FORMULA, DATE_PART implement RowLocalAttribute and execute
+//     inline). ZSCORE/TSCORE/NORMALIZED/PERCENTILE need population stats.
 //   - no windows (window operators run over the post-aggregate row set)
 //   - features either empty or every operator implements
 //     feature.StreamingComputer (PrePass + Finalize + EmitRow)
@@ -130,8 +132,17 @@ func CanStreamRequest(req *types.Request, schema *encoding.Schema) bool {
 // Returns false on any unknown component type so the buffered path can
 // surface the canonical error message.
 func (p *Processor) canStream(req *types.Request) bool {
-	if len(req.Groups) > 0 || len(req.Attributes) > 0 || len(req.Windows) > 0 {
+	if len(req.Windows) > 0 {
 		return false
+	}
+	// Groups still force buffered until processStreamingGrouped lands.
+	if len(req.Groups) > 0 {
+		return false
+	}
+	for _, attr := range req.Attributes {
+		if !attr.Type.Streamable() {
+			return false
+		}
 	}
 	if len(req.Features) > 0 && !feature.IsStreamable(req.Features, p.schema) {
 		return false
@@ -235,6 +246,13 @@ func (p *Processor) processStreaming(ctx context.Context, req *types.Request, it
 		entries[i] = onlineEntry{agg: agg, online: online}
 	}
 
+	// Build row-local attribute computers. canStream verified every
+	// attribute is row-local; factory failures here are PROCESSING_CONFIG.
+	rowLocalAttrs, err := p.buildRowLocalAttributes(req.Attributes)
+	if err != nil {
+		return nil, err
+	}
+
 	var totalRows, filteredRows int64
 	for iter.Next() {
 		totalRows++
@@ -273,6 +291,18 @@ func (p *Processor) processStreaming(ctx context.Context, req *types.Request, it
 			continue
 		}
 		filteredRows++
+
+		// Apply row-local attributes inline; values land on the record
+		// under their label so aggregations referencing the label resolve
+		// like they do in the buffered path.
+		for _, ra := range rowLocalAttrs {
+			val, err := ra.computer.Row(r, ra.attr.Field)
+			if err != nil {
+				return nil, err
+			}
+			r.Set(ra.label, val)
+		}
+
 		for _, e := range entries {
 			if err := e.online.UpdateRow(r, e.agg.Field); err != nil {
 				return nil, err
@@ -301,6 +331,47 @@ func (p *Processor) processStreaming(ctx context.Context, req *types.Request, it
 			FilteredRows: filteredRows,
 		},
 	}, nil
+}
+
+// rowLocalAttrEntry pairs an attribute spec with its constructed
+// row-local computer and resolved output label. The streaming path
+// drives one entry per filter-passing record.
+type rowLocalAttrEntry struct {
+	attr     *types.Attribute
+	computer RowLocalAttribute
+	label    string
+}
+
+// buildRowLocalAttributes constructs RowLocalAttribute instances for the
+// streaming path. Returns PROCESSING_INTERNAL if any attribute fails the
+// type assertion (canStream should have rejected the request earlier).
+func (p *Processor) buildRowLocalAttributes(attrs []*types.Attribute) ([]rowLocalAttrEntry, error) {
+	if len(attrs) == 0 {
+		return nil, nil
+	}
+	out := make([]rowLocalAttrEntry, 0, len(attrs))
+	for _, attr := range attrs {
+		factory, ok := attributeRegistry[attr.Type]
+		if !ok {
+			return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+				fmt.Sprintf("unknown attribute type: %s", attr.Type))
+		}
+		computer, err := factory(attr, p.schema)
+		if err != nil {
+			return nil, err
+		}
+		rowLocal, ok := computer.(RowLocalAttribute)
+		if !ok {
+			return nil, errors.NewCodedError(errors.PROCESSING_INTERNAL,
+				fmt.Sprintf("attribute %s does not implement RowLocalAttribute", attr.Type))
+		}
+		label := attr.Label
+		if label == "" {
+			label = fmt.Sprintf("%s_%s", attr.Type, attr.Field)
+		}
+		out = append(out, rowLocalAttrEntry{attr: attr, computer: rowLocal, label: label})
+	}
+	return out, nil
 }
 
 // buildFilterFuncs constructs FilterFuncs from filter specifications.

--- a/processing/processor.go
+++ b/processing/processor.go
@@ -106,6 +106,15 @@ func (p *Processor) Process(ctx context.Context, req *types.Request, iter Record
 	return resp, nil
 }
 
+// CanStreamRequest is the exported parity hook used by tests in
+// descriptor/ (which cannot import processing) to confirm that a
+// PredictResult.Streamable value matches the runtime gate. Application
+// code should rely on PredictResult.Streamable, not this helper.
+func CanStreamRequest(req *types.Request, schema *encoding.Schema) bool {
+	p := &Processor{schema: schema}
+	return p.canStream(req)
+}
+
 // canStream reports whether the request can be safely executed via the
 // streaming path. Streaming requires:
 //   - no grouping (groups need the full record set partitioned by key)

--- a/processing/processor.go
+++ b/processing/processor.go
@@ -87,9 +87,12 @@ func (p *Processor) Process(ctx context.Context, req *types.Request, iter Record
 	if p.canStream(req) {
 		var resp *types.Response
 		var err error
-		if len(req.Groups) > 0 {
+		switch {
+		case len(req.Groups) > 0:
 			resp, err = p.processStreamingGrouped(ctx, req, iter)
-		} else {
+		case hasTwoPassAttribute(req):
+			resp, err = p.processStreamingTwoPass(ctx, req, iter)
+		default:
 			resp, err = p.processStreaming(ctx, req, iter)
 		}
 		if err != nil {
@@ -121,6 +124,30 @@ func CanStreamRequest(req *types.Request, schema *encoding.Schema) bool {
 	return p.canStream(req)
 }
 
+// requiresTwoPass reports whether the attribute type implements
+// TwoPassAttribute (and therefore needs a PrePass over filter-passing
+// records before per-row emission). Mirrors the attribute factories in
+// processing/attribute.go: ZSCORE/TSCORE/NORMALIZED need population
+// stats; FORMULA/DATE_PART are pure row-local.
+func requiresTwoPass(t types.AttributeType) bool {
+	switch t {
+	case types.ATTR_ZSCORE, types.ATTR_TSCORE, types.ATTR_NORMALIZED:
+		return true
+	}
+	return false
+}
+
+// hasTwoPassAttribute reports whether req has any attribute whose type
+// requires the two-pass streaming path.
+func hasTwoPassAttribute(req *types.Request) bool {
+	for _, attr := range req.Attributes {
+		if requiresTwoPass(attr.Type) {
+			return true
+		}
+	}
+	return false
+}
+
 // canStream reports whether the request can be safely executed via the
 // streaming path. Streaming requires:
 //   - groups: empty, OR every grouper.Type.Streamable()=true (CATEGORY,
@@ -146,10 +173,21 @@ func (p *Processor) canStream(req *types.Request) bool {
 			return false
 		}
 	}
+	hasTwoPassAttr := false
 	for _, attr := range req.Attributes {
 		if !attr.Type.Streamable() {
 			return false
 		}
+		if requiresTwoPass(attr.Type) {
+			hasTwoPassAttr = true
+		}
+	}
+	// Two-pass attribute orchestration does not yet compose with the
+	// streaming feature pipeline (filter/EmitRow ordering) or grouped
+	// streaming (per-group attribute stats). Force buffered for those
+	// combinations until the next iteration extends coverage.
+	if hasTwoPassAttr && (len(req.Features) > 0 || len(req.Groups) > 0) {
+		return false
 	}
 	if len(req.Features) > 0 && !feature.IsStreamable(req.Features, p.schema) {
 		return false
@@ -525,6 +563,191 @@ func (p *Processor) processStreamingGrouped(ctx context.Context, req *types.Requ
 	_ = ctx
 	return &types.Response{
 		Data: data,
+		Metadata: &types.ResponseMetadata{
+			TotalRows:    totalRows,
+			FilteredRows: filteredRows,
+		},
+	}, nil
+}
+
+// twoPassAttrEntry pairs an attribute spec with its constructed
+// two-pass computer and resolved output label. processStreamingTwoPass
+// drives one entry per filter-passing record (PrePass) then one per
+// record again in pass 2 (Row).
+type twoPassAttrEntry struct {
+	attr     *types.Attribute
+	computer TwoPassAttribute
+	label    string
+}
+
+// buildTwoPassAttributes splits the attribute list into two-pass and
+// row-local buckets. Both buckets share the same construction +
+// validation path; only the runtime drive differs.
+func (p *Processor) buildTwoPassAttributes(attrs []*types.Attribute) (twoPass []twoPassAttrEntry, rowLocal []rowLocalAttrEntry, err error) {
+	for _, attr := range attrs {
+		factory, ok := attributeRegistry[attr.Type]
+		if !ok {
+			return nil, nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+				fmt.Sprintf("unknown attribute type: %s", attr.Type))
+		}
+		computer, factoryErr := factory(attr, p.schema)
+		if factoryErr != nil {
+			return nil, nil, factoryErr
+		}
+		label := attr.Label
+		if label == "" {
+			label = fmt.Sprintf("%s_%s", attr.Type, attr.Field)
+		}
+		if tp, ok := computer.(TwoPassAttribute); ok {
+			twoPass = append(twoPass, twoPassAttrEntry{attr: attr, computer: tp, label: label})
+			continue
+		}
+		if rl, ok := computer.(RowLocalAttribute); ok {
+			rowLocal = append(rowLocal, rowLocalAttrEntry{attr: attr, computer: rl, label: label})
+			continue
+		}
+		return nil, nil, errors.NewCodedError(errors.PROCESSING_INTERNAL,
+			fmt.Sprintf("attribute %s implements neither TwoPassAttribute nor RowLocalAttribute", attr.Type))
+	}
+	return twoPass, rowLocal, nil
+}
+
+// processStreamingTwoPass runs the two-pass streaming path: pass 1
+// folds every filter-passing record into TwoPassAttribute.PrePass,
+// Finalize locks population stats, iter.Reset() rewinds, and pass 2
+// emits attribute values + folds online aggregations row-by-row.
+//
+// canStream verified: no features, no groups, no windows, every
+// aggregation online, every attribute either two-pass or row-local.
+// These restrictions keep the orchestration matrix manageable for v1;
+// extending to feature/grouped combinations is tracked separately.
+//
+// Memory bound: O(per_attribute_state). Pass 1 + pass 2 = 2× iter
+// scan; the underlying file is typically OS-page-cached after pass 1.
+func (p *Processor) processStreamingTwoPass(ctx context.Context, req *types.Request, iter RecordIterator) (*types.Response, error) {
+	filterFns, err := p.buildFilterFuncs(req.Filterers)
+	if err != nil {
+		return nil, err
+	}
+	twoPassAttrs, rowLocalAttrs, err := p.buildTwoPassAttributes(req.Attributes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build aggregator instances once; they are reset implicitly by
+	// being constructed fresh per Process call. Each one will fold
+	// pass 2's filter-passing records into its running state.
+	type onlineEntry struct {
+		agg    *types.Aggregation
+		online OnlineAggregator
+	}
+	entries := make([]onlineEntry, len(req.Aggregations))
+	for i, agg := range req.Aggregations {
+		factory := aggregatorRegistry[agg.Type]
+		instance, err := factory(agg, p.schema)
+		if err != nil {
+			return nil, err
+		}
+		online, ok := instance.(OnlineAggregator)
+		if !ok {
+			return nil, errors.NewCodedError(errors.PROCESSING_INTERNAL,
+				fmt.Sprintf("aggregator %s does not implement OnlineAggregator", agg.Type))
+		}
+		entries[i] = onlineEntry{agg: agg, online: online}
+	}
+
+	// Pass 1: fold every filter-passing record into each two-pass
+	// attribute's PrePass. Filters apply here so attribute population
+	// stats match the buffered Compute path (which receives the already-
+	// filtered slice).
+	var totalRows, filteredRows int64
+	for iter.Next() {
+		totalRows++
+		r := iter.Record()
+		pass := true
+		for _, fn := range filterFns {
+			ok, err := fn(r)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				pass = false
+				break
+			}
+		}
+		if !pass {
+			continue
+		}
+		filteredRows++
+		for _, ta := range twoPassAttrs {
+			if err := ta.computer.PrePass(r, ta.attr.Field); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, ta := range twoPassAttrs {
+		if err := ta.computer.Finalize(); err != nil {
+			return nil, err
+		}
+	}
+	iter.Reset()
+
+	// Pass 2: re-scan, apply filters again, emit attribute values onto
+	// each filter-passing record (two-pass first so any row-local
+	// attribute referencing a two-pass label sees it), fold each agg.
+	for iter.Next() {
+		r := iter.Record()
+		pass := true
+		for _, fn := range filterFns {
+			ok, err := fn(r)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				pass = false
+				break
+			}
+		}
+		if !pass {
+			continue
+		}
+		for _, ta := range twoPassAttrs {
+			val, err := ta.computer.Row(r, ta.attr.Field)
+			if err != nil {
+				return nil, err
+			}
+			r.Set(ta.label, val)
+		}
+		for _, ra := range rowLocalAttrs {
+			val, err := ra.computer.Row(r, ra.attr.Field)
+			if err != nil {
+				return nil, err
+			}
+			r.Set(ra.label, val)
+		}
+		for _, e := range entries {
+			if err := e.online.UpdateRow(r, e.agg.Field); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	row := make(map[string]any, len(entries))
+	for _, e := range entries {
+		val, err := e.online.Finalize()
+		if err != nil {
+			return nil, err
+		}
+		label := e.agg.Label
+		if label == "" {
+			label = fmt.Sprintf("%s_%s", e.agg.Type, e.agg.Field)
+		}
+		row[label] = val
+	}
+
+	_ = ctx
+	return &types.Response{
+		Data: []map[string]any{row},
 		Metadata: &types.ResponseMetadata{
 			TotalRows:    totalRows,
 			FilteredRows: filteredRows,

--- a/processing/processor.go
+++ b/processing/processor.go
@@ -85,7 +85,13 @@ func (p *Processor) LastPath() ProcessPath {
 // Welford-Pébaÿ recurrences in the streaming path).
 func (p *Processor) Process(ctx context.Context, req *types.Request, iter RecordIterator) (*types.Response, error) {
 	if p.canStream(req) {
-		resp, err := p.processStreaming(ctx, req, iter)
+		var resp *types.Response
+		var err error
+		if len(req.Groups) > 0 {
+			resp, err = p.processStreamingGrouped(ctx, req, iter)
+		} else {
+			resp, err = p.processStreaming(ctx, req, iter)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -135,9 +141,10 @@ func (p *Processor) canStream(req *types.Request) bool {
 	if len(req.Windows) > 0 {
 		return false
 	}
-	// Groups still force buffered until processStreamingGrouped lands.
-	if len(req.Groups) > 0 {
-		return false
+	for _, grp := range req.Groups {
+		if !grp.Type.Streamable() {
+			return false
+		}
 	}
 	for _, attr := range req.Attributes {
 		if !attr.Type.Streamable() {
@@ -326,6 +333,198 @@ func (p *Processor) processStreaming(ctx context.Context, req *types.Request, it
 	_ = ctx
 	return &types.Response{
 		Data: []map[string]any{row},
+		Metadata: &types.ResponseMetadata{
+			TotalRows:    totalRows,
+			FilteredRows: filteredRows,
+		},
+	}, nil
+}
+
+// processStreamingGrouped runs the streaming execution path for
+// requests with one streamable grouper. Each filter-passing record's
+// group key indexes a per-key bucket of fresh OnlineAggregator
+// instances; finalize emits one output row per distinct key with the
+// group field set to the key string. Matches the buffered processGrouped
+// contract: only the first group is consulted (multi-grouper composite
+// keys are not supported in either path today).
+//
+// Memory bound: O(distinct_groups × per_aggregator_state). High-cardinality
+// groups still hold every key's aggregator in memory; the win is avoiding
+// the full record buffer that the buffered path requires.
+func (p *Processor) processStreamingGrouped(ctx context.Context, req *types.Request, iter RecordIterator) (*types.Response, error) {
+	grp := req.Groups[0]
+	grouperFactory, ok := grouperRegistry[grp.Type]
+	if !ok {
+		return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+			fmt.Sprintf("unknown group type: %s", grp.Type))
+	}
+	grouperInstance, err := grouperFactory(grp, p.schema)
+	if err != nil {
+		return nil, err
+	}
+	streamGrp, ok := grouperInstance.(StreamingGrouper)
+	if !ok {
+		return nil, errors.NewCodedError(errors.PROCESSING_INTERNAL,
+			fmt.Sprintf("grouper %s does not implement StreamingGrouper", grp.Type))
+	}
+
+	// Pre-compute aggregator labels so per-key bucket construction is cheap.
+	type aggSpec struct {
+		agg     *types.Aggregation
+		label   string
+		factory AggregatorFactory
+	}
+	specs := make([]aggSpec, len(req.Aggregations))
+	for i, agg := range req.Aggregations {
+		factory := aggregatorRegistry[agg.Type] // canStream verified
+		label := agg.Label
+		if label == "" {
+			label = fmt.Sprintf("%s_%s", agg.Type, agg.Field)
+		}
+		specs[i] = aggSpec{agg: agg, label: label, factory: factory}
+	}
+
+	// Build feature handles + filter funcs + row-local attrs once.
+	var streamingFeatures []feature.StreamingHandle
+	if len(req.Features) > 0 {
+		handles, err := feature.BuildStreaming(req.Features, p.schema)
+		if err != nil {
+			return nil, err
+		}
+		streamingFeatures = handles
+		for iter.Next() {
+			rec := iter.Record()
+			for _, h := range streamingFeatures {
+				if err := h.Computer.PrePass(rec, h.Feature.Field); err != nil {
+					return nil, err
+				}
+			}
+		}
+		for _, h := range streamingFeatures {
+			if err := h.Computer.Finalize(); err != nil {
+				return nil, err
+			}
+		}
+		iter.Reset()
+	}
+
+	filterFns, err := p.buildFilterFuncs(req.Filterers)
+	if err != nil {
+		return nil, err
+	}
+	rowLocalAttrs, err := p.buildRowLocalAttributes(req.Attributes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Per-group bucket. Keys are insertion-ordered to match buffered
+	// path's map-iteration nondeterminism: callers that need stable
+	// ordering must apply Sort.
+	type bucket struct {
+		online []OnlineAggregator
+	}
+	buckets := make(map[string]*bucket)
+
+	var totalRows, filteredRows int64
+	for iter.Next() {
+		totalRows++
+		r := iter.Record()
+
+		for _, h := range streamingFeatures {
+			outputs, err := h.Computer.EmitRow(r, h.Feature.Field)
+			if err != nil {
+				return nil, err
+			}
+			for label, out := range outputs {
+				if len(out.Nulls) > 0 && out.Nulls[0] {
+					r.SetNull(label)
+				} else {
+					r.Set(label, out.Values[0])
+				}
+			}
+		}
+
+		pass := true
+		for _, fn := range filterFns {
+			ok, err := fn(r)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				pass = false
+				break
+			}
+		}
+		if !pass {
+			continue
+		}
+		filteredRows++
+
+		for _, ra := range rowLocalAttrs {
+			val, err := ra.computer.Row(r, ra.attr.Field)
+			if err != nil {
+				return nil, err
+			}
+			r.Set(ra.label, val)
+		}
+
+		key, ok, err := streamGrp.KeyForRow(r, grp.Field)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue // null group key — buffered path skips these too
+		}
+
+		b, exists := buckets[key]
+		if !exists {
+			online := make([]OnlineAggregator, len(specs))
+			for i, s := range specs {
+				inst, err := s.factory(s.agg, p.schema)
+				if err != nil {
+					return nil, err
+				}
+				oa, ok := inst.(OnlineAggregator)
+				if !ok {
+					return nil, errors.NewCodedError(errors.PROCESSING_INTERNAL,
+						fmt.Sprintf("aggregator %s does not implement OnlineAggregator", s.agg.Type))
+				}
+				online[i] = oa
+			}
+			b = &bucket{online: online}
+			buckets[key] = b
+		}
+		for i, oa := range b.online {
+			if err := oa.UpdateRow(r, specs[i].agg.Field); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	data := make([]map[string]any, 0, len(buckets))
+	for key, b := range buckets {
+		// +1 reserved for the group key written below.
+		row := make(map[string]any, len(specs)+1)
+		for i, oa := range b.online {
+			val, err := oa.Finalize()
+			if err != nil {
+				return nil, err
+			}
+			row[specs[i].label] = val
+		}
+		row[grp.Field] = key
+		data = append(data, row)
+	}
+
+	// Apply sort to grouped output, mirroring processRecords behavior so
+	// callers receive deterministic ordering on a small post-aggregate set.
+	if len(req.Sort) > 0 {
+		window.Sort(data, req.Sort)
+	}
+
+	_ = ctx
+	return &types.Response{
+		Data: data,
 		Metadata: &types.ResponseMetadata{
 			TotalRows:    totalRows,
 			FilteredRows: filteredRows,

--- a/processing/processor_streaming_test.go
+++ b/processing/processor_streaming_test.go
@@ -116,9 +116,9 @@ func TestProcessor_NonStreamableGroupForcesBuffered(t *testing.T) {
 	}
 }
 
-// TestProcessor_StreamingFallsBackForAttributes verifies attributes
-// always use the buffered path.
-func TestProcessor_StreamingFallsBackForAttributes(t *testing.T) {
+// TestProcessor_StreamingTwoPassForNormalizedAttribute verifies
+// ATTR_NORMALIZED routes through the two-pass streaming orchestrator.
+func TestProcessor_StreamingTwoPassForNormalizedAttribute(t *testing.T) {
 	schema := numericSchema()
 	proc := NewProcessor(schema)
 
@@ -137,8 +137,34 @@ func TestProcessor_StreamingFallsBackForAttributes(t *testing.T) {
 	if _, err := proc.Process(context.Background(), req, iter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if proc.LastPath() != PathStreaming {
+		t.Errorf("LastPath = %s, want streaming (NORMALIZED is two-pass streamable)", proc.LastPath())
+	}
+}
+
+// TestProcessor_PercentileAttributeForcesBuffered: ATTR_PERCENTILE has
+// no streaming path — needs sorted distribution.
+func TestProcessor_PercentileAttributeForcesBuffered(t *testing.T) {
+	schema := numericSchema()
+	proc := NewProcessor(schema)
+
+	records := makeRecords(schema, "score", []float64{10, 20, 30})
+	iter := NewSliceIterator(records)
+
+	req := &types.Request{
+		Attributes: []*types.Attribute{
+			{Type: types.ATTR_PERCENTILE, Field: "score", Label: "p"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_AVERAGE, Field: "p", Label: "avg"},
+		},
+	}
+
+	if _, err := proc.Process(context.Background(), req, iter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if proc.LastPath() != PathBuffered {
-		t.Errorf("LastPath = %s, want buffered (attributes force fallback)", proc.LastPath())
+		t.Errorf("LastPath = %s, want buffered (PERCENTILE forces fallback)", proc.LastPath())
 	}
 }
 

--- a/processing/processor_streaming_test.go
+++ b/processing/processor_streaming_test.go
@@ -61,9 +61,9 @@ func TestProcessor_StreamingPathFallsBackForBufferedAgg(t *testing.T) {
 	}
 }
 
-// TestProcessor_StreamingFallsBackForGroups verifies grouping always
-// uses the buffered path.
-func TestProcessor_StreamingFallsBackForGroups(t *testing.T) {
+// TestProcessor_StreamingForStreamableGroups verifies grouped streaming
+// runs when every grouper.Type.Streamable() is true.
+func TestProcessor_StreamingForStreamableGroups(t *testing.T) {
 	schema := numericSchema()
 	proc := NewProcessor(schema)
 
@@ -79,11 +79,40 @@ func TestProcessor_StreamingFallsBackForGroups(t *testing.T) {
 		},
 	}
 
+	resp, err := proc.Process(context.Background(), req, iter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if proc.LastPath() != PathStreaming {
+		t.Errorf("LastPath = %s, want streaming (CATEGORY group is streamable)", proc.LastPath())
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 group rows, got %d", len(resp.Data))
+	}
+}
+
+// TestProcessor_NonStreamableGroupForcesBuffered verifies QUANTILE
+// (non-streamable) routes through the buffered path.
+func TestProcessor_NonStreamableGroupForcesBuffered(t *testing.T) {
+	schema := numericSchema()
+	proc := NewProcessor(schema)
+
+	records := makeRecords(schema, "age", []float64{1, 2, 3, 4, 5, 6, 7, 8})
+	iter := NewSliceIterator(records)
+
+	req := &types.Request{
+		Groups: []*types.Group{
+			{Type: types.GROUP_QUANTILE, Field: "age", Interval: 4},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_COUNT, Field: "age", Label: "n"},
+		},
+	}
 	if _, err := proc.Process(context.Background(), req, iter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if proc.LastPath() != PathBuffered {
-		t.Errorf("LastPath = %s, want buffered (groups force fallback)", proc.LastPath())
+		t.Errorf("LastPath = %s, want buffered (QUANTILE forces fallback)", proc.LastPath())
 	}
 }
 

--- a/processing/streamability_test.go
+++ b/processing/streamability_test.go
@@ -1,0 +1,33 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/frankbardon/pulse/types"
+)
+
+// TestRegistryStreamabilityMatchesTypes asserts that for every registered
+// aggregator, the runtime capability (does the constructed instance
+// implement OnlineAggregator?) matches the type's declared Streamable()
+// value. This catches drift between types/streamability.go and the
+// processing implementations.
+func TestRegistryStreamabilityMatchesTypes(t *testing.T) {
+	for _, aggType := range types.AllAggregationTypes() {
+		factory, ok := aggregatorRegistry[aggType]
+		if !ok {
+			t.Errorf("aggregator %s not in registry", aggType)
+			continue
+		}
+		instance, err := factory(&types.Aggregation{Type: aggType, Field: "x"}, nil)
+		if err != nil {
+			t.Errorf("aggregator %s factory error: %v", aggType, err)
+			continue
+		}
+		_, runtimeOnline := instance.(OnlineAggregator)
+		declared := aggType.Streamable()
+		if runtimeOnline != declared {
+			t.Errorf("aggregator %s: types.Streamable()=%v but runtime OnlineAggregator=%v — update types/streamability.go to match implementation",
+				aggType, declared, runtimeOnline)
+		}
+	}
+}

--- a/processing/streamability_test.go
+++ b/processing/streamability_test.go
@@ -3,8 +3,73 @@ package processing
 import (
 	"testing"
 
+	"github.com/frankbardon/pulse/encoding"
 	"github.com/frankbardon/pulse/types"
 )
+
+// TestCanStreamRequest_RegressionMatrix exercises the exported
+// CanStreamRequest hook (used by descriptor/ for predict parity). Each
+// row is a (request, schema, want) triple. If predict.Streamable ever
+// drifts from runtime behavior, this matrix breaks.
+func TestCanStreamRequest_RegressionMatrix(t *testing.T) {
+	numericSchema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "score", Type: encoding.FieldTypeF64},
+		},
+	}
+	decimalSchema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "amount", Type: encoding.FieldTypeDecimal128, Precision: 10, Scale: 2},
+		},
+	}
+	cases := []struct {
+		name   string
+		req    *types.Request
+		schema *encoding.Schema
+		want   bool
+	}{
+		{
+			name:   "online aggregations on numeric stream",
+			req:    &types.Request{Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}}},
+			schema: numericSchema,
+			want:   true,
+		},
+		{
+			name:   "median forces buffered",
+			req:    &types.Request{Aggregations: []*types.Aggregation{{Type: types.AGG_MEDIAN, Field: "score"}}},
+			schema: numericSchema,
+			want:   false,
+		},
+		{
+			name: "groups force buffered",
+			req: &types.Request{
+				Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
+				Groups:       []*types.Group{{Type: types.GROUP_CATEGORY, Field: "score"}},
+			},
+			schema: numericSchema,
+			want:   false,
+		},
+		{
+			name:   "decimal field forces buffered",
+			req:    &types.Request{Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "amount"}}},
+			schema: decimalSchema,
+			want:   false,
+		},
+		{
+			name:   "no aggregations forces buffered",
+			req:    &types.Request{},
+			schema: numericSchema,
+			want:   false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := CanStreamRequest(c.req, c.schema); got != c.want {
+				t.Errorf("CanStreamRequest = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
 
 // TestRegistryStreamabilityMatchesTypes asserts that for every registered
 // aggregator, the runtime capability (does the constructed instance

--- a/processing/streamability_test.go
+++ b/processing/streamability_test.go
@@ -71,6 +71,42 @@ func TestCanStreamRequest_RegressionMatrix(t *testing.T) {
 	}
 }
 
+// TestRegistryAttributeStreamabilityMatchesTypes asserts that for every
+// registered attribute, runtime RowLocalAttribute support matches the
+// type's declared Streamable() value.
+func TestRegistryAttributeStreamabilityMatchesTypes(t *testing.T) {
+	for _, attrType := range types.AllAttributeTypes() {
+		factory, ok := attributeRegistry[attrType]
+		if !ok {
+			t.Errorf("attribute %s not in registry", attrType)
+			continue
+		}
+		// FORMULA needs a non-empty expression; DATE_PART needs params.
+		// Provide minimum viable params so factory succeeds.
+		spec := &types.Attribute{Type: attrType, Field: "x"}
+		switch attrType {
+		case types.ATTR_FORMULA:
+			spec.Expression = "1"
+		case types.ATTR_DATE_PART:
+			spec.Params = []byte(`{"part":"year"}`)
+		}
+		schema := &encoding.Schema{
+			Fields: []encoding.Field{{Name: "x", Type: encoding.FieldTypeDate}},
+		}
+		instance, err := factory(spec, schema)
+		if err != nil {
+			t.Errorf("attribute %s factory error: %v", attrType, err)
+			continue
+		}
+		_, runtimeRowLocal := instance.(RowLocalAttribute)
+		declared := attrType.Streamable()
+		if runtimeRowLocal != declared {
+			t.Errorf("attribute %s: types.Streamable()=%v but runtime RowLocalAttribute=%v — update types/streamability.go to match implementation",
+				attrType, declared, runtimeRowLocal)
+		}
+	}
+}
+
 // TestRegistryStreamabilityMatchesTypes asserts that for every registered
 // aggregator, the runtime capability (does the constructed instance
 // implement OnlineAggregator?) matches the type's declared Streamable()

--- a/processing/streamability_test.go
+++ b/processing/streamability_test.go
@@ -41,10 +41,19 @@ func TestCanStreamRequest_RegressionMatrix(t *testing.T) {
 			want:   false,
 		},
 		{
-			name: "groups force buffered",
+			name: "streamable group + online aggs streams",
 			req: &types.Request{
 				Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
 				Groups:       []*types.Group{{Type: types.GROUP_CATEGORY, Field: "score"}},
+			},
+			schema: numericSchema,
+			want:   true,
+		},
+		{
+			name: "non-streamable group forces buffered",
+			req: &types.Request{
+				Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "score"}},
+				Groups:       []*types.Group{{Type: types.GROUP_QUANTILE, Field: "score", Interval: 4}},
 			},
 			schema: numericSchema,
 			want:   false,

--- a/processing/streamability_test.go
+++ b/processing/streamability_test.go
@@ -81,8 +81,9 @@ func TestCanStreamRequest_RegressionMatrix(t *testing.T) {
 }
 
 // TestRegistryAttributeStreamabilityMatchesTypes asserts that for every
-// registered attribute, runtime RowLocalAttribute support matches the
-// type's declared Streamable() value.
+// registered attribute, runtime streamability support (RowLocalAttribute
+// for one-pass row-local OR TwoPassAttribute for population-stat
+// streaming) matches the type's declared Streamable() value.
 func TestRegistryAttributeStreamabilityMatchesTypes(t *testing.T) {
 	for _, attrType := range types.AllAttributeTypes() {
 		factory, ok := attributeRegistry[attrType]
@@ -108,10 +109,12 @@ func TestRegistryAttributeStreamabilityMatchesTypes(t *testing.T) {
 			continue
 		}
 		_, runtimeRowLocal := instance.(RowLocalAttribute)
+		_, runtimeTwoPass := instance.(TwoPassAttribute)
+		runtimeStreamable := runtimeRowLocal || runtimeTwoPass
 		declared := attrType.Streamable()
-		if runtimeRowLocal != declared {
-			t.Errorf("attribute %s: types.Streamable()=%v but runtime RowLocalAttribute=%v — update types/streamability.go to match implementation",
-				attrType, declared, runtimeRowLocal)
+		if runtimeStreamable != declared {
+			t.Errorf("attribute %s: types.Streamable()=%v but runtime RowLocalAttribute=%v TwoPassAttribute=%v — update types/streamability.go to match implementation",
+				attrType, declared, runtimeRowLocal, runtimeTwoPass)
 		}
 	}
 }

--- a/pulse.go
+++ b/pulse.go
@@ -118,6 +118,21 @@ func (p *Pulse) Compose(ctx context.Context, req *ComposedRequest) ([]*Response,
 	return p.svc.Compose(ctx, req)
 }
 
+// ComposeOptions controls parallel execution. See service.ComposeOptions.
+type ComposeOptions = service.ComposeOptions
+
+// ComposeParallel runs every request in req concurrently across a bounded
+// worker pool. Responses are returned in input order. Workers share the
+// engine's read-only registries; each Process call constructs fresh
+// stateful operators per request, so concurrent execution is safe.
+//
+// Defaults: MaxWorkers = runtime.GOMAXPROCS(0), no per-request timeout,
+// FailFast = true (set FailFast=false to collect every request's outcome
+// instead of cancelling siblings on first error).
+func (p *Pulse) ComposeParallel(ctx context.Context, req *ComposedRequest, opts ComposeOptions) ([]*Response, error) {
+	return p.svc.ComposeParallel(ctx, req, opts)
+}
+
 // Import converts tabular source data into a .pulse file.
 // The job's FS field is set to the Pulse instance's filesystem if not already set.
 func (p *Pulse) Import(ctx context.Context, job *pio.ImportJob) (*pio.ImportReport, error) {

--- a/pulse.go
+++ b/pulse.go
@@ -91,6 +91,28 @@ func (p *Pulse) Process(ctx context.Context, req *Request) (*Response, error) {
 	return p.svc.Process(ctx, req)
 }
 
+// Row is a single result row in a processing stream.
+type Row = service.Row
+
+// RowIter is a pull-based iterator over a processing result. Each call
+// to Next returns the next row or (nil, false, nil) on exhaustion. Close
+// releases underlying resources. Metadata returns the run metadata once
+// available (always present after the iterator is drained).
+type RowIter = service.RowIter
+
+// ProcessStream executes a request and returns a pull-based row iterator
+// over the result. Equivalent to Process for any request shape — same
+// gates, same errors — but streaming consumers (HTTP responders, NDJSON
+// writers, downstream pipelines) can drain rows one at a time without
+// buffering the full result in their own memory.
+//
+// Predict's Streamable flag reports whether the underlying execution
+// avoids buffering inside the engine; ProcessStream wraps the result
+// regardless, so the API is stable for non-streamable requests too.
+func (p *Pulse) ProcessStream(ctx context.Context, req *Request) (RowIter, error) {
+	return p.svc.ProcessStream(ctx, req)
+}
+
 // Compose executes multiple requests, returning a response for each.
 func (p *Pulse) Compose(ctx context.Context, req *ComposedRequest) ([]*Response, error) {
 	return p.svc.Compose(ctx, req)

--- a/pulse_test.go
+++ b/pulse_test.go
@@ -822,6 +822,43 @@ func TestNoOsExec(t *testing.T) {
 	}
 }
 
+func TestComposeParallel_FacadeOrderPreserved(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+	createTestPulseFile(t, memFs, "test.pulse", []string{"age"}, [][]string{
+		{"10"}, {"20"}, {"30"}, {"40"}, {"50"},
+	})
+
+	p, err := New(Options{FS: memFs})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	composed := &ComposedRequest{
+		Requests: []*Request{
+			{Cohort: &types.Cohort{Filename: "test.pulse"}, Aggregations: []*types.Aggregation{{Type: types.AGG_AVERAGE, Field: "age", Label: "a"}}},
+			{Cohort: &types.Cohort{Filename: "test.pulse"}, Aggregations: []*types.Aggregation{{Type: types.AGG_SUM, Field: "age", Label: "b"}}},
+			{Cohort: &types.Cohort{Filename: "test.pulse"}, Aggregations: []*types.Aggregation{{Type: types.AGG_COUNT, Field: "age", Label: "c"}}},
+		},
+	}
+
+	resps, err := p.ComposeParallel(context.Background(), composed, ComposeOptions{MaxWorkers: 3})
+	if err != nil {
+		t.Fatalf("ComposeParallel: %v", err)
+	}
+	if len(resps) != 3 {
+		t.Fatalf("got %d responses, want 3", len(resps))
+	}
+	if _, ok := resps[0].Data[0]["a"]; !ok {
+		t.Error("slot 0 missing label a")
+	}
+	if _, ok := resps[1].Data[0]["b"]; !ok {
+		t.Error("slot 1 missing label b")
+	}
+	if _, ok := resps[2].Data[0]["c"]; !ok {
+		t.Error("slot 2 missing label c")
+	}
+}
+
 func TestProcessStream_FacadeReturnsIterator(t *testing.T) {
 	memFs := afero.NewMemMapFs()
 	createTestPulseFile(t, memFs, "test.pulse", []string{"age"}, [][]string{

--- a/pulse_test.go
+++ b/pulse_test.go
@@ -822,6 +822,47 @@ func TestNoOsExec(t *testing.T) {
 	}
 }
 
+func TestProcessStream_FacadeReturnsIterator(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+	createTestPulseFile(t, memFs, "test.pulse", []string{"age"}, [][]string{
+		{"10"}, {"20"}, {"30"},
+	})
+
+	p, err := New(Options{FS: memFs})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	iter, err := p.ProcessStream(context.Background(), &Request{
+		Cohort: &types.Cohort{Filename: "test.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_COUNT, Field: "age", Label: "n"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ProcessStream: %v", err)
+	}
+	defer iter.Close()
+
+	var rows []Row
+	for {
+		row, ok, err := iter.Next(context.Background())
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if !ok {
+			break
+		}
+		rows = append(rows, row)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if iter.Metadata() == nil {
+		t.Fatal("Metadata nil after drain")
+	}
+}
+
 func TestCohort_SchemaNotNil(t *testing.T) {
 	memFs := afero.NewMemMapFs()
 	schema := &encoding.Schema{

--- a/service/compose_parallel.go
+++ b/service/compose_parallel.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/frankbardon/pulse/errors"
+	"github.com/frankbardon/pulse/types"
+)
+
+// ComposeOptions controls parallel execution of a ComposedRequest.
+//
+// Order of responses is always preserved — slot-by-index — regardless of
+// MaxWorkers or completion order.
+type ComposeOptions struct {
+	// MaxWorkers caps concurrent in-flight Process calls. Zero means
+	// runtime.GOMAXPROCS(0). Negative values are clamped to 1.
+	MaxWorkers int
+
+	// PerRequestTimeout, if positive, derives a context.WithTimeout for
+	// each request. Zero means no per-request timeout (the parent ctx's
+	// deadline still applies).
+	PerRequestTimeout time.Duration
+
+	// FailFast cancels in-flight siblings on the first request error.
+	// Default is true: surface errors quickly. Set false to collect every
+	// request's outcome (errors aggregated into a single CodedError with
+	// per-index detail).
+	FailFast bool
+}
+
+// resolvedOptions returns a copy with defaults applied.
+func (o ComposeOptions) resolved() ComposeOptions {
+	out := o
+	if out.MaxWorkers == 0 {
+		out.MaxWorkers = runtime.GOMAXPROCS(0)
+	}
+	if out.MaxWorkers < 1 {
+		out.MaxWorkers = 1
+	}
+	return out
+}
+
+// ComposeParallel runs every request in composed concurrently across a
+// bounded worker pool. Responses are returned in the same order as
+// composed.Requests; per-request errors are surfaced according to opts.
+//
+// Registry factories return fresh stateful instances per request, so
+// concurrent Process calls do not share aggregator/attribute state. Geo
+// and decimal aggregators dispatch through buffered code paths that are
+// also safe for concurrent invocation (no shared mutable state).
+func (s *Service) ComposeParallel(
+	ctx context.Context,
+	composed *types.ComposedRequest,
+	opts ComposeOptions,
+) ([]*types.Response, error) {
+	if composed == nil || len(composed.Requests) == 0 {
+		return nil, errors.NewCodedError(errors.SERVICE_VALIDATION,
+			"composed request must contain at least one request")
+	}
+
+	o := opts.resolved()
+	n := len(composed.Requests)
+
+	// Per-slot result and error storage; never shared across slots so no
+	// inter-slot synchronization is required beyond the slot itself.
+	responses := make([]*types.Response, n)
+	errs := make([]error, n)
+
+	// Cancellation context: derived once so FailFast can fan out cancellation
+	// to every in-flight goroutine via cancel().
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// failOnce ensures FailFast triggers cancel() exactly once, even if
+	// multiple goroutines fail concurrently.
+	var failOnce sync.Once
+	triggerFailFast := func() {
+		if o.FailFast {
+			failOnce.Do(cancel)
+		}
+	}
+
+	sem := make(chan struct{}, o.MaxWorkers)
+	var wg sync.WaitGroup
+
+	for i, req := range composed.Requests {
+		// Bail before launching when ctx is already cancelled.
+		if runCtx.Err() != nil {
+			break
+		}
+		i, req := i, req
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			reqCtx := runCtx
+			if o.PerRequestTimeout > 0 {
+				var reqCancel context.CancelFunc
+				reqCtx, reqCancel = context.WithTimeout(runCtx, o.PerRequestTimeout)
+				defer reqCancel()
+			}
+
+			resp, err := s.Process(reqCtx, req)
+			if err != nil {
+				errs[i] = err
+				triggerFailFast()
+				return
+			}
+			responses[i] = resp
+		}()
+	}
+	wg.Wait()
+
+	// Aggregate errors if any. FailFast surfaces the first observed error
+	// (lowest-index winner); non-FailFast wraps every error with its slot
+	// index so callers see the full picture.
+	var firstErr error
+	var failed []int
+	for i, e := range errs {
+		if e != nil {
+			failed = append(failed, i)
+			if firstErr == nil {
+				firstErr = e
+			}
+		}
+	}
+	if firstErr != nil {
+		if o.FailFast {
+			return nil, fmt.Errorf("compose parallel: request %d: %w", failed[0], firstErr)
+		}
+		details := map[string]any{"failed_indices": failed, "first_error": firstErr.Error()}
+		return nil, errors.NewCodedErrorWithDetails(errors.SERVICE_INTERNAL,
+			fmt.Sprintf("compose parallel: %d/%d requests failed", len(failed), n),
+			details)
+	}
+
+	return responses, nil
+}

--- a/service/compose_parallel_test.go
+++ b/service/compose_parallel_test.go
@@ -1,0 +1,248 @@
+package service
+
+import (
+	"context"
+	"math"
+	"runtime"
+	"testing"
+	"time"
+
+	pulseerrors "github.com/frankbardon/pulse/errors"
+	"github.com/frankbardon/pulse/types"
+)
+
+// composeFiveAvgRequests returns five requests, each computing AVG of a
+// shifted score field. Used to verify order preservation.
+func composeFiveAvgRequests() *types.ComposedRequest {
+	r := func(label string) *types.Request {
+		return &types.Request{
+			Cohort: &types.Cohort{Filename: "test.pulse"},
+			Aggregations: []*types.Aggregation{
+				{Type: types.AGG_AVERAGE, Field: "score", Label: label},
+			},
+		}
+	}
+	return &types.ComposedRequest{
+		Requests: []*types.Request{r("a"), r("b"), r("c"), r("d"), r("e")},
+	}
+}
+
+func TestComposeParallel_PreservesOrder(t *testing.T) {
+	cfg := setupTestFS(t, "test.pulse", testSchema(), testRecords())
+	svc := New(cfg)
+
+	resps, err := svc.ComposeParallel(context.Background(), composeFiveAvgRequests(), ComposeOptions{MaxWorkers: 4})
+	if err != nil {
+		t.Fatalf("ComposeParallel: %v", err)
+	}
+	if len(resps) != 5 {
+		t.Fatalf("got %d responses, want 5", len(resps))
+	}
+	labels := []string{"a", "b", "c", "d", "e"}
+	for i, label := range labels {
+		if resps[i] == nil || len(resps[i].Data) == 0 {
+			t.Fatalf("slot %d empty", i)
+			continue
+		}
+		val, ok := resps[i].Data[0][label].(float64)
+		if !ok {
+			t.Errorf("slot %d label %q missing or wrong type", i, label)
+			continue
+		}
+		if !floatClose(val, 30.0, 0.001) {
+			t.Errorf("slot %d %s = %v, want 30.0", i, label, val)
+		}
+	}
+}
+
+func TestComposeParallel_DefaultsApplied(t *testing.T) {
+	cfg := setupTestFS(t, "test.pulse", testSchema(), testRecords())
+	svc := New(cfg)
+
+	// MaxWorkers=0 should resolve to GOMAXPROCS; pool execution still works.
+	_, err := svc.ComposeParallel(context.Background(), composeFiveAvgRequests(), ComposeOptions{})
+	if err != nil {
+		t.Fatalf("ComposeParallel with default options: %v", err)
+	}
+
+	// Negative MaxWorkers clamps to 1.
+	_, err = svc.ComposeParallel(context.Background(), composeFiveAvgRequests(), ComposeOptions{MaxWorkers: -5})
+	if err != nil {
+		t.Fatalf("ComposeParallel MaxWorkers=-5 should clamp to 1, got error: %v", err)
+	}
+}
+
+func TestComposeParallel_RespectsWorkerCap(t *testing.T) {
+	// Verify MaxWorkers caps in-flight goroutines. We can't observe the
+	// worker count directly without instrumentation, so use atomic
+	// counters around Process via a mid-flight sleep request.
+	//
+	// Build a cohort with 1000 rows so each Process call has a few ms of
+	// real work. Concurrent maximum is observed via a tracked counter.
+	rows := make([][]uint64, 1000)
+	for i := range rows {
+		rows[i] = []uint64{uint64(i), math.Float64bits(float64(i))}
+	}
+	cfg := setupTestFS(t, "test.pulse", testSchema(), rows)
+	svc := New(cfg)
+
+	// Wrap svc.Process via a subtype isn't possible; instead we set a
+	// small MaxWorkers and rely on PerRequestTimeout to confirm bounded
+	// concurrency by ensuring the run takes at least ceil(N/W) * latency.
+	// We measure ratio of total duration vs. single-request latency.
+	composed := &types.ComposedRequest{}
+	for range 16 {
+		composed.Requests = append(composed.Requests, &types.Request{
+			Cohort: &types.Cohort{Filename: "test.pulse"},
+			Aggregations: []*types.Aggregation{
+				{Type: types.AGG_AVERAGE, Field: "score", Label: "avg"},
+			},
+		})
+	}
+
+	startSerial := time.Now()
+	if _, err := svc.Process(context.Background(), composed.Requests[0]); err != nil {
+		t.Fatalf("baseline Process: %v", err)
+	}
+	singleLatency := time.Since(startSerial)
+
+	startParallel := time.Now()
+	resps, err := svc.ComposeParallel(context.Background(), composed, ComposeOptions{MaxWorkers: 2})
+	if err != nil {
+		t.Fatalf("ComposeParallel: %v", err)
+	}
+	parallelDur := time.Since(startParallel)
+
+	if len(resps) != 16 {
+		t.Fatalf("got %d, want 16", len(resps))
+	}
+	// With MaxWorkers=2 and 16 requests, total ≈ 8 * latency. Allow
+	// generous slack for scheduling: must be at least 4× single latency.
+	min := singleLatency * 4
+	if parallelDur < min {
+		t.Logf("baseline=%s parallel=%s — too fast for 16 reqs / 2 workers (smoke test, not strict)", singleLatency, parallelDur)
+	}
+}
+
+func TestComposeParallel_FailFastCancelsSiblings(t *testing.T) {
+	cfg := setupTestFS(t, "test.pulse", testSchema(), testRecords())
+	svc := New(cfg)
+
+	// Mix valid and invalid requests. Slot 0 references a missing file
+	// → SERVICE_RESOURCE error fires fast → siblings cancel.
+	composed := &types.ComposedRequest{
+		Requests: []*types.Request{
+			{
+				Cohort: &types.Cohort{Filename: "missing.pulse"},
+				Aggregations: []*types.Aggregation{
+					{Type: types.AGG_AVERAGE, Field: "score", Label: "broken"},
+				},
+			},
+			{
+				Cohort: &types.Cohort{Filename: "test.pulse"},
+				Aggregations: []*types.Aggregation{
+					{Type: types.AGG_AVERAGE, Field: "score", Label: "ok"},
+				},
+			},
+		},
+	}
+
+	_, err := svc.ComposeParallel(context.Background(), composed, ComposeOptions{
+		MaxWorkers: 2,
+		FailFast:   true,
+	})
+	if err == nil {
+		t.Fatal("expected error from fail-fast")
+	}
+}
+
+func TestComposeParallel_NoFailFastAggregatesErrors(t *testing.T) {
+	cfg := setupTestFS(t, "test.pulse", testSchema(), testRecords())
+	svc := New(cfg)
+
+	composed := &types.ComposedRequest{
+		Requests: []*types.Request{
+			{
+				Cohort: &types.Cohort{Filename: "missing_a.pulse"},
+				Aggregations: []*types.Aggregation{
+					{Type: types.AGG_AVERAGE, Field: "score", Label: "a"},
+				},
+			},
+			{
+				Cohort: &types.Cohort{Filename: "test.pulse"},
+				Aggregations: []*types.Aggregation{
+					{Type: types.AGG_AVERAGE, Field: "score", Label: "b"},
+				},
+			},
+			{
+				Cohort: &types.Cohort{Filename: "missing_c.pulse"},
+				Aggregations: []*types.Aggregation{
+					{Type: types.AGG_AVERAGE, Field: "score", Label: "c"},
+				},
+			},
+		},
+	}
+
+	_, err := svc.ComposeParallel(context.Background(), composed, ComposeOptions{
+		MaxWorkers: 3,
+		FailFast:   false,
+	})
+	if err == nil {
+		t.Fatal("expected aggregated error for failed requests")
+	}
+	if !pulseerrors.HasCode(err, pulseerrors.SERVICE_INTERNAL) {
+		t.Errorf("expected SERVICE_INTERNAL aggregated error, got %v", err)
+	}
+}
+
+func TestComposeParallel_NilRequestErrors(t *testing.T) {
+	svc := New(setupTestFS(t, "test.pulse", testSchema(), testRecords()))
+	_, err := svc.ComposeParallel(context.Background(), nil, ComposeOptions{})
+	if err == nil {
+		t.Fatal("expected validation error for nil composed")
+	}
+	_, err = svc.ComposeParallel(context.Background(), &types.ComposedRequest{}, ComposeOptions{})
+	if err == nil {
+		t.Fatal("expected validation error for empty requests")
+	}
+}
+
+// TestComposeParallel_FreshOperatorsPerRequest is the registry-singleton
+// smoke test. Two parallel runs of the same request should yield the
+// same results. Stateful aggregator drift would manifest as either a
+// race detector trip (run with -race) or wrong values.
+func TestComposeParallel_FreshOperatorsPerRequest(t *testing.T) {
+	cfg := setupTestFS(t, "test.pulse", testSchema(), testRecords())
+	svc := New(cfg)
+
+	composed := &types.ComposedRequest{}
+	for range 32 {
+		composed.Requests = append(composed.Requests, &types.Request{
+			Cohort: &types.Cohort{Filename: "test.pulse"},
+			Aggregations: []*types.Aggregation{
+				{Type: types.AGG_SUM, Field: "score", Label: "s"},
+				{Type: types.AGG_AVERAGE, Field: "score", Label: "a"},
+				{Type: types.AGG_VARIANCE, Field: "score", Label: "v"},
+			},
+		})
+	}
+
+	resps, err := svc.ComposeParallel(context.Background(), composed, ComposeOptions{
+		MaxWorkers: runtime.GOMAXPROCS(0),
+	})
+	if err != nil {
+		t.Fatalf("ComposeParallel: %v", err)
+	}
+
+	wantSum := 150.0 // 10+20+30+40+50
+	wantAvg := 30.0
+	for i, resp := range resps {
+		if s, ok := resp.Data[0]["s"].(float64); !ok || !floatClose(s, wantSum, 0.001) {
+			t.Errorf("slot %d sum = %v, want %v", i, resp.Data[0]["s"], wantSum)
+		}
+		if a, ok := resp.Data[0]["a"].(float64); !ok || !floatClose(a, wantAvg, 0.001) {
+			t.Errorf("slot %d avg = %v, want %v", i, resp.Data[0]["a"], wantAvg)
+		}
+	}
+}
+

--- a/service/process_stream.go
+++ b/service/process_stream.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	pulseerrors "github.com/frankbardon/pulse/errors"
+	"github.com/frankbardon/pulse/types"
+)
+
+// Row is a single result row in a processing stream. Aliased so callers
+// can write `service.Row` without leaking the underlying map type.
+type Row = map[string]any
+
+// RowIter is a pull-based iterator over a processing result. Next reports
+// (row, true, nil) for each available row, then (nil, false, nil) on
+// exhaustion. Close releases any underlying file handles.
+//
+// Implementations are NOT goroutine-safe. A single consumer per iterator.
+type RowIter interface {
+	Next(ctx context.Context) (Row, bool, error)
+	Close() error
+	// Metadata returns the run metadata (total/filtered row counts,
+	// cohort filename). Available after the iterator is exhausted; may
+	// return nil before then. Streaming consumers that need metadata
+	// before draining should call Process instead.
+	Metadata() *types.ResponseMetadata
+}
+
+// ProcessStream executes a request and returns a pull-based row iterator
+// over the result. The semantics match Process — same gates, same errors,
+// same metadata — but the consumer can drain rows incrementally instead
+// of receiving the whole []map[string]any up front.
+//
+// Today the iterator buffers internally (calls Process and walks Data).
+// The signature is forward-compatible with a future true-streaming path
+// driven by the streaming Processor; consumers that adopt it now will
+// pick up that change without a code change on their side.
+func (s *Service) ProcessStream(ctx context.Context, req *types.Request) (RowIter, error) {
+	if req == nil || req.Cohort == nil {
+		return nil, pulseerrors.NewCodedError(pulseerrors.SERVICE_VALIDATION,
+			"process_stream request requires a cohort")
+	}
+	resp, err := s.Process(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &bufferedRowIter{rows: resp.Data, meta: resp.Metadata}, nil
+}
+
+// bufferedRowIter walks a pre-materialized row slice. It is the trivial
+// implementation behind ProcessStream until the streaming Processor path
+// is wired through.
+type bufferedRowIter struct {
+	rows   []Row
+	idx    int
+	meta   *types.ResponseMetadata
+	closed bool
+}
+
+var errIterClosed = errors.New("row iterator closed")
+
+func (it *bufferedRowIter) Next(ctx context.Context) (Row, bool, error) {
+	if it.closed {
+		return nil, false, errIterClosed
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	if it.idx >= len(it.rows) {
+		return nil, false, nil
+	}
+	row := it.rows[it.idx]
+	it.idx++
+	return row, true, nil
+}
+
+func (it *bufferedRowIter) Close() error {
+	it.closed = true
+	it.rows = nil
+	return nil
+}
+
+func (it *bufferedRowIter) Metadata() *types.ResponseMetadata {
+	return it.meta
+}

--- a/service/process_stream_test.go
+++ b/service/process_stream_test.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	pulseerrors "github.com/frankbardon/pulse/errors"
+	"github.com/frankbardon/pulse/types"
+)
+
+func TestProcessStream_DrainsRowsInOrder(t *testing.T) {
+	schema := testSchema()
+	cfg := setupTestFS(t, "test.pulse", schema, testRecords())
+	svc := New(cfg)
+
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "test.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_AVERAGE, Field: "score", Label: "avg_score"},
+		},
+	}
+
+	iter, err := svc.ProcessStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ProcessStream: %v", err)
+	}
+	defer iter.Close()
+
+	rows := drain(t, iter)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	val, ok := rows[0]["avg_score"].(float64)
+	if !ok || !floatClose(val, 30.0, 0.001) {
+		t.Errorf("avg_score = %v, want 30.0", rows[0]["avg_score"])
+	}
+}
+
+func TestProcessStream_GroupedRowsAvailable(t *testing.T) {
+	// Group by score (numeric, not categorical here, but GROUP_RANGE works
+	// on numeric fields). Five rows × 10..50 → groups by 25.
+	schema := testSchema()
+	cfg := setupTestFS(t, "test.pulse", schema, [][]uint64{
+		{1, math.Float64bits(10)},
+		{2, math.Float64bits(15)},
+		{3, math.Float64bits(30)},
+		{4, math.Float64bits(45)},
+		{5, math.Float64bits(50)},
+	})
+	svc := New(cfg)
+
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "test.pulse"},
+		Groups: []*types.Group{{Type: types.GROUP_RANGE, Field: "score", Interval: 25}},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_COUNT, Field: "score", Label: "n"},
+		},
+	}
+
+	iter, err := svc.ProcessStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ProcessStream: %v", err)
+	}
+	defer iter.Close()
+
+	rows := drain(t, iter)
+	if len(rows) < 2 {
+		t.Fatalf("expected at least 2 group rows, got %d", len(rows))
+	}
+}
+
+func TestProcessStream_MetadataAvailableAfterDrain(t *testing.T) {
+	schema := testSchema()
+	cfg := setupTestFS(t, "test.pulse", schema, testRecords())
+	svc := New(cfg)
+
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "test.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_COUNT, Field: "score", Label: "n"},
+		},
+	}
+
+	iter, err := svc.ProcessStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ProcessStream: %v", err)
+	}
+	defer iter.Close()
+
+	_ = drain(t, iter)
+	meta := iter.Metadata()
+	if meta == nil {
+		t.Fatal("metadata is nil after drain")
+	}
+	if meta.TotalRows != 5 {
+		t.Errorf("TotalRows = %d, want 5", meta.TotalRows)
+	}
+	if meta.CohortFile != "test.pulse" {
+		t.Errorf("CohortFile = %q, want test.pulse", meta.CohortFile)
+	}
+}
+
+func TestProcessStream_NilCohortReturnsValidationError(t *testing.T) {
+	svc := New(setupTestFS(t, "test.pulse", testSchema(), testRecords()))
+	_, err := svc.ProcessStream(context.Background(), &types.Request{})
+	if err == nil {
+		t.Fatal("expected validation error for nil cohort")
+	}
+	if !pulseerrors.HasCode(err, pulseerrors.SERVICE_VALIDATION) {
+		t.Errorf("expected SERVICE_VALIDATION, got %v", err)
+	}
+}
+
+func TestProcessStream_CtxCancelledDuringDrain(t *testing.T) {
+	svc := New(setupTestFS(t, "test.pulse", testSchema(), testRecords()))
+	req := &types.Request{
+		Cohort:       &types.Cohort{Filename: "test.pulse"},
+		Aggregations: []*types.Aggregation{{Type: types.AGG_COUNT, Field: "score", Label: "n"}},
+	}
+	iter, err := svc.ProcessStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ProcessStream: %v", err)
+	}
+	defer iter.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err = iter.Next(ctx)
+	if err == nil {
+		t.Fatal("expected context error from Next on cancelled ctx")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestProcessStream_CloseIsIdempotent(t *testing.T) {
+	svc := New(setupTestFS(t, "test.pulse", testSchema(), testRecords()))
+	req := &types.Request{
+		Cohort:       &types.Cohort{Filename: "test.pulse"},
+		Aggregations: []*types.Aggregation{{Type: types.AGG_COUNT, Field: "score", Label: "n"}},
+	}
+	iter, err := svc.ProcessStream(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ProcessStream: %v", err)
+	}
+	if err := iter.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	if err := iter.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+	_, _, err = iter.Next(context.Background())
+	if err == nil {
+		t.Error("expected error from Next after Close")
+	}
+}
+
+func drain(t *testing.T, iter RowIter) []Row {
+	t.Helper()
+	var out []Row
+	for {
+		row, ok, err := iter.Next(context.Background())
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if !ok {
+			return out
+		}
+		out = append(out, row)
+	}
+}

--- a/skills/getting-started.md
+++ b/skills/getting-started.md
@@ -91,8 +91,8 @@ JSON tags are verified against `types.Request`: `cohort`, `filterers`, `groups`,
 
 ```
 pulse [--json]                                               # manifest at root
-pulse api process    --request FILE [--json]
-pulse api compose    --request FILE [--json]
+pulse api process    --request FILE [--json] [--stream]
+pulse api compose    --request FILE [--json] [--stream] [--parallel N] [--no-fail-fast]
 pulse api sample     --input FILE [--count N] [--json]
 pulse api facet      --input FILE --field NAME [--json]
 pulse api predict    --request FILE [--json] [--strict]
@@ -116,6 +116,18 @@ pulse mcp          [--data-dir DIR]   # serve Model Context Protocol over stdio
 ## Pipeline order
 
 Load -> Filter -> Group -> Aggregate -> Attributes -> Output.
+</reference>
+
+<reference>
+## Streaming and parallel batches
+
+`pulse api process --stream` emits result rows as NDJSON, one row per line, instead of buffering the full response. Useful for grouped queries with many output rows piped into downstream tooling.
+
+`pulse api compose --parallel N` runs requests concurrently across a bounded worker pool. `N=0` resolves to GOMAXPROCS, `N=1` is sequential (default), `N>1` parallelizes. Responses always preserve input order. Add `--no-fail-fast` to aggregate every error instead of cancelling siblings on the first failure.
+
+`pulse api compose --stream` emits one NDJSON line per row, prefixed with `{"index":N,"row":{...}}` so downstream consumers can route rows to the right request.
+
+Streaming-eligible requests can be detected up front via `pulse api predict`: the `streamable` field reports whether ProcessStream avoids buffering inside the engine, and `streamable_reasons` lists every gate that forced buffering (groups, attributes, windows, decimal fields, geo aggregations, non-online aggregators).
 </reference>
 
 <reference>

--- a/skills/getting-started.md
+++ b/skills/getting-started.md
@@ -127,7 +127,9 @@ Load -> Filter -> Group -> Aggregate -> Attributes -> Output.
 
 `pulse api compose --stream` emits one NDJSON line per row, prefixed with `{"index":N,"row":{...}}` so downstream consumers can route rows to the right request.
 
-Streaming-eligible requests can be detected up front via `pulse api predict`: the `streamable` field reports whether ProcessStream avoids buffering inside the engine, and `streamable_reasons` lists every gate that forced buffering (groups, attributes, windows, decimal fields, geo aggregations, non-online aggregators).
+Streaming-eligible requests can be detected up front via `pulse api predict`: the `streamable` field reports whether ProcessStream avoids buffering inside the engine, and `streamable_reasons` lists every gate that forced buffering (non-streamable groupers like QUANTILE/DATE, population-stat attributes, windows, decimal fields, geo aggregations, non-online aggregators).
+
+Streams today: no-group online aggregations; grouped requests when every grouper is CATEGORY/RANGE/ROUNDED/H3_CELL with online aggregators; row-local attributes ATTR_FORMULA / ATTR_DATE_PART. Forced buffered: median/percentile, ZScore, GROUP_QUANTILE/GROUP_DATE, windows, decimal-typed aggregations, geo aggregations, ATTR_ZSCORE/TSCORE/NORMALIZED/PERCENTILE.
 </reference>
 
 <reference>

--- a/skills/getting-started.md
+++ b/skills/getting-started.md
@@ -129,7 +129,7 @@ Load -> Filter -> Group -> Aggregate -> Attributes -> Output.
 
 Streaming-eligible requests can be detected up front via `pulse api predict`: the `streamable` field reports whether ProcessStream avoids buffering inside the engine, and `streamable_reasons` lists every gate that forced buffering (non-streamable groupers like QUANTILE/DATE, population-stat attributes, windows, decimal fields, geo aggregations, non-online aggregators).
 
-Streams today: no-group online aggregations; grouped requests when every grouper is CATEGORY/RANGE/ROUNDED/H3_CELL with online aggregators; row-local attributes ATTR_FORMULA / ATTR_DATE_PART. Forced buffered: median/percentile, ZScore, GROUP_QUANTILE/GROUP_DATE, windows, decimal-typed aggregations, geo aggregations, ATTR_ZSCORE/TSCORE/NORMALIZED/PERCENTILE.
+Streams today: no-group online aggregations; grouped requests when every grouper is CATEGORY/RANGE/ROUNDED/H3_CELL with online aggregators; row-local attributes ATTR_FORMULA / ATTR_DATE_PART; two-pass attributes ATTR_ZSCORE / ATTR_TSCORE / ATTR_NORMALIZED (Welford pass 1 for population stats, per-row emit in pass 2). Forced buffered: median/percentile/ZScore aggregators, ATTR_PERCENTILE, GROUP_QUANTILE/GROUP_DATE, windows, decimal-typed aggregations, geo aggregations, two-pass attribute combined with features or groups.
 </reference>
 
 <reference>

--- a/types/streamability.go
+++ b/types/streamability.go
@@ -1,0 +1,92 @@
+package types
+
+// Streamable reports whether this aggregation type supports the single-pass
+// streaming execution path. Streamable aggregators implement
+// processing.OnlineAggregator (UpdateRow + Finalize) and produce a result
+// with O(1) or O(unique) state per row.
+//
+// Source of truth for predict.Streamable; cross-checked at test time against
+// the processing registry by TestRegistryStreamabilityMatchesTypes.
+//
+// Default branch returns false so newly-added aggregator types must opt in
+// explicitly.
+func (t AggregationType) Streamable() bool {
+	switch t {
+	case AGG_COUNT, AGG_SUM, AGG_AVERAGE, AGG_MIN, AGG_MAX,
+		AGG_STDDEV, AGG_VARIANCE, AGG_RANGE,
+		AGG_FREQUENCY, AGG_MODE,
+		AGG_SKEWNESS, AGG_KURTOSIS,
+		AGG_DISTINCT_COUNT:
+		return true
+	case AGG_MEDIAN, AGG_PERCENTILE, AGG_ZSCORE,
+		AGG_GEO_CENTROID, AGG_GEO_BBOX:
+		return false
+	}
+	return false
+}
+
+// Streamable reports whether this attribute type can be computed in a
+// single pass. Every attribute today is buffered (population stats need a
+// first pass); the method exists so future row-local attributes can opt in
+// without changing the shape of the streamability check.
+func (t AttributeType) Streamable() bool {
+	switch t {
+	case ATTR_ZSCORE, ATTR_TSCORE, ATTR_NORMALIZED,
+		ATTR_FORMULA, ATTR_PERCENTILE, ATTR_DATE_PART:
+		return false
+	}
+	return false
+}
+
+// Streamable reports whether this filterer type evaluates per-row without
+// looking at other rows. All registered filterers are row-local today.
+func (t FiltererType) Streamable() bool {
+	switch t {
+	case FILTER_INCLUDE, FILTER_EXCLUDE, FILTER_RANGE,
+		FILTER_EXPRESSION,
+		FILTER_GEO_WITHIN, FILTER_GEO_WITHIN_RADIUS_M:
+		return true
+	}
+	return false
+}
+
+// Streamable reports whether this group type can emit groups before the
+// input is exhausted. CATEGORY/ROUNDED/RANGE/H3_CELL bucket per row;
+// QUANTILE/DATE require finalize-time work over the full set.
+//
+// The streaming Process path does not currently emit grouped output even
+// for streamable groupers — Request.Streamable returns false whenever
+// groups are present. The method is wired through so a future grouped
+// streaming iterator can flip the gate without re-deriving the rule.
+func (t GroupType) Streamable() bool {
+	switch t {
+	case GROUP_CATEGORY, GROUP_ROUNDED, GROUP_RANGE, GROUP_H3_CELL:
+		return true
+	case GROUP_QUANTILE, GROUP_DATE:
+		return false
+	}
+	return false
+}
+
+// Streamable reports whether this window type can be computed without
+// buffering. All window operators run over the post-aggregate row set in
+// a final pass; none stream today.
+func (t WindowType) Streamable() bool {
+	return false
+}
+
+// Streamable reports whether this feature type can run in the
+// pre-pass+finalize+emit streaming pipeline (feature.StreamingComputer).
+//
+// Source of truth is feature.IsStreamable(req.Features, schema) at runtime;
+// this method mirrors the per-type capability used by predict.
+func (t FeatureType) Streamable() bool {
+	switch t {
+	case FEAT_LOG, FEAT_SQRT, FEAT_BUCKETIZE,
+		FEAT_ONE_HOT, FEAT_DATE_FEATURES,
+		FEAT_FREQUENCY_ENCODE, FEAT_TARGET_ENCODE,
+		FEAT_TRAIN_TEST_SPLIT:
+		return true
+	}
+	return false
+}

--- a/types/streamability.go
+++ b/types/streamability.go
@@ -26,15 +26,24 @@ func (t AggregationType) Streamable() bool {
 }
 
 // Streamable reports whether this attribute type can be computed in a
-// single pass. Row-local attributes (FORMULA, DATE_PART) implement
-// processing.RowLocalAttribute and execute inline against each record.
-// Population-stat attributes (ZSCORE, TSCORE, NORMALIZED, PERCENTILE)
-// need a first pass to derive global stats and remain buffered.
+// streaming path. Three tiers exist at runtime:
+//
+//   - Row-local: FORMULA, DATE_PART implement processing.RowLocalAttribute
+//     and execute inline with no PrePass.
+//   - Two-pass: ZSCORE, TSCORE, NORMALIZED implement
+//     processing.TwoPassAttribute and need a PrePass over filter-passing
+//     records, Finalize, then per-row Row() in pass 2 (iter.Reset()).
+//   - Buffered-only: PERCENTILE needs a sorted view of every value;
+//     no streaming algorithm preserves exact rank semantics.
+//
+// Streamable() returns true for the first two tiers since both routes
+// avoid materializing the full record set in memory.
 func (t AttributeType) Streamable() bool {
 	switch t {
-	case ATTR_FORMULA, ATTR_DATE_PART:
+	case ATTR_FORMULA, ATTR_DATE_PART,
+		ATTR_ZSCORE, ATTR_TSCORE, ATTR_NORMALIZED:
 		return true
-	case ATTR_ZSCORE, ATTR_TSCORE, ATTR_NORMALIZED, ATTR_PERCENTILE:
+	case ATTR_PERCENTILE:
 		return false
 	}
 	return false

--- a/types/streamability.go
+++ b/types/streamability.go
@@ -26,13 +26,15 @@ func (t AggregationType) Streamable() bool {
 }
 
 // Streamable reports whether this attribute type can be computed in a
-// single pass. Every attribute today is buffered (population stats need a
-// first pass); the method exists so future row-local attributes can opt in
-// without changing the shape of the streamability check.
+// single pass. Row-local attributes (FORMULA, DATE_PART) implement
+// processing.RowLocalAttribute and execute inline against each record.
+// Population-stat attributes (ZSCORE, TSCORE, NORMALIZED, PERCENTILE)
+// need a first pass to derive global stats and remain buffered.
 func (t AttributeType) Streamable() bool {
 	switch t {
-	case ATTR_ZSCORE, ATTR_TSCORE, ATTR_NORMALIZED,
-		ATTR_FORMULA, ATTR_PERCENTILE, ATTR_DATE_PART:
+	case ATTR_FORMULA, ATTR_DATE_PART:
+		return true
+	case ATTR_ZSCORE, ATTR_TSCORE, ATTR_NORMALIZED, ATTR_PERCENTILE:
 		return false
 	}
 	return false

--- a/types/streamability_test.go
+++ b/types/streamability_test.go
@@ -42,9 +42,9 @@ func TestStreamability_AggregationsKnown(t *testing.T) {
 
 func TestStreamability_AttributesKnown(t *testing.T) {
 	expected := map[AttributeType]bool{
-		ATTR_ZSCORE:     false,
-		ATTR_TSCORE:     false,
-		ATTR_NORMALIZED: false,
+		ATTR_ZSCORE:     true,
+		ATTR_TSCORE:     true,
+		ATTR_NORMALIZED: true,
 		ATTR_FORMULA:    true,
 		ATTR_PERCENTILE: false,
 		ATTR_DATE_PART:  true,

--- a/types/streamability_test.go
+++ b/types/streamability_test.go
@@ -45,9 +45,9 @@ func TestStreamability_AttributesKnown(t *testing.T) {
 		ATTR_ZSCORE:     false,
 		ATTR_TSCORE:     false,
 		ATTR_NORMALIZED: false,
-		ATTR_FORMULA:    false,
+		ATTR_FORMULA:    true,
 		ATTR_PERCENTILE: false,
-		ATTR_DATE_PART:  false,
+		ATTR_DATE_PART:  true,
 	}
 	for _, a := range AllAttributeTypes() {
 		want, ok := expected[a]

--- a/types/streamability_test.go
+++ b/types/streamability_test.go
@@ -1,0 +1,143 @@
+package types
+
+import "testing"
+
+// TestStreamability_AggregationsKnown asserts every aggregation type returns
+// the documented streamability value. Adding a new aggregation requires
+// extending the switch in streamability.go AND this table.
+func TestStreamability_AggregationsKnown(t *testing.T) {
+	expected := map[AggregationType]bool{
+		AGG_COUNT:          true,
+		AGG_SUM:            true,
+		AGG_AVERAGE:        true,
+		AGG_MIN:            true,
+		AGG_MAX:            true,
+		AGG_STDDEV:         true,
+		AGG_VARIANCE:       true,
+		AGG_RANGE:          true,
+		AGG_FREQUENCY:      true,
+		AGG_MODE:           true,
+		AGG_SKEWNESS:       true,
+		AGG_KURTOSIS:       true,
+		AGG_DISTINCT_COUNT: true,
+		AGG_MEDIAN:         false,
+		AGG_PERCENTILE:     false,
+		AGG_ZSCORE:         false,
+		AGG_GEO_CENTROID:   false,
+		AGG_GEO_BBOX:       false,
+	}
+	for _, agg := range AllAggregationTypes() {
+		want, ok := expected[agg]
+		if !ok {
+			t.Fatalf("aggregation %s missing from streamability table — declare it in types/streamability.go and add an entry here", agg)
+		}
+		if got := agg.Streamable(); got != want {
+			t.Errorf("%s.Streamable() = %v, want %v", agg, got, want)
+		}
+	}
+	if len(expected) != len(AllAggregationTypes()) {
+		t.Fatalf("streamability table size mismatch: %d entries, %d types", len(expected), len(AllAggregationTypes()))
+	}
+}
+
+func TestStreamability_AttributesKnown(t *testing.T) {
+	expected := map[AttributeType]bool{
+		ATTR_ZSCORE:     false,
+		ATTR_TSCORE:     false,
+		ATTR_NORMALIZED: false,
+		ATTR_FORMULA:    false,
+		ATTR_PERCENTILE: false,
+		ATTR_DATE_PART:  false,
+	}
+	for _, a := range AllAttributeTypes() {
+		want, ok := expected[a]
+		if !ok {
+			t.Fatalf("attribute %s missing from streamability table", a)
+		}
+		if got := a.Streamable(); got != want {
+			t.Errorf("%s.Streamable() = %v, want %v", a, got, want)
+		}
+	}
+	if len(expected) != len(AllAttributeTypes()) {
+		t.Fatalf("attribute streamability table size mismatch: %d entries, %d types", len(expected), len(AllAttributeTypes()))
+	}
+}
+
+func TestStreamability_FilterersKnown(t *testing.T) {
+	expected := map[FiltererType]bool{
+		FILTER_INCLUDE:             true,
+		FILTER_EXCLUDE:             true,
+		FILTER_RANGE:               true,
+		FILTER_EXPRESSION:          true,
+		FILTER_GEO_WITHIN:          true,
+		FILTER_GEO_WITHIN_RADIUS_M: true,
+	}
+	for _, f := range AllFiltererTypes() {
+		want, ok := expected[f]
+		if !ok {
+			t.Fatalf("filterer %s missing from streamability table", f)
+		}
+		if got := f.Streamable(); got != want {
+			t.Errorf("%s.Streamable() = %v, want %v", f, got, want)
+		}
+	}
+	if len(expected) != len(AllFiltererTypes()) {
+		t.Fatalf("filterer streamability table size mismatch: %d entries, %d types", len(expected), len(AllFiltererTypes()))
+	}
+}
+
+func TestStreamability_GroupsKnown(t *testing.T) {
+	expected := map[GroupType]bool{
+		GROUP_CATEGORY: true,
+		GROUP_ROUNDED:  true,
+		GROUP_RANGE:    true,
+		GROUP_H3_CELL:  true,
+		GROUP_QUANTILE: false,
+		GROUP_DATE:     false,
+	}
+	for _, g := range AllGroupTypes() {
+		want, ok := expected[g]
+		if !ok {
+			t.Fatalf("grouper %s missing from streamability table", g)
+		}
+		if got := g.Streamable(); got != want {
+			t.Errorf("%s.Streamable() = %v, want %v", g, got, want)
+		}
+	}
+	if len(expected) != len(AllGroupTypes()) {
+		t.Fatalf("grouper streamability table size mismatch: %d entries, %d types", len(expected), len(AllGroupTypes()))
+	}
+}
+
+func TestStreamability_WindowsKnown(t *testing.T) {
+	for _, w := range AllWindowTypes() {
+		if w.Streamable() {
+			t.Errorf("%s.Streamable() = true, want false (no window operator streams today)", w)
+		}
+	}
+}
+
+func TestStreamability_FeaturesKnown(t *testing.T) {
+	expected := map[FeatureType]bool{
+		FEAT_LOG:              true,
+		FEAT_SQRT:             true,
+		FEAT_BUCKETIZE:        true,
+		FEAT_ONE_HOT:          true,
+		FEAT_DATE_FEATURES:    true,
+		FEAT_FREQUENCY_ENCODE: true,
+		FEAT_TARGET_ENCODE:    true,
+		FEAT_TRAIN_TEST_SPLIT: true,
+	}
+	for _, f := range AllFeatureTypes() {
+		want, ok := expected[f]
+		if !ok {
+			t.Fatalf("feature %s missing from streamability table", f)
+		}
+		if got := f.Streamable(); got != want {
+			t.Errorf("%s.Streamable() = %v, want %v", f, got, want)
+		}
+	}
+	if len(expected) != len(AllFeatureTypes()) {
+		t.Fatalf("feature streamability table size mismatch: %d entries, %d types", len(expected), len(AllFeatureTypes()))
+	}
+}


### PR DESCRIPTION
## Summary

Ships [improvement-01](.planning/improvement-01-streaming-parallel-compose/idea.md) — the parallel compose + streaming iterator pair — as one PR so they share types, the streamability contract, and the registry audit.

- **`pulse.ComposeParallel(ctx, req, opts)`** — bounded worker pool, slot-by-index order preservation, `FailFast` default true.
- **`pulse.ProcessStream(ctx, req)`** → `RowIter` — pull-based iterator over result rows; today wraps `Process` and walks materialized `Data`, signature is forward-compatible with true incremental emission.
- **Streamability contract** — `Streamable() bool` on every operator type lives in `types/streamability.go` (predict reads from there; structural ban on importing `processing/` preserved). Predict gains `Streamable bool` + `StreamableReasons []string`. `processing.CanStreamRequest` exported as the runtime parity hook.
- **CLI** — `process --stream`, `compose --stream`, `compose --parallel N`, `compose --no-fail-fast`.
- **Audit** — every factory in `processing/registry.go` returns a fresh stateful instance; no shared mutable state outside `sync.Pool`. Registry is parallel-safe today; new test `TestComposeParallel_FreshOperatorsPerRequest` runs 32×3 ops under `-race` to catch future regressions.

### New CI gates

- `TestRegistryStreamabilityMatchesTypes` — runtime `OnlineAggregator` parity with `types.AggregationType.Streamable()`
- `TestPredict_Streamable_MatchesRuntime` — predict ↔ `processing.CanStreamRequest` parity matrix
- `TestStreamability_*Known` (×6) — exhaustiveness gates per operator category
- `TestCanStreamRequest_RegressionMatrix` — runtime gate matrix

## Test plan

- [x] `go test ./... -race` passes (full suite incl. existing goldens regenerated for new `streamable` field)
- [x] `go vet ./...` clean
- [x] CLI smoke: `api process --stream`, `api compose --stream`, `api compose --parallel 2` end-to-end
- [x] Concurrency smoke: `TestComposeParallel_FreshOperatorsPerRequest` under `-race` clean (no shared-state drift)
- [x] Predict envelope golden updated; `TestClaudeMdMentionsFormatVersion` still passes (additive — `1.0` unchanged)
- [x] Update Demand table extended with the new streamability row; documented in CLAUDE.md
- [x] `skills/getting-started.md` lists new flags + streamability reading guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)