### PR TITLE
docs: refresh README and expand MCP guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pulse
 
-High-performance, self-describing tabular data processing engine written in Go. Ships as a CLI binary and an embeddable Go library.
+High-performance, self-describing tabular data processing engine written in Go. Ships as a Go library (`github.com/frankbardon/pulse`) and a CLI binary (`cmd/pulse/`). Library is primary; CLI is a thin adapter.
 
-Pulse reads and writes `.pulse` files — a compact binary format with an inline schema, categorical dictionaries, and per-field descriptions. Import from CSV, TSV, NDJSON, Parquet, or Excel; run aggregations, filters, and groupings; export results back to any supported format.
+Pulse reads and writes `.pulse` files — a compact binary format with an inline schema, categorical dictionaries, and per-field descriptions. Import from CSV, TSV, NDJSON, JSON array, Parquet, Apache Arrow IPC, or Excel; run aggregations, filters, groupers, windows, features, statistical tests, and regressions; export back to any supported format.
 
-Designed for LLM-native workflows: every command supports `--json`, a bundled skill pack teaches agents how to operate Pulse, and `api predict` validates requests before execution.
+LLM-native by design: every command supports `--json`, every operator declares its accepted types and streamability in the manifest, an embedded skill pack teaches agents how to operate Pulse, an embedded request-example library gives them runnable templates, and `pulse mcp` serves the full surface over Model Context Protocol.
 
 ## Installation
 
@@ -33,14 +33,13 @@ Requires Go 1.22+.
 pulse import csv --input data.csv --output data.pulse
 ```
 
-Schema is inferred automatically (up to 500 rows sampled). To supply an explicit schema:
+Schema is inferred from a sample of rows (default 500). To supply an explicit schema:
 
 ```bash
 # Generate a schema template from your data
 pulse import schema-template data.csv > schema.json
 
-# Edit schema.json — add descriptions, adjust types
-# Then import with the schema
+# Edit schema.json — adjust types, add descriptions
 pulse import csv --input data.csv --schema schema.json --output data.pulse
 ```
 
@@ -50,7 +49,7 @@ pulse import csv --input data.csv --schema schema.json --output data.pulse
 pulse cohort inspect data.pulse --json
 ```
 
-Returns field names, types, byte offsets, descriptions, and categorical dictionaries.
+Returns field names, types, byte offsets, descriptions, and categorical dictionaries (truncated by default; pass `--full-dict` for the full mapping).
 
 ### Run an aggregation
 
@@ -89,71 +88,204 @@ pulse api process --request request.json --json
 }
 ```
 
+### Smart defaults
+
+If you name a field but omit `type`, Pulse fills in a sensible operator from the schema type — `AGG_SUM` for numerics, `AGG_FREQUENCY` for categoricals, `GROUP_RANGE` (interval 10) for numerics, `GROUP_CATEGORY` for categoricals, `GROUP_DATE` ("day") for dates, `GROUP_H3_CELL` (resolution 7) for geo. Disable with `--no-defaults` or `pulse.Options{DisableDefaults: true}`. The full rule table lives in `descriptor/defaults.go`.
+
 ### Validate before executing
 
 ```bash
 pulse api predict --request request.json --json
 ```
 
-Returns the proposed schema, warnings (e.g., numeric aggregation on a categorical field), and estimated row count without touching the data.
+Returns the proposed schema, applied defaults, streamability, warnings (e.g., numeric aggregation on a categorical field), and structural errors without touching record data. Pass `--strict` to treat warnings as errors.
 
-### Export back to tabular
+### Streaming
+
+For requests Pulse can stream (single-pass aggregations on non-decimal/non-geo fields, no buffered ops), use `--stream` to get NDJSON one row per line:
+
+```bash
+pulse api process --request request.json --stream
+pulse api compose --request batch.json --stream
+```
+
+Library equivalent: `pulse.ProcessStream(ctx, req)` returns a `RowIter`.
+
+### Parallel compose
+
+```bash
+pulse api compose --request batch.json --parallel 4 --json
+```
+
+Library equivalent: `pulse.ComposeParallel(ctx, req, pulse.ComposeOptions{MaxWorkers: 4})`. Order-preserving by slot; `--no-fail-fast` aggregates errors instead of cancelling on first failure.
+
+### Natural-language ask
+
+> **Beta — do not trust yet.** The natural-language query path (`pulse api ask --query`, `pulse_ask` with `query`) is experimental. Parsing is heuristic, coverage is partial, and silent misinterpretation is possible. Inspect the resolved request before relying on the result, and prefer a structured `request` for production workloads.
+
+```bash
+pulse api ask --file data.pulse --query "average revenue by region, top 5"
+```
+
+Parses the query against the schema, validates, and executes — one round trip. Pass `--predict` to validate without executing, `--on-invalid suggest` to get structured fixup hints instead of an error.
+
+### Export and convert
 
 ```bash
 pulse export csv --input data.pulse --output results.csv
 pulse export parquet --input data.pulse --output results.parquet
-```
 
-### Convert between formats directly
-
-```bash
 pulse convert data.csv data.parquet
 pulse convert data.xlsx output.tsv --schema schema.json
 ```
 
-Format is auto-detected from file extensions. No intermediate `.pulse` file is written unless `--keep-pulse=path` is specified.
+Format auto-detected from extensions. `convert` does not write an intermediate `.pulse` unless `--keep-pulse=path`.
 
-### Sample rows
+### Sample rows / facet a field
 
 ```bash
 pulse api sample --input data.pulse --count 10
-```
-
-### Get distinct values for a field
-
-```bash
 pulse api facet --input data.pulse --field brand
 ```
+
+### Synthetic data
+
+Generate a deterministic synthetic cohort from a schema spec or from a previously-captured profile:
+
+```bash
+pulse synth from-schema --spec spec.json --output synth.pulse --seed 42
+pulse profile create --input real.pulse --output profile.json --include-correlations
+pulse synth from-profile --profile profile.json --output synth.pulse --rows 100000 --seed 42
+```
+
+12 distributions (`normal`, `lognormal`, `poisson`, `exponential`, `pareto`, `bernoulli`, `weighted_categorical`, `regex`, `uniform`, `uniform_date`, `monotonic_from`, `constant`), pairwise correlations, value constraints. See the `synthetic-data` skill.
 
 ## CLI Reference
 
 ```
 pulse
