### PR TITLE
fix(processing): resolve categorical filter values via dictionary before ParseFloat

### DIFF
--- a/processing/filterer.go
+++ b/processing/filterer.go
@@ -19,19 +19,22 @@ func newIncludeFilterer() FiltererBuilder {
 }
 
 func (f *includeFilterer) Build(filter *types.Filterer, schema *encoding.Schema) (FilterFunc, error) {
+	field := schema.Field(filter.Field)
+	isCategorical := field != nil && field.Type.IsCategorical() && field.Dictionary != nil
+
 	valueSet := make(map[float64]bool, len(filter.Values))
 	for _, v := range filter.Values {
+		if isCategorical {
+			id, ok := field.Dictionary.IDFor(v)
+			if !ok {
+				return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+					fmt.Sprintf("include value %q not found in dictionary for field %q", v, filter.Field))
+			}
+			valueSet[float64(id)] = true
+			continue
+		}
 		fv, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			// For categorical fields, try dictionary lookup
-			field := schema.Field(filter.Field)
-			if field != nil && field.Type.IsCategorical() && field.Dictionary != nil {
-				id, ok := field.Dictionary.IDFor(v)
-				if ok {
-					valueSet[float64(id)] = true
-					continue
-				}
-			}
 			return nil, errors.WrapCodedError(err, errors.PROCESSING_CONFIG,
 				fmt.Sprintf("parsing include value %q", v))
 		}
@@ -56,18 +59,22 @@ func newExcludeFilterer() FiltererBuilder {
 }
 
 func (f *excludeFilterer) Build(filter *types.Filterer, schema *encoding.Schema) (FilterFunc, error) {
+	field := schema.Field(filter.Field)
+	isCategorical := field != nil && field.Type.IsCategorical() && field.Dictionary != nil
+
 	valueSet := make(map[float64]bool, len(filter.Values))
 	for _, v := range filter.Values {
+		if isCategorical {
+			id, ok := field.Dictionary.IDFor(v)
+			if !ok {
+				return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+					fmt.Sprintf("exclude value %q not found in dictionary for field %q", v, filter.Field))
+			}
+			valueSet[float64(id)] = true
+			continue
+		}
 		fv, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			field := schema.Field(filter.Field)
-			if field != nil && field.Type.IsCategorical() && field.Dictionary != nil {
-				id, ok := field.Dictionary.IDFor(v)
-				if ok {
-					valueSet[float64(id)] = true
-					continue
-				}
-			}
 			return nil, errors.WrapCodedError(err, errors.PROCESSING_CONFIG,
 				fmt.Sprintf("parsing exclude value %q", v))
 		}

--- a/processing/filterer_edge_test.go
+++ b/processing/filterer_edge_test.go
@@ -1,10 +1,31 @@
 package processing
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/frankbardon/pulse/encoding"
 	"github.com/frankbardon/pulse/types"
 )
