### PR TITLE
chore(build): strip symbols and trim paths for smaller binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 BINARY_NAME=pulse
 BUILD_DIR=bin
 GO=go
+LDFLAGS=-s -w
+BUILD_FLAGS=-trimpath -ldflags="$(LDFLAGS)"
 
 ifneq (,$(wildcard ./.env))
     include .env
@@ -10,7 +12,7 @@ ifneq (,$(wildcard ./.env))
 endif
 
 build:
-	$(GO) build -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/pulse
+	$(GO) build $(BUILD_FLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/pulse
 
 clean:
 	rm -rf $(BUILD_DIR) coverage.out


### PR DESCRIPTION
## Summary
- Add `-trimpath` and `-ldflags=\"-s -w\"` to the default `make build` target
- Reduces the `pulse` binary from **62.6MB → 42.1MB (-33%)**
- CGO stays enabled: `github.com/uber/h3-go/v4` requires the H3 C library for `point_f64` / `h3_cell` field types, `GROUP_H3_CELL`, and `AGG_GEO_CENTROID`. Disabling CGO breaks the build with `build constraints exclude all Go files`.

## Test plan
- [x] `make test` — full suite passes
- [x] `make build` — binary produced, 42.1MB on darwin/arm64
- [x] Smoke-test `bin/pulse manifest --json` on built binary
- [x] Confirm no panics from stripped DWARF in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)