-├── --json                          Root manifest (self-description)
+├── --json [--slim]                       Root manifest (self-description)
 ├── import
-│   ├── csv|tsv|ndjson|parquet|excel  --input FILE --output FILE [--schema FILE]
-│   ├── predict                       --input FILE [--schema FILE] --json
-│   └── schema-template INPUT         Generate editable schema from source
+│   ├── csv|tsv|ndjson|jsonarray|         --input FILE --output FILE [--schema FILE]
+│   │   parquet|arrow|excel
+│   ├── auto SOURCE                       Managed import (auto-detect format)
+│   ├── list                              List managed import handles
+│   ├── drop HANDLE                       Drop a managed handle
+│   ├── predict                           --input FILE [--schema FILE] --json
+│   └── schema-template INPUT             Generate editable schema from source
 ├── export
-│   ├── csv|tsv|ndjson|parquet|excel  --input FILE --output FILE
-│   └── predict                       --input FILE --format FORMAT --json
-├── convert INPUT OUTPUT [--schema FILE] [--keep-pulse PATH]
+│   ├── csv|tsv|ndjson|jsonarray|         --input FILE --output FILE
+│   │   parquet|arrow|excel
+│   └── predict                           --input FILE --format FORMAT --json
+├── convert INPUT OUTPUT [--from F] [--to F] [--schema FILE] [--keep-pulse PATH]
 │   └── predict INPUT OUTPUT --json
 ├── cohort
 │   ├── inspect PATH [--json] [--full-dict]
 │   └── filter --input FILE --output FILE --filter EXPR
 ├── api
-│   ├── process --request FILE [--json]
-│   ├── compose --request FILE [--json]
+│   ├── process --request FILE [--json] [--stream] [--no-defaults]
+│   ├── compose --request FILE [--json] [--stream] [--parallel N] [--no-fail-fast]
 │   ├── sample --input FILE --count N
 │   ├── facet --input FILE --field NAME
-│   └── predict --request FILE --json [--strict]
-└── skills
-    ├── list [--json]
-    └── show NAME
+│   ├── predict --request FILE --json [--strict]
+│   └── ask [--file F] [--query Q] [--request FILE] [--predict] [--on-invalid suggest]
+├── synth
+│   ├── from-schema --spec FILE --output FILE [--rows N] [--seed N]
+│   └── from-profile --profile FILE --output FILE --rows N [--seed N]
+├── profile
+│   └── create --input FILE --output FILE [--top-k N] [--include-correlations]
+├── skills
+│   ├── list [--json]
+│   └── show NAME
+├── examples
+│   ├── search [--query Q] [--tag T ...] [--category C] [--json]
+│   └── show NAME [--json]
+├── errors
+│   ├── lookup CODE [--json]
+│   └── list [--domain D] [--query Q] [--json]
+└── mcp [--data-dir DIR] [--bind-on-open]   Serve MCP over stdio
 ```
 
-Every leaf command supports `--json` for structured output wrapped in an envelope with `format_version`, `data`, `errors`, and `warnings`.
+Every leaf supports `--json` for output wrapped in a `descriptor.Envelope` with `format_version: "1.0"`, `data`, `errors`, and `warnings`.
+
+## MCP Usage
+
+Pulse ships an MCP (Model Context Protocol) server that exposes the full library surface to AI clients (Claude Desktop, Claude Code, Cursor, any MCP-aware host). One binary, one command:
+
+```bash
+pulse mcp --data-dir /path/to/data
+```
+
+`PULSE_DATA_DIR` is honored if `--data-dir` is omitted. The server speaks JSON-RPC over stdio (logs to stderr).
+
+### Wiring into a host
+
+For Claude Desktop, add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "pulse": {
+      "command": "pulse",
+      "args": ["mcp"],
+      "env": {
+        "PULSE_DATA_DIR": "/Users/me/data"
+      }
+    }
+  }
+}
+```
+
+For Claude Code:
+
+```bash
+claude mcp add pulse --env PULSE_DATA_DIR=/Users/me/data -- pulse mcp
+```
+
+Restart the host. Pulse tools appear in the tool list.
+
+### Tool surface
+
+| Tool | Purpose |
+|---|---|
+| `pulse_manifest` | **Call first.** Self-description: commands, operators, accepted types, tests, regressions, distributions, error codes, MCP tools, cohort field types. Cache once per session. |
+| `pulse_ask` | **Preferred entry point.** One-shot import → inspect → predict → execute. Accepts `source` (raw file) + `query` (natural language, **beta — see below**) or a structured `request`. |
+| `pulse_inspect` | Read header + schema (no record bytes). Also binds session-scoped field-name enums on action tools. |
+| `pulse_predict` | Validate a request against the schema without executing. |
+| `pulse_process` | Execute one pre-built request. |
+| `pulse_compose` | Execute a batch of requests in one round trip. |
+| `pulse_sample` | Return up to N rows for preview. |
+| `pulse_facet` | Distinct values for a single field. |
+| `pulse_import` | Import a tabular source into a managed `.pulse` handle (TTL-tracked, default 7d). |
+| `pulse_drop` | Drop a managed handle. |
+| `pulse_imports_list` | Enumerate managed handles with sidecar metadata. |
+| `pulse_examples_search` | Search the embedded request-example library by query, tags, category. |
+| `pulse_examples_get` | Fetch one runnable example by name. |
+| `pulse_errors_lookup` | Per-code Message + Fixup detail (kept out of the manifest for context economy). |
+| `pulse_skills_list` / `pulse_skills_get` | Embedded skill pack. |
+
+### Resources and prompts
+
+| URI | What |
+|---|---|
+| `pulse://<path>` | One per `.pulse` file under the data directory. Read returns `descriptor.InspectResult` JSON. |
+| `pulse-skill://<name>` | One per embedded skill. Read returns the markdown body. |
+
+Two prompts (`pulse-bootstrap`, `pulse-author-request`) are registered for hosts that surface them as slash commands.
+
+### Recommended session flow
+
+1. `pulse_manifest` once. Cache the result.
+2. `pulse_ask` with `source` + `query` (or `cohort` + `query`) for everything else.
+3. Reach for `pulse_predict` / `pulse_sample` / `pulse_facet` / `pulse_compose` only when you need finer control than the one-shot affords.
+
+> **Natural-language `query` is beta.** Heuristic parsing only — silent misinterpretation is possible. Always check `query_resolution` and the resolved `request` in the response before trusting results. For production, author a structured `request` against the cached manifest and skip the `query` field.
+
+### Schema-bound enums
+
+After a successful `pulse_inspect` (or after `pulse_ask` opens a cohort), the server registers session-scoped variants of the action tools whose JSON Schemas embed enums on field-name parameters — picked from a typed list rather than free-texted. Works on SSE / Streamable HTTP transports; on stdio the session does not support tool overrides, so enums are advisory and `pulse_predict` remains the validation gate. Disable with `--bind-on-open=false`.
+
+The `mcp-integration` skill (`pulse skills show mcp-integration`) is the authoritative reference.
 
 ## Embedding Pulse in a Go Application
 