+
+func numericCategoricalSchema(t *testing.T) *encoding.Schema {
+	t.Helper()
+	dict := encoding.NewDictionary()
+	if _, err := dict.Add("100"); err != nil {
+		t.Fatalf("dict.Add: %v", err)
+	}
+	if _, err := dict.Add("2178"); err != nil {
+		t.Fatalf("dict.Add: %v", err)
+	}
+	if _, err := dict.Add("500"); err != nil {
+		t.Fatalf("dict.Add: %v", err)
+	}
+	return &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "brand_code", Type: encoding.FieldTypeCategoricalU16, Dictionary: dict},
+		},
+	}
+}
 
 func TestFilterer_Range_InvalidValues(t *testing.T) {
 	schema := numericSchema()
@@ -139,5 +160,102 @@ func TestFilterer_Exclude_CategoricalValues(t *testing.T) {
 	}
 	if !pass2 {
 		t.Error("expected Samsung to pass exclude filter for Apple")
+	}
+}
+
+// Regression: numeric-string dictionary entries must be resolved via the
+// dictionary, not parsed as floats. Previously "2178" was parsed as 2178.0
+// and compared against the encoded dictionary index, which silently never
+// matched.
+func TestFilterer_Include_CategoricalNumericValues(t *testing.T) {
+	schema := numericCategoricalSchema(t)
+	fn := makeFilterFunc(t, types.FILTER_INCLUDE, "brand_code", []string{"2178"}, "", schema)
+
+	// Dictionary order: "100" -> 0, "2178" -> 1, "500" -> 2.
+	rec100 := NewRecord(schema, map[string]float64{"brand_code": 0})
+	rec2178 := NewRecord(schema, map[string]float64{"brand_code": 1})
+	rec500 := NewRecord(schema, map[string]float64{"brand_code": 2})
+
+	pass, err := fn(rec2178)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pass {
+		t.Error("expected record at dict index 1 (\"2178\") to pass include filter")
+	}
+
+	for _, rec := range []*Record{rec100, rec500} {
+		pass, err := fn(rec)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pass {
+			t.Error("expected non-matching record to fail include filter")
+		}
+	}
+}
+
+func TestFilterer_Exclude_CategoricalNumericValues(t *testing.T) {
+	schema := numericCategoricalSchema(t)
+	fn := makeFilterFunc(t, types.FILTER_EXCLUDE, "brand_code", []string{"2178"}, "", schema)
+
+	rec100 := NewRecord(schema, map[string]float64{"brand_code": 0})
+	rec2178 := NewRecord(schema, map[string]float64{"brand_code": 1})
+	rec500 := NewRecord(schema, map[string]float64{"brand_code": 2})
+
+	pass, err := fn(rec2178)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pass {
+		t.Error("expected record at dict index 1 (\"2178\") to be excluded")
+	}
+
+	for _, rec := range []*Record{rec100, rec500} {
+		pass, err := fn(rec)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !pass {
+			t.Error("expected non-matching record to pass exclude filter")
+		}
+	}
+}
+
+func TestFilterer_Include_CategoricalValueNotInDictionary(t *testing.T) {
+	schema := numericCategoricalSchema(t)
+	factory := filtererRegistry[types.FILTER_INCLUDE]
+	builder := factory()
+
+	_, err := builder.Build(&types.Filterer{
+		Type:   types.FILTER_INCLUDE,
+		Field:  "brand_code",
+		Values: []string{"9999"},
+	}, schema)
+	if err == nil {
+		t.Fatal("expected error for categorical filter value missing from dictionary")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "brand_code") || !strings.Contains(msg, "9999") {
+		t.Errorf("error should mention field and value, got: %v", err)
+	}
+}
+
+func TestFilterer_Exclude_CategoricalValueNotInDictionary(t *testing.T) {
+	schema := numericCategoricalSchema(t)
+	factory := filtererRegistry[types.FILTER_EXCLUDE]
+	builder := factory()
+
+	_, err := builder.Build(&types.Filterer{
+		Type:   types.FILTER_EXCLUDE,
+		Field:  "brand_code",
+		Values: []string{"9999"},
+	}, schema)
+	if err == nil {
+		t.Fatal("expected error for categorical filter value missing from dictionary")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "brand_code") || !strings.Contains(msg, "9999") {
+		t.Errorf("error should mention field and value, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Categorical-field include/exclude filters silently returned zero rows when the user-supplied value parsed as a number (e.g. brand code `"2178"`). `strconv.ParseFloat` short-circuited the dictionary lookup, so the raw numeric value was compared against the encoded dictionary **index** at runtime — a coincidence match at best.
- Fix: for categorical fields with a dictionary, try `Dictionary.IDFor` first; fall back to `ParseFloat` only for non-categorical fields. Categorical values absent from the dictionary now return a `PROCESSING_CONFIG` error rather than producing a silently empty result.
- `FILTER_RANGE`, `FILTER_EXPRESSION`, and the grouper are unaffected — see plan doc.

## Test plan
- [x] `go test ./processing/ -run TestFilterer -v` — 22 passing, including new `TestFilterer_Include_CategoricalNumericValues`, `TestFilterer_Exclude_CategoricalNumericValues`, `TestFilterer_Include_CategoricalValueNotInDictionary`, `TestFilterer_Exclude_CategoricalValueNotInDictionary`
- [x] `go test ./...` — all packages green
- [x] `go vet ./...` clean
- [x] Reviewer: confirm option-2 strictness (reject dict miss) is preferred over preserving a raw-index escape hatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)