@@ -176,7 +308,6 @@ import (
 func main() {
     ctx := context.Background()
 
-    // Create a Pulse instance.
     p, err := pulse.New(pulse.Options{DataDir: "/var/data"})
     if err != nil {
         log.Fatal(err)
@@ -212,7 +343,7 @@ func main() {
     }
     fmt.Printf("Fields: %d\n", result.FieldCount)
 
-    // Validate a request before execution.
+    // Validate before execution.
     prediction, err := p.Predict(ctx, &pulse.Request{
         Cohort: &types.Cohort{Filename: "dataset.pulse"},
         Aggregations: []*types.Aggregation{
@@ -226,6 +357,10 @@ func main() {
 }
 ```
 
+### Public facade
+
+`pulse.Pulse` exposes: `New`, `Open`, `Process`, `ProcessStream`, `Compose`, `ComposeParallel`, `Ask`, `Import`, `ImportFile`, `Drop`, `Imports`, `SweepImports`, `ResolveImport`, `Export`, `Convert`, `Inspect`, `Predict`, `Sample`, `Facet`, `Synth`, `Profile`, `Manifest`, plus example/error lookup helpers.
+
 ### Custom filesystem
 
 Pulse accepts any `afero.Fs` for testing or non-local backends:
@@ -237,47 +372,33 @@ import "github.com/spf13/afero"
 p, _ := pulse.New(pulse.Options{
     FS: afero.NewMemMapFs(),
 })
-
-// Or a custom S3-backed filesystem
-p, _ := pulse.New(pulse.Options{
-    FS: myS3Fs,
-})
 ```
 
-### Available types
+`fs.NewMemMap()` returns a complete in-memory `Config` for hermetic tests — no disk I/O.
 
-```go
-import "github.com/frankbardon/pulse/types"
+### Operator catalogue
 
-// Aggregations: AGG_COUNT, AGG_SUM, AGG_AVERAGE, AGG_MIN, AGG_MAX,
-//               AGG_STDDEV, AGG_RANGE, AGG_FREQUENCY, AGG_ZSCORE
+Counts as currently registered (the manifest is the source of truth — `pulse --json --slim`):
 
-// Filters: FILTER_INCLUDE, FILTER_EXCLUDE, FILTER_RANGE, FILTER_EXPRESSION
-
-// Groups: GROUP_CATEGORY, GROUP_ROUNDED
-
-// Attributes: ATTR_ZSCORE, ATTR_TSCORE, ATTR_NORMALIZED,
-//             ATTR_FORMULA, ATTR_PERCENTILE, ATTR_DATE_PART
-
-// Windows: WIN_LAG, WIN_LEAD, WIN_ROW_NUMBER, WIN_RANK, WIN_DENSE_RANK,
-//          WIN_RUNNING_SUM, WIN_RUNNING_AVG, WIN_MOVING_AVG,
-//          WIN_EWMA, WIN_PCT_CHANGE
-```
+- **18 aggregators** (`AGG_*`): COUNT, SUM, AVERAGE, MIN, MAX, MEDIAN, STDDEV, RANGE, FREQUENCY, MODE, PERCENTILE, ZSCORE, KURTOSIS, GEO_CENTROID, GEO_BBOX, …
+- **9 attributes** (`ATTR_*`): ZSCORE, TSCORE, NORMALIZED, FORMULA, PERCENTILE, DATE_PART, …
+- **6 filterers** (`FILTER_*`): INCLUDE, EXCLUDE, RANGE, EXPRESSION, GEO_WITHIN, GEO_WITHIN_RADIUS_M
+- **6 groupers** (`GROUP_*`): CATEGORY, RANGE, ROUNDED, DATE, QUANTILE, H3_CELL
+- **10 windows** (`WIN_*`): LAG, LEAD, ROW_NUMBER, RANK, DENSE_RANK, RUNNING_SUM, RUNNING_AVG, MOVING_AVG, EWMA, PCT_CHANGE
+- **9 features** (`FEAT_*`): LOG, SQRT, BUCKETIZE, ONE_HOT, FREQUENCY_ENCODE, TARGET_ENCODE, DATE_FEATURES, TRAIN_TEST_SPLIT, POLY
+- **20 statistical tests** (`TEST_*`): tier-1 row tests (T, WELCH, CHISQ, ANOVA_F, ANOVA_WELCH, ANOVA_RM, KS, PAIRED_T, PROP_Z, PEARSON_R, SPEARMAN_R, KENDALL_TAU, MANN_WHITNEY_U, WILCOXON_SR, KRUSKAL_WALLIS, BROWN_FORSYTHE, FISHER_EXACT, SHAPIRO_WILK) and tier-2 post-tests (TUKEY_HSD, TREND, variants)
+- **3 regressions** (`REG_*`): OLS, GLM, BAYES_LINEAR — with `Resample` / `Selection` modifiers and `FEAT_POLY` composition cover 13 textbook regression names
+- **12 synth distributions**
 
 ## LLM Skill Pack
 
-Pulse bundles 12 skill documents that teach LLM agents how to operate it. Skills are embedded in the binary via `//go:embed` — no external files needed.
+Pulse bundles 21 skill documents that teach LLM agents how to operate it. Skills are embedded via `//go:embed` — no external files.
 
 ### Discovering skills
 
 ```bash
-# List all bundled skills
 pulse skills list
-
-# List with metadata (for programmatic consumption)
 pulse skills list --json
-
-# Read a specific skill
 pulse skills show aggregation-guide
 ```
 
@@ -285,80 +406,99 @@ pulse skills show aggregation-guide
 
 | Skill | Purpose |
 |---|---|
-| `getting-started` | Pulse vocabulary, file format, CLI overview |
-| `cohort-schema-design` | Field types, nullability, descriptions |
-| `aggregation-guide` | When and how to use each aggregator |
-| `attribute-composition` | Derived attributes: z-score, formula, etc. |
-| `grouper-design` | GROUP_CATEGORY vs GROUP_ROUNDED |
-| `compose-requests` | Multi-request composition |
-| `debugging-with-predict` | Iterating with `api predict` |
-| `error-code-reference` | Error codes and recovery steps |
-| `import-best-practices` | Schema inference, fail-closed semantics |
-| `export-format-selection` | Choosing the right output format |
+| `getting-started` | Pulse vocabulary, MCP tool surface, file format, operator catalog |
+| `cohort-schema-design` | Field types, nullability, bit-packing, descriptions |
+| `aggregation-guide` | Aggregator selection (AGG_*) and filterer selection (FILTER_*) |
+| `attribute-composition` | ATTR_* derived columns: z-score, formula, percentile, date_part |
+| `grouper-design` | CATEGORY, RANGE, ROUNDED, DATE, QUANTILE, H3_CELL |
+| `window-operations` | LAG/LEAD/RANK/MOVING_AVG/EWMA partitioning and frame semantics |
+| `feature-engineering` | Pre-filter FEAT_* operators for ML pipelines + leakage trap |
+| `statistical-testing` | Tier-1 row tests and tier-2 post-tests |
+| `regression-modeling` | OLS, GLM, Bayesian linear; modifiers; 13 textbook names mapped |
+| `synthetic-data` | Distributions, correlations, constraints |
+| `compose-requests` | Multi-request batching against one cohort |
+| `debugging-with-predict` | Iterating with `pulse_predict` / `pulse api predict` |
+| `error-code-reference` | Reading envelopes; calling `pulse_errors_lookup` |
+| `import-best-practices` | Schema inference, fail-closed semantics, PULSE_IMPORT_* |
+| `export-format-selection` | CSV / TSV / NDJSON / JSON array / Parquet / Arrow / Excel |
+| `financial-cohorts` | decimal128 semantics for money |
+| `geospatial-cohorts` | point_f64, h3_cell, geo filters and aggregations |
+| `mcp-integration` | MCP tool surface, schema-bound enums, session bootstrap |
+| `request-recipes` | Canonical request JSON skeletons keyed by intent |
+| `query-router-prompt` | System-prompt template for natural-language → AskRequest |
+| `contributor-workflow` | Recipes for extending Pulse |
 
-### Integrating with an LLM agent
-
-The recommended workflow for an LLM agent using Pulse:
-
-1. **Discover the surface**: `pulse --json` returns the full manifest — commands, components, field types, and skills.
-2. **Load relevant skills**: based on the task, call `pulse skills show <name>` to inject domain guidance into the agent's context.
-3. **Validate before execution**: use `pulse api predict` to check a request for structural errors and warnings before running it.
-4. **Execute**: `pulse api process --request req.json --json` returns structured results.
-
-From Go:
+### From Go
 
 ```go
 import "github.com/frankbardon/pulse/skills"
 
-// At agent boot, load all skill metadata.
 for _, s := range skills.List() {
     fmt.Printf("%s: %s\n", s.Name, s.Description)
 }
 
-// Inject a specific skill into the agent's context.
 content, ok := skills.Get("aggregation-guide")
 if ok {
     agent.AddContext(content)
 }
 ```
 
-The root manifest (`pulse --json`) includes a `skills[]` array so agents can discover available skills in a single call.
+The root manifest (`pulse --json`) includes a `skills[]` array so agents can discover available skills in one call.
 
 ## .pulse File Format
 
 Binary, self-describing, fully transportable:
 
 - **9-byte header**: magic bytes (`PULSE\x00\x00\x00`) + format version (`0x01`)
-- **Schema block**: field count, per-field descriptors (type, name, byte offset, bit position, CSV column index, optional description)
+- **Schema block**: field count, per-field descriptors (type, name, byte offset, bit position, source column index, optional description capped at 1000 bytes)
 - **Dictionary blocks**: one per categorical field (string-to-integer mapping stored inline)
 - **Record data**: fixed-width binary records, one per row
 
-15 field types:
+19 field types:
 
 | Type | Bytes | Notes |
 |---|---|---|
 | `u8`, `u16`, `u32`, `u64` | 1, 2, 4, 8 | Unsigned integers |
 | `f32`, `f64` | 4, 8 | IEEE 754 floats |
 | `date` | 4 | Days since Unix epoch |
-| `packed_bool` | 1 | Single boolean |
-| `nullable_bool` | 1 | Tri-state: true/false/null |
-| `nullable_u4` | 1 | 4-bit unsigned, nullable |
+| `packed_bool` | 0 | Bit-packed; shares bytes with adjacent packed fields |
+| `nullable_bool` | 0 | Tri-state; bit-packed |
+| `nullable_u4` | 0 | 4-bit unsigned, nullable; bit-packed |
 | `nullable_u8`, `nullable_u16` | 1, 2 | Nullable unsigned integers |
 | `categorical_u8`, `categorical_u16`, `categorical_u32` | 1, 2, 4 | Dictionary-encoded strings |
+| `decimal128` | 16 | Fixed precision/scale; banker's rounding |
+| `nullable_decimal128` | 16 | Nullable decimal128 |
+| `point_f64` | 16 | Lat/lon pair |
+| `h3_cell` | 8 | Uber H3 cell index |
 
-Categorical width is auto-selected from sample cardinality during import.
+Categorical width auto-selected from sample cardinality during import. Bit-packed types report `ByteSize() == 0` — they share bytes with adjacent packed fields. Schema reader rejects unknown type bytes at parse time with `ENCODING_INVALID`.
 
 ## Configuration
 
-Pulse uses a single environment variable:
+Three environment variables, all optional:
 
 ```bash
-export PULSE_DATA_DIR=/path/to/data
+export PULSE_DATA_DIR=/path/to/data        # Base directory for .pulse cohort files
+export PULSE_IMPORTS_DIR=imports           # Subdir for managed-import handles (default "imports")
+export PULSE_IMPORT_TTL=7d                 # Default TTL for managed handles ("24h", "30m", "7d", "pin")
 ```
 
-When set, the CLI resolves relative cohort paths against this directory. Not required — absolute paths always work.
+Embedders override per-instance via `pulse.Options{DataDir, ImportsDir, ImportTTL, FS}`. No config files.
 
-No config files. No install command.
+## Output Format Contract
+
+All `--json` output is wrapped in a `descriptor.Envelope`:
+
+```json
+{
+  "format_version": "1.0",
+  "data": { ... },
+  "errors": [],
+  "warnings": []
+}
+```
+
+`format_version` is `"1.0"`. Errors/warnings use `{"code", "message", "details"}` entries (empty array when absent, never null). Additive-only: new `data` fields don't bump the version; renames or removals do.
 
 ## Development
 
@@ -367,24 +507,22 @@ No config files. No install command.
 ```bash
 make build    # Binary at ./bin/pulse
 make test     # go test ./...
+make fmt      # gofmt
+make vet      # go vet
 make lint     # staticcheck (auto-installed via go run)
 make cover    # Coverage report
+make docs     # Build mdBook
 make clean    # Remove artifacts
 ```
+
+A `.env` at repo root is auto-loaded by the Makefile.
 
 ### Run tests
 
 ```bash
-# Full suite (17 packages, ~5 seconds)
 go test ./...
-
-# Single package
 go test ./processing/...
-
-# Verbose with specific test
 go test ./service/... -v -run TestProcess
-
-# Fuzz tests
 go test ./encoding/... -fuzz FuzzPulseFileHeader -fuzztime 30s
 ```
 
@@ -392,24 +530,29 @@ go test ./encoding/... -fuzz FuzzPulseFileHeader -fuzztime 30s
 
 ```
 pulse/
-├── pulse.go              Public facade: New, Open, Process, Import, Export, ...
-├── cmd/pulse/            CLI binary (thin adapter)
-├── encoding/             .pulse binary format: header, schema, records
-├── processing/           Aggregators, attributes, filterers, groupers
-├── service/              Orchestration layer
-├── io/                   Bidirectional I/O pipeline
-│   ├── csv/              CSV reader + writer
-│   ├── tsv/              TSV reader + writer
-│   ├── ndjson/           NDJSON reader + writer
-│   ├── parquet/          Parquet reader + writer (Apache Arrow)
-│   └── excel/            Excel reader + writer (Excelize)
-├── fs/                   Filesystem abstraction (afero)
-├── errors/               Typed error codes
-├── types/                Request/response types
-├── descriptor/           Self-description: manifest, predict, inspect
-├── skills/               Embedded LLM skill pack
-└── internal/cli/         CLI internals
+├── pulse.go                Public facade
+├── cmd/pulse/              CLI binary (thin adapter)
+├── service/                Orchestration: wires processing to encoding
+├── processing/             Aggregators, attributes, filterers, groupers
+│   ├── window/             WIN_* operators
+│   └── feature/            FEAT_* pre-filter feature engineers
+├── encoding/               .pulse binary codec
+├── io/                     Tabular ↔ .pulse adapters
+│   └── csv|tsv|ndjson|jsonarray|arrow|parquet|excel/
+├── fs/                     afero-based filesystem abstraction
+├── errors/                 Typed error codes (CodedError system)
+├── types/                  Request/response structs + streamability table
+├── descriptor/             manifest, predict, inspect, envelope (no-execute)
+├── skills/                 //go:embed markdown skill pack
+├── examples/               //go:embed runnable request examples
+├── synth/                  Synthetic data generator
+├── docs/                   mdBook source (GitHub Pages)
+└── internal/
+    ├── cli/                CLI internals
+    └── mcp/                MCP server (wraps pulse.Pulse)
 ```
+
+Documentation: <https://frankbardon.github.io/pulse/>.
 
 ## License
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,9 +41,9 @@
 - [Dictionary Blocks](format/dictionaries.md)
 - [Record Layout](format/records.md)
 
-# MCP Integration (Pointer)
+# MCP Integration
 
-- [How LLMs Use Pulse](mcp/index.md)
+- [Server, Tools, Resources](mcp/index.md)
 
 # Examples Library
 

--- a/docs/src/cli/mcp.md
+++ b/docs/src/cli/mcp.md
@@ -67,12 +67,13 @@ see `skills/mcp-integration.md` for the LLM-facing implications.
 }
 ```
 
-Restart the client. The Pulse tools (`pulse_inspect`, `pulse_predict`,
-`pulse_process`, `pulse_compose`, `pulse_ask`, `pulse_sample`,
-`pulse_facet`, `pulse_manifest`, `pulse_skills_list`,
-`pulse_skills_get`, `pulse_synth_*`, `pulse_profile`) and resources
-(`pulse://*.pulse`, `pulse-skill://*`) appear in the tool/resource
-list.
+Restart the client. The Pulse tools (`pulse_manifest`, `pulse_ask`,
+`pulse_inspect`, `pulse_predict`, `pulse_process`, `pulse_compose`,
+`pulse_sample`, `pulse_facet`, `pulse_import`, `pulse_drop`,
+`pulse_imports_list`, `pulse_examples_search`, `pulse_examples_get`,
+`pulse_errors_lookup`, `pulse_skills_list`, `pulse_skills_get`) and
+resources (`pulse://*.pulse`, `pulse-skill://*`) appear in the
+tool/resource list.
 
 ## Wiring it into Claude Code
 

--- a/docs/src/mcp/index.md
+++ b/docs/src/mcp/index.md
@@ -1,55 +1,271 @@
-# How LLMs Use Pulse
+# MCP Integration
 
-This chapter is a **pointer**, not a guide. The human-facing site you are reading
-is for operators, embedders, and contributors. LLM-facing guidance ships inside
-the Pulse binary as an embedded skill pack and is delivered over the Model
-Context Protocol.
+**Audience:** operators wiring Pulse into an MCP-aware AI client (Claude Desktop, Claude Code, Cursor, Zed, custom hosts), and embedders who want to expose Pulse to an LLM agent.
 
-## Two surfaces, one engine
+This page is the human-facing guide: what the server does, how to wire it up, what the LLM sees, and how to debug a misbehaving session. Agent-facing guidance ships inside the binary as the `mcp-integration` skill — fetch it via `pulse_skills_get` (or `pulse skills show mcp-integration`).
 
-| Surface | Audience | How it is delivered |
-|---|---|---|
-| This mdBook site | Humans — operators, embedders, contributors | Static HTML at <https://frankbardon.github.io/pulse/> |
-| Embedded skill pack | LLM agents | `pulse mcp` server, loaded with `pulse_skills_list` then `pulse_skills_get` |
+## What `pulse mcp` is
 
-The skill pack speaks MCP voice: tool calls, JSON request payloads, error
-codes, no CLI invocations. This site speaks CLI voice and Go-library voice.
+`pulse mcp` runs the Pulse library as a Model Context Protocol (MCP) server. The host (Claude Desktop, Claude Code, etc.) launches it as a subprocess, speaks JSON-RPC over its stdio streams, and shuts it down on session close. The LLM sees Pulse as a set of **tools** (callable functions), **resources** (browseable URIs), and **prompts** (canned slash commands).
 
-## Task → skill cross-reference
+```
+┌─────────────┐  stdio JSON-RPC  ┌────────────┐  Go calls  ┌─────────────┐
+│  AI client  │ ───────────────→ │ pulse mcp  │ ─────────→ │ pulse.Pulse │
+│   (host)    │ ←─────────────── │ (this bin) │ ←───────── │  (library)  │
+└─────────────┘                  └────────────┘            └─────────────┘
+                                       │
+                                       └── stderr ─→ host log pane
+```
 
-If you are writing a system prompt for an LLM agent that uses Pulse, point it at
-these skills rather than at this site:
+The server is a thin translator. Every tool wraps a public method on `pulse.Pulse`; the same code path powers the CLI.
 
-| LLM task | Skill name |
+## Quickstart
+
+```bash
+# 1. Build and place on PATH
+make build && cp ./bin/pulse /usr/local/bin/
+
+# 2. Pick a data directory
+mkdir -p /var/data/pulse
+
+# 3. Wire into your host (see below) and restart it
+
+# 4. From the LLM session, call:
+#    pulse_manifest      → cache once
+#    pulse_ask           → run analyses
+```
+
+## Wiring into a host
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```jsonc
+{
+  "mcpServers": {
+    "pulse": {
+      "command": "/usr/local/bin/pulse",
+      "args": ["mcp"],
+      "env": {
+        "PULSE_DATA_DIR": "/var/data/pulse"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. Pulse tools appear in the tool picker.
+
+### Claude Code
+
+```bash
+claude mcp add pulse --env PULSE_DATA_DIR=/var/data/pulse -- pulse mcp
+```
+
+Or by hand in `~/.claude.json` (or per-project `.claude.json`):
+
+```jsonc
+{
+  "mcpServers": {
+    "pulse": {
+      "command": "/usr/local/bin/pulse",
+      "args":    ["mcp"],
+      "env":     { "PULSE_DATA_DIR": "/var/data/pulse" }
+    }
+  }
+}
+```
+
+### Cursor / Zed / generic stdio hosts
+
+Any host that speaks the MCP stdio transport can launch `pulse mcp` the same way — provide the binary path, the `mcp` argument, and the `PULSE_DATA_DIR` env var.
+
+## What the LLM sees
+
+### Tool surface
+
+Sixteen tools, registered at server start. Names and order match `internal/mcp/mcptools/meta.go`.
+
+| Tool | Purpose |
 |---|---|
+| `pulse_manifest` | **Call first.** Self-description: commands, operators (with accepted types + streamability), tier-1/tier-2 tests, regressions, synth distributions, error code list, MCP tool list, cohort field types with operator cross-references. Cache once per session. |
+| `pulse_ask` | **Preferred entry point.** One-shot: optional auto-import → inspect → predict → execute. Accepts `source` (raw file path) + `query` (natural language, **beta**) or a structured `request`. |
+| `pulse_inspect` | Read `.pulse` header + schema (no record bytes). Side effect: registers session-scoped schema-bound tool variants (see below). |
+| `pulse_predict` | Validate a request against the schema without executing. Returns errors, warnings, applied defaults, streamability reasons. |
+| `pulse_process` | Execute one pre-built request. |
+| `pulse_compose` | Execute a batch of requests against the same cohort in one round trip. |
+| `pulse_sample` | Return up to N rows for preview / diagnostics. |
+| `pulse_facet` | Distinct values for a single field. |
+| `pulse_import` | Convert a tabular source (csv, tsv, ndjson, jsonarray, parquet, arrow, excel) into a managed `.pulse` handle under `imports/`, with TTL-tracked sidecar. Pulse-format inputs pass through. |
+| `pulse_drop` | Delete a managed-import handle and its sidecar. |
+| `pulse_imports_list` | Enumerate managed handles with sidecar metadata (source, format, imported_at, expires_at, ttl, expired flag, pinned flag). |
+| `pulse_examples_search` | Search the embedded request-example library by query, taxonomy tags (ANDed), or category. |
+| `pulse_examples_get` | Fetch one runnable example body by name. |
+| `pulse_errors_lookup` | Per-code Message + Fixup detail (kept out of the manifest for context economy). |
+| `pulse_skills_list` | Embedded skill metadata. |
+| `pulse_skills_get` | Fetch one skill body by name. |
+
+> **Natural-language `query` is beta.** Heuristic parsing only — silent misinterpretation is possible. The LLM should always check the `query_resolution` and resolved `request` in the response before trusting results. For production, author a structured `request` against the cached manifest and skip the `query` field.
+
+### Resources
+
+| URI scheme | Yields |
+|---|---|
+| `pulse://<path>` | One resource per `.pulse` file under the data directory. Read returns `descriptor.InspectResult` JSON (header + schema only — no record bytes). |
+| `pulse-skill://<name>` | One per embedded skill. Read returns the markdown body. |
+
+Resources are registered once at server start. Files added afterwards do not appear until the server restarts. Listing is cheap because the server only reads header bytes.
+
+### Prompts
+
+| Name | Args | Returns |
+|---|---|---|
+| `pulse-bootstrap` | none | A short instructions block telling the assistant what to call (and in what order) before authoring any request, and where the authoritative references live. Inject at session start. |
+| `pulse-author-request` | `question` | A guided tool-call sequence for translating a natural-language analytical question into a Pulse request: manifest → examples search → ask. |
+
+Hosts that surface prompts as slash commands let users trigger these directly.
+
+## Recommended session flow
+
+The two-call default for nearly every user request:
+
+1. **`pulse_manifest`** once at session start. No arguments. Cache the payload — it is deterministic for a binary version and carries every fact needed to author a valid request.
+2. **`pulse_ask`** for everything else. It collapses import + inspect + predict + execute into one round trip. When the user hands the LLM a raw file:
+
+   ```json
+   {
+     "request": "{\"source\":\"data.csv\",\"query\":\"average revenue by month\"}"
+   }
+   ```
+
+   When the cohort already exists as a managed handle or `.pulse` file:
+
+   ```json
+   {
+     "request": "{\"cohort\":{\"filename\":\"sales.pulse\"},\"query\":\"top 5 regions by revenue\"}"
+   }
+   ```
+
+   On predict-invalid with `on_invalid="suggest"`, the response carries structured `Fixup` entries derived from each error code's metadata so the LLM can repair the request without another round trip.
+
+Reach for the multi-step path (`pulse_inspect` → `pulse_predict` → `pulse_process`) only when:
+- diagnosing a failed predict and you want the full envelope,
+- previewing rows (`pulse_sample`) or value distributions (`pulse_facet`),
+- pre-staging a managed handle with a specific name / TTL / pinning (`pulse_import`),
+- batching multiple requests in one call (`pulse_compose`).
+
+## Managed imports + TTL
+
+`pulse_import` lets the LLM hand the server any tabular file and address it from then on as if it were a `.pulse`.
+
+- **Convertible formats** (csv, tsv, ndjson, jsonarray, parquet, arrow, excel) are imported into `$PULSE_DATA_DIR/imports/<handle>.pulse` with a sidecar `<handle>.pulse.meta.json` carrying `imported_at`, `expires_at`, `ttl_seconds`, source path, source format, and row count. `result.managed=true`.
+- **Pulse passthroughs** (`.pulse` extension) under `PULSE_DATA_DIR` are not copied — the server returns the relative path verbatim with `managed=false`. A `.pulse` outside `PULSE_DATA_DIR` is copied into the managed pool.
+
+**Source path resolution.** Relative `source` paths resolve against `PULSE_DATA_DIR`. Absolute paths read from the host filesystem through a separate "source fs."
+
+**Import jail.** Absolute source paths are confined to a single directory tree (the *jail root*). Default: the working directory the MCP server was launched from. Paths that escape the jail (including `..`) return `PULSE_IMPORT_SOURCE_FORBIDDEN`. Override via `pulse.Options.ImportSourceJailRoot` when embedding.
+
+**Sliding TTL.** Default lifetime is `7d` (overridable via `PULSE_IMPORT_TTL`, or per-import via the `ttl` field — accepts Go duration like `"24h"`, day form like `"7d"`, or `"pin"` for never-expire). Every subsequent inspect/predict/process/sample/facet/ask against the handle slides `expires_at` forward. The pool self-sweeps on every `pulse_import` call — no daemon required. Inspect with `pulse_imports_list`; evict manually with `pulse_drop`.
+
+## Schema-bound enums
+
+After a successful `pulse_inspect` (or after `pulse_ask` opens a cohort), the server registers session-scoped variants of the action tools (`pulse_process`, `pulse_predict`, `pulse_compose`, `pulse_sample`, `pulse_facet`) whose JSON Schemas embed enum constraints on field-name parameters. The LLM picks field names from a typed list rather than free-texting and discovering on predict that the name was wrong.
+
+What gets constrained on bound `pulse_process` / `pulse_predict` / `pulse_compose` schemas:
+
+| Path | Enum |
+|---|---|
+| `aggregations[].field` | All cohort field names |
+| `aggregations[].type` | Full aggregator catalogue (`AGG_*`) |
+| `attributes[].field` | Numeric fields only (includes decimal) |
+| `attributes[].type` | Full attribute catalogue (`ATTR_*`) |
+| `filterers[].field` | All cohort field names |
+| `filterers[].type` | Full filterer catalogue (`FILTER_*`) |
+| `groups[].field` | All cohort field names |
+| `groups[].type` | Full grouper catalogue (`GROUP_*`) |
+| `windows[].field`, `windows[].partition_by[]` | All cohort field names |
+| `windows[].order_by[].field` | Numeric and date fields |
+| `windows[].type` | Full window catalogue (`WIN_*`) |
+| `tests[].field`, `tests[].field2` | Numeric fields only |
+| `tests[].split_by` / `rows` / `cols` / `subject_field` | All cohort field names |
+| `tests[].type` | Full test catalogue (`TEST_*`) |
+| `pulse_facet` `field` arg | All cohort field names |
+
+**Trigger and lifecycle.** Binding fires on a successful `pulse_inspect`. `mcp-go` auto-fires `notifications/tools/list_changed` on `AddSessionTools`; the host refreshes its tool list and picks up the bound schemas on the next list. Bound tools share names with the global tools — session-scoped variants override globals for that session.
+
+**Limitations.**
+- *Multi-file sessions:* the latest inspect wins. Track multiple cohorts client-side.
+- *No per-element type ↔ field correlation:* JSON Schema can't easily express "if `aggregations[i].type == AGG_SUM` then `aggregations[i].field` must be numeric." Operator–type compatibility lives in the `type` property description; strict validation remains `pulse_predict`'s job.
+- *Transport support:* binding requires a session that implements `SessionWithTools`. SSE / Streamable HTTP transports work; on stdio, binding is a no-op fallback and the global (unbound) schemas remain in effect. The manifest's `accepts_types` table is still authoritative, so authoring is not blocked — just less ergonomic.
+- *Empty enums omitted:* when the cohort has zero fields in a category (e.g. no geo fields), the enum is omitted entirely rather than emitted as `[]`.
+
+Disable binding entirely with `--bind-on-open=false`.
+
+## Configuration
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `PULSE_DATA_DIR` | Cohort base directory. Required. | (none — server fails to start without it) |
+| `PULSE_IMPORTS_DIR` | Subdirectory for managed-import handles. | `imports` |
+| `PULSE_IMPORT_TTL` | Default TTL for managed handles. Accepts Go duration (`24h`, `30m`), day form (`7d`, `30d`), or `pin`. | `7d` |
+
+Embedders can override per-instance via `pulse.Options{DataDir, ImportsDir, ImportTTL, ImportSourceJailRoot, FS, ImportSourceFS, BindOnOpen}` — see `pulse.go`.
+
+## Transport caveats
+
+- **Stdio.** The default and only transport `pulse mcp` ships today. Schema binding is a no-op (see Limitations). Stdout is the JSON-RPC channel; stderr is the log channel — never write structured output to stdout outside the protocol.
+- **SSE / Streamable HTTP.** Not exposed by the `mcp` CLI leaf yet. The underlying `mcp-go` server supports them; embedders can call `mcp.NewWithOptions(p, ...)` and serve via `mcp-go`'s SSE / streamable HTTP entry points directly.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `data directory required: set PULSE_DATA_DIR or pass --data-dir` | Neither env var nor flag set | Pass `PULSE_DATA_DIR` in the host's `env` block, or `--data-dir` in `args` |
+| Tools don't appear in the host UI after editing config | Host caches tool list | Restart the host fully (not just the conversation) |
+| `pulse_import` returns `PULSE_IMPORT_SOURCE_FORBIDDEN` for an absolute path | Path escapes the import jail (default = server's working dir) | Either move the file under the jail, launch the server from a higher-level directory, or set `pulse.Options.ImportSourceJailRoot` when embedding |
+| `pulse_inspect` succeeds but bound enums never fire | Stdio session — binding is a no-op there | Use `pulse_predict` for validation; the manifest's `accepts_types` lists give the LLM the same information |
+| Tool calls hang | Host wrote non-protocol bytes to the server's stdin, or server wrote non-protocol bytes to stdout | Check server stderr; restart the session. `pulse mcp` itself only writes a one-line startup notice to stderr at boot |
+| `pulse_ask` with `query` returns nonsense or wrong fields | Natural-language parsing is heuristic and beta | Inspect `query_resolution` in the response. For production, author a structured `request` against the cached manifest |
+
+To see what the server registers without launching the host:
+
+```bash
+pulse --json | jq '.data.mcp_tools[]'
+pulse manifest --json | jq '.data.skills[]'
+```
+
+## Skill cross-reference for LLM agents
+
+If you are writing a system prompt for an LLM agent that uses Pulse, point it at these skills rather than at this site:
+
+| LLM task | Skill |
+|---|---|
+| MCP wiring, tool surface, schema binding | `mcp-integration` |
 | Author a `Process` request | `request-recipes` |
 | Compose multiple sub-requests in one call | `compose-requests` |
 | Iterate on a request with `pulse_predict` | `debugging-with-predict` |
 | Look up an error code or warning | `error-code-reference` |
-| Pick an aggregator (or a filterer) | `aggregation-guide` |
+| Pick an aggregator / filterer | `aggregation-guide` |
 | Pick an attribute (z-score, percentile, formula, ...) | `attribute-composition` |
 | Design a grouper | `grouper-design` |
 | Use a window operator (`WIN_*`) | `window-operations` |
 | Use a feature engineer (`FEAT_*`) | `feature-engineering` |
 | Run a statistical test (tier-1 or tier-2) | `statistical-testing` |
+| Fit a regression (OLS, GLM, Bayesian) | `regression-modeling` |
 | Generate synthetic data | `synthetic-data` |
 | Understand a cohort's schema layout | `cohort-schema-design` |
 | Import a tabular source into `.pulse` | `import-best-practices` |
 | Pick an export format | `export-format-selection` |
-| Work with decimal128 (currency, precise arithmetic) | `financial-cohorts` |
+| Work with `decimal128` (currency, precise arithmetic) | `financial-cohorts` |
 | Work with `point_f64` / `h3_cell` | `geospatial-cohorts` |
 | Route a natural-language query to a Pulse request | `query-router-prompt` |
-| Wire Pulse into an MCP client | `mcp-integration` |
 | Get started end-to-end (LLM walkthrough) | `getting-started` |
 
-## How an agent discovers the skill pack
+The agent should call `pulse_skills_list` once at session start to enumerate the catalog, then `pulse_skills_get` on demand. The returned text is authoritative; this site does not duplicate it and may lag.
 
-At session start, an LLM connected to a Pulse MCP server should call
-`pulse_skills_list` once to enumerate the catalog, then `pulse_skills_get` on
-demand for the skills relevant to its current task. The agent should treat the
-returned text as authoritative guidance; this site does not duplicate that
-content and may lag.
+## Related
 
-For wiring details (Claude Desktop, Claude Code, generic MCP clients), see
-[`mcp` (CLI leaf)](../cli/mcp.md) on the human side and the `mcp-integration`
-skill on the LLM side.
+- [`mcp` (CLI leaf)](../cli/mcp.md) — flag reference and exit codes for the server binary
+- [Deployment](../ops/deployment.md) — production hardening notes
+- [Troubleshooting](../ops/troubleshooting.md) — non-MCP failure modes


### PR DESCRIPTION
## Summary
- README brought up to date with current CLI surface (`api` group, `cohort`, `synth`/`profile`, `examples`, `errors`, `mcp`), real operator counts, 19 field types, `descriptor.Envelope` contract, and the new `PULSE_IMPORTS_DIR` / `PULSE_IMPORT_TTL` env vars; adds a dedicated MCP usage section.
- `docs/src/mcp/index.md` rewritten from a thin pointer into a full operator guide — server overview, host wiring (Claude Desktop / Code / Cursor), 16-tool surface table, resources, prompts, recommended session flow, managed imports + TTL, schema-bound enums with constraint table, env vars, transport caveats, troubleshooting matrix.
- `docs/src/cli/mcp.md` tool list corrected (removed nonexistent `pulse_synth_*` / `pulse_profile`, added the 7 actual current tools).
- Natural-language `query` flagged as beta in three places (README ask section, MCP tool table, recommended-flow callout).
- Removed stray `jsonshared` mention from the project-structure listing (internal helper, not a user-visible format).

## Test plan
- [x] `make docs` builds the mdBook without errors
- [x] Visual check of the rendered MCP page (`docs/src/mcp/index.md`)
- [x] Visual check of README on GitHub
- [x] Confirm no broken cross-links in `docs/src/SUMMARY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)