### PR TITLE
feat(projection): pulse.Options.ProjectBufferedFields for narrow-request memory wins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ Any change to Pulse code, configuration, file format, or public surface MUST upd
 | Extension registration validation rule (regex, reserved namespace, ParamMeta shape) | `extensions_validate.go` + `skills/extension-points.md` + CLAUDE.md "Extension Points" section | `TestExtensions_NameInvalidRegex`, `TestExtensions_NameReservedNamespace`, `TestExtensions_ParamMetaInvalidJSONType` |
 | `FacetRequest` / `FacetResult` shape | `types/facet.go` + `skills/facet-design.md` + `descriptor/capabilities_facet.go` + `descriptor/facet.go` (`ValidateFacet`) | `TestFacetSchema_*`, `TestManifestFacetCapability` |
 | Facet streamability conditions | `descriptor/capabilities_facet.go` (`StreamableConditions`) + `skills/facet-design.md` | reviewer enforcement |
+| `pulse.Options.ProjectBufferedFields` flag or `processing.NeededFields` extraction (new operator slot, expr identifier source, Params-referenced field) | CLAUDE.md "Projected buffered decode" subsection + `skills/extension-points.md` (FieldInputs hook + extractor surface) | `TestNeededFields_*`, `TestProjection_BufferedMatchesFullDecode_*`, `TestProjection_ByteCursorAlignmentWhenSkipping`, `TestReadRecordProjected_*` |
+| `FieldInputsFunc` hook on a registration struct (added/removed) | `extensions.go` (registration struct field) + `extensions_runtime.go` (wire into ExtensionRegistry.FieldInputs) + `skills/extension-points.md` | `TestNeededFields_ExtensionWithFieldInputs`, `TestNeededFields_UnknownExtensionWidens` |
 
 The Update Demand applies recursively to itself: new trigger rows require this table to be updated in the same PR. `TestUpdateDemandTableCovers` parses this section and asserts every component category and contract type has a row.
 
@@ -181,6 +183,12 @@ Capability declarations live in `descriptor/capabilities_*.go`. MCP tool metadat
 
 Four orchestrator modes — single-pass, grouped, two-pass attributes (Welford-Pébaÿ), streaming features. Forced buffered: median/percentile/zscore aggregators, `ATTR_PERCENTILE`, `GROUP_QUANTILE`/`GROUP_DATE`, window operators, decimal/geo paths, tier-1 tests combined with groupers/features/two-pass attrs, all tier-2 tests. CLI streams via `pulse api process --stream` / `pulse api compose --stream` (NDJSON one row per line). Library: `pulse.ProcessStream(ctx, req) (RowIter, error)`.
 
+### Projected buffered decode
+
+`pulse.Options.ProjectBufferedFields` (opt-in, defaults `false`) enables per-request field projection on the streaming iterator. When enabled, `processing.NeededFields(req, schema, ext)` walks every request slot — Aggregations.Field, Attributes (Field, Target, Predictors, expr-AST identifiers via `expr-lang/expr/parser` + `expr-lang/expr/ast` for `ATTR_FORMULA` / `FILTER_EXPRESSION`), Filterers.Field, Groups.Field, Windows (Field + PartitionBy + OrderBy), Features (Field + `stratify` / `target` from Params for `FEAT_TRAIN_TEST_SPLIT` / `FEAT_TARGET_ENCODE`), Tests (Field, Field2, SplitBy, Rows, Cols, SubjectField, OrderBy), Regressions (Target + Predictors), Sort.Field — and returns the `FieldSet` the request actually reads. The iterator's `ReadRecordWithWideProjected` then advances byte cursors for every field but skips map writes outside the set. Per-record `values`/`nulls`/`wide` map allocations drop proportional to the projection ratio; decode CPU is unchanged. Bit-packed neighbours stay correct because every field still consumes its on-wire bytes, only the map writes are guarded.
+
+Extension operators surface a per-registration `FieldInputs FieldInputsFunc` hook. When set, the projection extractor calls it with the operator's `Params` and includes the returned field names. When absent on a custom operator, the extractor widens to `*` (every field) — projection then falls back to the full-decode path so the runtime stays correct. Built-in operators are fully introspectable; only extension-resolved operators can widen.
+
 ### Parallel Compose
 
 `pulse.ComposeParallel(ctx, req, opts)` fans out a `ComposedRequest` over a bounded worker pool. Order-preserving by slot index. `ComposeOptions{MaxWorkers, PerRequestTimeout, FailFast}` (FailFast defaults true). CLI: `pulse api compose --parallel N [--no-fail-fast]`.
@@ -270,6 +278,8 @@ Hermetic testing: `fs.NewMemMap()` returns a `Config` backed by `afero.NewMemMap
 **Manifest visibility:** the root manifest carries a top-level `extensions` block listing every registered operator + expr function + lookup table (with `has_rows_data` to distinguish static maps from function-driven tables). The schema-bound MCP tools (post-`pulse_inspect`) include custom names in their per-category enums.
 
 **Snapshot pattern:** `descriptor.ExtensionsSnapshot` is the read-only projection passed into `descriptor.PredictOptions.Extensions` and `mcp.BindSessionToolsWithExtensions`. Built by `pulse.New` via `buildExtensionsSnapshot`, cached on the Service. Predict and the schema binder consume the snapshot only — descriptor stays free of `service/` and `processing/` imports (gated by `TestPredictNoExecutionImports`).
+
+**FieldInputs hook (buffered-projection introspection):** every operator registration (`AggregatorRegistration`, `AttributeRegistration`, `FiltererRegistration`, `GrouperRegistration`, `WindowRegistration`, `FeatureRegistration`, `TestRegistration`) accepts an optional `FieldInputs FieldInputsFunc`. When set, `processing.NeededFields` calls it with the operator's raw `Params` and includes the returned field names in the projection set. When omitted on a custom operator, the projection extractor widens to "every field" so the runtime stays correct (the operator is opaque). Built-in operators are always introspectable; only extension-resolved operators can widen. The hook is plumbed via `buildRuntimeExtensions` into `processing.ExtensionRegistry.FieldInputs`, keyed by `StreamabilityKey(category, name)`.
 
 The embedder-facing surface lives in `extensions.go` (types), `extensions_validate.go` (validation), `extensions_probe.go` (probe-validation), `extensions_runtime.go` (runtime registry conversion), and `extensions_snapshot.go` (manifest/predict snapshot). The runtime-side overlay lives in `processing/extensions.go`.
 

--- a/encoding/reader.go
+++ b/encoding/reader.go
@@ -40,10 +40,31 @@ func (rr *RecordReader) ReadRecord(values map[string]float64, nulls map[string]b
 	return rr.ReadRecordWithWide(values, nulls, nil)
 }
 
+// FieldFilter returns true for field names whose values should be
+// written into the caller's maps. Used by ReadRecordWithWideProjected
+// to skip map writes for fields the request doesn't read. A nil
+// FieldFilter is equivalent to "keep every field."
+type FieldFilter func(name string) bool
+
 // ReadRecordWithWide reads a record and populates a wide map with typed
 // values for decimal128, point_f64, and h3_cell fields. The wide map may
 // be nil to skip wide population.
 func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[string]bool, wide map[string]any) error {
+	return rr.readRecord(values, nulls, wide, nil)
+}
+
+// ReadRecordWithWideProjected reads a record but only writes the
+// fields for which keep(name) returns true into the caller's maps.
+// Bytes for excluded fields are still consumed from the underlying
+// reader so byte offsets stay aligned — projection saves map
+// allocations, not decode work.
+//
+// keep == nil falls back to the full-decode path.
+func (rr *RecordReader) ReadRecordWithWideProjected(values map[string]float64, nulls map[string]bool, wide map[string]any, keep FieldFilter) error {
+	return rr.readRecord(values, nulls, wide, keep)
+}
+
+func (rr *RecordReader) readRecord(values map[string]float64, nulls map[string]bool, wide map[string]any, keep FieldFilter) error {
 	// Clear caller-provided maps.
 	for k := range values {
 		delete(values, k)
@@ -56,6 +77,7 @@ func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[
 	}
 
 	for _, field := range rr.schema.Fields {
+		keepField := keep == nil || keep(field.Name)
 		switch field.Type {
 		case FieldTypePackedBool:
 			v, err := ReadBit(rr.r, uint(field.BitPosition))
@@ -64,6 +86,9 @@ func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[
 					return io.EOF
 				}
 				return err
+			}
+			if !keepField {
+				continue
 			}
 			if v {
 				values[field.Name] = 1
@@ -78,6 +103,9 @@ func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[
 					return io.EOF
 				}
 				return err
+			}
+			if !keepField {
+				continue
 			}
 			// For nullable bool, bit=0 can mean null or false depending on convention.
 			// Treat as: 1=true, 0=false. Null tracking requires a separate null bitmap
@@ -96,6 +124,9 @@ func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[
 				}
 				return err
 			}
+			if !keepField {
+				continue
+			}
 			if v == nullableU4NullSentinel {
 				nulls[field.Name] = true
 				values[field.Name] = 0
@@ -110,6 +141,9 @@ func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[
 					return io.EOF
 				}
 				return err
+			}
+			if !keepField {
+				continue
 			}
 			if field.Type == FieldTypeNullableDecimal128 && isNull {
 				nulls[field.Name] = true
@@ -129,6 +163,9 @@ func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[
 				}
 				return err
 			}
+			if !keepField {
+				continue
+			}
 			// No useful float64 representation; record stores 0 to keep
 			// the values map populated for callers that index by name.
 			values[field.Name] = 0
@@ -144,6 +181,9 @@ func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[
 				}
 				return err
 			}
+			if !keepField {
+				continue
+			}
 			values[field.Name] = float64(c)
 			if wide != nil {
 				wide[field.Name] = c
@@ -156,6 +196,9 @@ func (rr *RecordReader) ReadRecordWithWide(values map[string]float64, nulls map[
 					return io.EOF
 				}
 				return err
+			}
+			if !keepField {
+				continue
 			}
 			values[field.Name] = rawToFloat64(field.Type, raw)
 		}

--- a/encoding/reader_projected_test.go
+++ b/encoding/reader_projected_test.go
@@ -1,0 +1,135 @@
+package encoding
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+// TestReadRecordProjected_SkipsMapWritesButAdvancesBytes verifies that
+// ReadRecordWithWideProjected skips map writes for excluded fields but
+// still consumes their on-wire bytes, so the byte cursor stays aligned
+// for fields that follow.
+func TestReadRecordProjected_SkipsMapWritesButAdvancesBytes(t *testing.T) {
+	schema := &Schema{
+		Fields: []Field{
+			{Name: "id", Type: FieldTypeU32, ByteOffset: 0, CsvColumnIdx: 0},
+			{Name: "v", Type: FieldTypeF64, ByteOffset: 4, CsvColumnIdx: 1},
+			{Name: "y", Type: FieldTypeU16, ByteOffset: 12, CsvColumnIdx: 2},
+		},
+	}
+
+	// Write one record manually: id=42, v=3.14, y=7.
+	var buf bytes.Buffer
+	if err := WriteFieldValue(&buf, FieldTypeU32, 42); err != nil {
+		t.Fatalf("write id: %v", err)
+	}
+	if err := WriteFieldValue(&buf, FieldTypeF64, math.Float64bits(3.14)); err != nil {
+		t.Fatalf("write v: %v", err)
+	}
+	if err := WriteFieldValue(&buf, FieldTypeU16, 7); err != nil {
+		t.Fatalf("write y: %v", err)
+	}
+
+	rr := NewRecordReader(bytes.NewReader(buf.Bytes()), schema)
+	values := make(map[string]float64)
+	nulls := make(map[string]bool)
+	wide := make(map[string]any)
+	keep := func(name string) bool { return name == "y" }
+	if err := rr.ReadRecordWithWideProjected(values, nulls, wide, keep); err != nil {
+		t.Fatalf("ReadRecordWithWideProjected: %v", err)
+	}
+
+	if _, ok := values["id"]; ok {
+		t.Errorf("id should be excluded from values map")
+	}
+	if _, ok := values["v"]; ok {
+		t.Errorf("v should be excluded from values map")
+	}
+	got, ok := values["y"]
+	if !ok {
+		t.Fatalf("y missing from values map")
+	}
+	if got != 7 {
+		t.Errorf("y = %v, want 7", got)
+	}
+}
+
+// TestReadRecordProjected_PackedBoolNeighborAlignment exercises the
+// byte-cursor advance through a packed_bool field that the caller
+// projects out. The fixed-width neighbour AFTER the packed field must
+// still decode correctly.
+func TestReadRecordProjected_PackedBoolNeighborAlignment(t *testing.T) {
+	schema := &Schema{
+		Fields: []Field{
+			{Name: "a", Type: FieldTypeU8, ByteOffset: 0, CsvColumnIdx: 0},
+			{Name: "flag", Type: FieldTypePackedBool, ByteOffset: 1, BitPosition: 0, CsvColumnIdx: 1},
+			{Name: "b", Type: FieldTypeU32, ByteOffset: 2, CsvColumnIdx: 2},
+		},
+	}
+
+	// On-wire: 1 byte for a, 1 byte for the packed flag (single bit), 4
+	// bytes for b. Mirrors the import.go writer convention.
+	var buf bytes.Buffer
+	if err := WriteFieldValue(&buf, FieldTypeU8, 5); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := WriteBit(&buf, 0, true); err != nil {
+		t.Fatalf("write flag: %v", err)
+	}
+	if err := WriteFieldValue(&buf, FieldTypeU32, 99); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+
+	rr := NewRecordReader(bytes.NewReader(buf.Bytes()), schema)
+	values := make(map[string]float64)
+	nulls := make(map[string]bool)
+	wide := make(map[string]any)
+	keep := func(name string) bool { return name == "b" }
+	if err := rr.ReadRecordWithWideProjected(values, nulls, wide, keep); err != nil {
+		t.Fatalf("ReadRecordWithWideProjected: %v", err)
+	}
+
+	if _, ok := values["a"]; ok {
+		t.Errorf("a should be excluded")
+	}
+	if _, ok := values["flag"]; ok {
+		t.Errorf("flag should be excluded")
+	}
+	got, ok := values["b"]
+	if !ok {
+		t.Fatalf("b missing from values map")
+	}
+	if got != 99 {
+		t.Errorf("b = %v, want 99 (byte cursor misaligned through packed_bool)", got)
+	}
+}
+
+// TestReadRecordProjected_NilFilterFallsThrough verifies that passing a
+// nil FieldFilter populates every field — identical behaviour to
+// ReadRecordWithWide.
+func TestReadRecordProjected_NilFilterFallsThrough(t *testing.T) {
+	schema := &Schema{
+		Fields: []Field{
+			{Name: "a", Type: FieldTypeU8, ByteOffset: 0, CsvColumnIdx: 0},
+			{Name: "b", Type: FieldTypeU16, ByteOffset: 1, CsvColumnIdx: 1},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteFieldValue(&buf, FieldTypeU8, 1); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := WriteFieldValue(&buf, FieldTypeU16, 2); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	rr := NewRecordReader(bytes.NewReader(buf.Bytes()), schema)
+	values := make(map[string]float64)
+	nulls := make(map[string]bool)
+	wide := make(map[string]any)
+	if err := rr.ReadRecordWithWideProjected(values, nulls, wide, nil); err != nil {
+		t.Fatalf("ReadRecordWithWideProjected: %v", err)
+	}
+	if values["a"] != 1 || values["b"] != 2 {
+		t.Errorf("nil filter must keep every field, got %v", values)
+	}
+}

--- a/extensions.go
+++ b/extensions.go
@@ -1,12 +1,26 @@
 package pulse
 
 import (
+	"encoding/json"
+
 	"github.com/frankbardon/pulse/encoding"
 	"github.com/frankbardon/pulse/processing"
 	"github.com/frankbardon/pulse/processing/feature"
 	"github.com/frankbardon/pulse/processing/window"
 	"github.com/frankbardon/pulse/types"
 )
+
+// FieldInputsFunc is the optional introspection callback an extension
+// registration may supply so the buffered-projection extractor can
+// determine which extra schema fields the operator reads beyond the
+// spec's explicit Field/Field2/PartitionBy/etc. references. raw is the
+// operator's Params block. Return value lists schema field names to
+// include; nil/empty means "no extra fields."
+//
+// Embedders that omit this hook leave their operator opaque to the
+// projection extractor — the runtime then widens the buffered-decode
+// field set to "every field" so the operator stays correct.
+type FieldInputsFunc func(raw json.RawMessage) []string
 
 // Extensions bundles every per-category registration slot plus the
 // expression-environment additions an embedder wants exposed to
@@ -68,6 +82,11 @@ type AggregatorRegistration struct {
 	Streamable  bool
 	Accepts     []encoding.FieldType
 	Params      []ParamMeta
+	// FieldInputs is the optional buffered-projection introspection
+	// hook. See FieldInputsFunc. Omit to keep the operator opaque to
+	// projection (runtime widens the field set when this operator
+	// appears in a request).
+	FieldInputs FieldInputsFunc
 }
 
 // AttributeMode declares which streaming tier an attribute factory
@@ -106,6 +125,9 @@ type AttributeRegistration struct {
 	Accepts     []encoding.FieldType
 	Emits       AttributeEmitType
 	Params      []ParamMeta
+	// FieldInputs is the optional buffered-projection introspection
+	// hook. See FieldInputsFunc.
+	FieldInputs FieldInputsFunc
 }
 
 // FiltererRegistration installs a custom FILTER_* operator. Filterers
@@ -119,6 +141,12 @@ type FiltererRegistration struct {
 	Factory     processing.FiltererFactory
 	Accepts     []encoding.FieldType
 	Params      []ParamMeta
+	// FieldInputs is the optional buffered-projection introspection
+	// hook. See FieldInputsFunc. Filterers don't carry a Params
+	// block today; the callback receives nil raw bytes and should
+	// return the static set of extra fields the filterer reads
+	// beyond Filterer.Field.
+	FieldInputs FieldInputsFunc
 }
 
 // GrouperRegistration installs a custom GROUP_* operator. Set
@@ -131,6 +159,9 @@ type GrouperRegistration struct {
 	Streamable  bool
 	Accepts     []encoding.FieldType
 	Params      []ParamMeta
+	// FieldInputs is the optional buffered-projection introspection
+	// hook. See FieldInputsFunc.
+	FieldInputs FieldInputsFunc
 }
 
 // WindowRegistration installs a custom WIN_* operator. Window
@@ -143,6 +174,9 @@ type WindowRegistration struct {
 	Factory     window.WindowFactory
 	Accepts     []encoding.FieldType
 	Params      []ParamMeta
+	// FieldInputs is the optional buffered-projection introspection
+	// hook. See FieldInputsFunc.
+	FieldInputs FieldInputsFunc
 }
 
 // FeatureRegistration installs a custom FEAT_* operator. Set
@@ -155,6 +189,9 @@ type FeatureRegistration struct {
 	Streamable  bool
 	Accepts     []encoding.FieldType
 	Params      []ParamMeta
+	// FieldInputs is the optional buffered-projection introspection
+	// hook. See FieldInputsFunc.
+	FieldInputs FieldInputsFunc
 }
 
 // TestTier selects which factory shape a TestRegistration provides.
@@ -182,6 +219,11 @@ type TestRegistration struct {
 	Streamable  bool
 	Accepts     []encoding.FieldType
 	Params      []ParamMeta
+	// FieldInputs is the optional buffered-projection introspection
+	// hook for tier-1 row tests. Tier-2 post-tests run on materialized
+	// result rows rather than source records, so projection doesn't
+	// apply — leave nil for tier-2 registrations.
+	FieldInputs FieldInputsFunc
 }
 
 // DistributionRegistration installs a custom synthetic-data

--- a/extensions_runtime.go
+++ b/extensions_runtime.go
@@ -26,7 +26,15 @@ func buildRuntimeExtensions(ext Extensions) *processing.ExtensionRegistry {
 	}
 
 	r := &processing.ExtensionRegistry{
-		Streamable: make(map[string]bool),
+		Streamable:  make(map[string]bool),
+		FieldInputs: make(map[string]processing.FieldInputsFunc),
+	}
+
+	addFieldInputs := func(category, name string, fn FieldInputsFunc) {
+		if fn == nil {
+			return
+		}
+		r.FieldInputs[processing.StreamabilityKey(category, name)] = processing.FieldInputsFunc(fn)
 	}
 
 	if len(ext.ExprFunctions) > 0 {
@@ -54,6 +62,7 @@ func buildRuntimeExtensions(ext Extensions) *processing.ExtensionRegistry {
 		for _, reg := range ext.Aggregators {
 			r.Aggregators[reg.Name] = reg.Factory
 			r.Streamable[processing.StreamabilityKey("aggregator", string(reg.Name))] = reg.Streamable
+			addFieldInputs("aggregator", string(reg.Name), reg.FieldInputs)
 		}
 	}
 
@@ -62,6 +71,7 @@ func buildRuntimeExtensions(ext Extensions) *processing.ExtensionRegistry {
 		for _, reg := range ext.Attributes {
 			r.Attributes[reg.Name] = reg.Factory
 			r.Streamable[processing.StreamabilityKey("attribute", string(reg.Name))] = reg.Mode != AttributeModeBuffered
+			addFieldInputs("attribute", string(reg.Name), reg.FieldInputs)
 		}
 	}
 
@@ -71,6 +81,7 @@ func buildRuntimeExtensions(ext Extensions) *processing.ExtensionRegistry {
 			r.Filterers[reg.Name] = reg.Factory
 			// Custom filterers are always row-local streamable today.
 			r.Streamable[processing.StreamabilityKey("filterer", string(reg.Name))] = true
+			addFieldInputs("filterer", string(reg.Name), reg.FieldInputs)
 		}
 	}
 
@@ -79,6 +90,7 @@ func buildRuntimeExtensions(ext Extensions) *processing.ExtensionRegistry {
 		for _, reg := range ext.Groupers {
 			r.Groupers[reg.Name] = reg.Factory
 			r.Streamable[processing.StreamabilityKey("grouper", string(reg.Name))] = reg.Streamable
+			addFieldInputs("grouper", string(reg.Name), reg.FieldInputs)
 		}
 	}
 
@@ -89,6 +101,7 @@ func buildRuntimeExtensions(ext Extensions) *processing.ExtensionRegistry {
 			// Custom windows run buffered today; the runtime path
 			// reflects the built-in behaviour.
 			r.Streamable[processing.StreamabilityKey("window", string(reg.Name))] = false
+			addFieldInputs("window", string(reg.Name), reg.FieldInputs)
 		}
 	}
 
@@ -97,6 +110,7 @@ func buildRuntimeExtensions(ext Extensions) *processing.ExtensionRegistry {
 		for _, reg := range ext.Features {
 			r.Features[reg.Name] = reg.Factory
 			r.Streamable[processing.StreamabilityKey("feature", string(reg.Name))] = reg.Streamable
+			addFieldInputs("feature", string(reg.Name), reg.FieldInputs)
 		}
 	}
 
@@ -109,6 +123,7 @@ func buildRuntimeExtensions(ext Extensions) *processing.ExtensionRegistry {
 				}
 				r.RowTests[reg.Name] = reg.RowFactory
 				r.Streamable[processing.StreamabilityKey("test", string(reg.Name))] = reg.Streamable
+				addFieldInputs("test", string(reg.Name), reg.FieldInputs)
 			case TestTierPost:
 				if r.PostTests == nil {
 					r.PostTests = make(map[types.TestType]processing.PostTestFactory)

--- a/processing/extensions.go
+++ b/processing/extensions.go
@@ -1,12 +1,21 @@
 package processing
 
 import (
+	"encoding/json"
+
 	"github.com/frankbardon/pulse/encoding"
 	"github.com/frankbardon/pulse/errors"
 	"github.com/frankbardon/pulse/processing/feature"
 	"github.com/frankbardon/pulse/processing/window"
 	"github.com/frankbardon/pulse/types"
 )
+
+// FieldInputsFunc reports the additional source-field names an
+// extension operator reads beyond the spec's explicit Field/Field2/
+// PartitionBy/etc. references. raw carries the operator's Params
+// block (may be nil for filterers). Return value is consumed by the
+// buffered-projection extractor; nil/empty means "no extra fields."
+type FieldInputsFunc func(raw json.RawMessage) []string
 
 // ExtensionRegistry holds per-Service overlays for every operator
 // category that supports the public extension API. A nil receiver is
@@ -43,6 +52,15 @@ type ExtensionRegistry struct {
 	// LookupTables are exposed to the runtime expression environment
 	// via the built-in lookup() function. Mirrors pulse.LookupTable.
 	LookupTables map[string]LookupTable
+
+	// FieldInputs is the per-(category, name) field-introspection
+	// callback consulted by the buffered-projection extractor
+	// (NeededFields). When the registry contains an entry for an
+	// extension operator the projection extractor calls the callback
+	// with the operator's raw Params; otherwise the extractor widens
+	// the projection to "every field" so the runtime stays correct
+	// for embedders that haven't opted in.
+	FieldInputs map[string]FieldInputsFunc
 }
 
 // ExprFunction is the runtime-side mirror of pulse.ExprFunction. The
@@ -283,6 +301,29 @@ func (r *ExtensionRegistry) FeatureFactories() map[types.FeatureType]feature.Fac
 		return nil
 	}
 	return r.Features
+}
+
+// FieldInputsFor consults the FieldInputs overlay for the operator
+// identified by (category, name). Returns (inputs, true) when the
+// registration supplied a callback, ([], true) when no extra fields
+// are read, or (nil, false) when the operator is custom but has no
+// registered callback — caller should treat that as "can't introspect"
+// and widen the projection.
+//
+// Built-in operators are not stored in this map; callers should only
+// reach FieldInputsFor for extension-resolved operators.
+func (r *ExtensionRegistry) FieldInputsFor(category, name string, raw json.RawMessage) ([]string, bool) {
+	if r == nil || r.FieldInputs == nil {
+		return nil, false
+	}
+	fn, ok := r.FieldInputs[StreamabilityKey(category, name)]
+	if !ok {
+		return nil, false
+	}
+	if fn == nil {
+		return nil, true
+	}
+	return fn(raw), true
 }
 
 // CustomAggregatorNames returns the overlay-only aggregator names in

--- a/processing/projection.go
+++ b/processing/projection.go
@@ -1,0 +1,361 @@
+package processing
+
+import (
+	"encoding/json"
+
+	exprast "github.com/expr-lang/expr/ast"
+	exprparser "github.com/expr-lang/expr/parser"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/types"
+)
+
+// FieldSet is an order-insignificant set of schema field names that
+// must be decoded into each Record during the buffered Process path.
+// The sentinel "*" entry means "no projection — keep every field" and
+// short-circuits Has() to true; callers that produced a wide set should
+// fall back to the full-decode path rather than try to project.
+type FieldSet map[string]struct{}
+
+// NewFieldSet returns an empty FieldSet sized for hint members.
+func NewFieldSet(hint int) FieldSet {
+	if hint < 4 {
+		hint = 4
+	}
+	return make(FieldSet, hint)
+}
+
+// Add inserts name into the set. Empty names are ignored.
+func (s FieldSet) Add(name string) {
+	if name == "" {
+		return
+	}
+	s[name] = struct{}{}
+}
+
+// Widen marks the set as covering every field. After this call Has()
+// returns true for any name. Used when extraction can't be proven
+// complete — for example a malformed expression or an extension
+// operator without an introspection hook.
+func (s FieldSet) Widen() {
+	s["*"] = struct{}{}
+}
+
+// IsWide reports whether the set has been widened to cover every field.
+func (s FieldSet) IsWide() bool {
+	_, ok := s["*"]
+	return ok
+}
+
+// Has reports whether name is in the set. Returns true for every name
+// when the set has been widened.
+func (s FieldSet) Has(name string) bool {
+	if _, ok := s["*"]; ok {
+		return true
+	}
+	_, ok := s[name]
+	return ok
+}
+
+// Len returns the number of explicitly listed fields. Returns the
+// schema field count when the set is wide (caller-supplied schema
+// resolves the count; pass len(schema.Fields) at the call site).
+func (s FieldSet) Len() int {
+	if _, ok := s["*"]; ok {
+		// Caller knows the schema size; we report explicit entries only.
+		return len(s) - 1
+	}
+	return len(s)
+}
+
+// NeededFields walks req against schema and returns the set of source
+// field names that the buffered or streaming path must decode into
+// each Record so every requested operator output computes correctly.
+//
+// When extraction can't prove completeness (malformed expression,
+// extension operator without a FieldInputs hook) the returned set is
+// widened and callers should fall back to the full-decode path.
+//
+// The ext argument may be nil — in that case any custom operator in
+// req that resolves only via overlay would still produce a wide set
+// because we'd have no introspection. Built-in operators are fully
+// introspectable here.
+func NeededFields(req *types.Request, schema *encoding.Schema, ext *ExtensionRegistry) FieldSet {
+	out := NewFieldSet(8)
+	if req == nil || schema == nil {
+		out.Widen()
+		return out
+	}
+
+	known := schemaFieldSet(schema)
+
+	addKnown := func(name string) {
+		if _, ok := known[name]; ok {
+			out.Add(name)
+		}
+	}
+	addAllKnown := func(names []string) {
+		for _, n := range names {
+			addKnown(n)
+		}
+	}
+
+	for _, f := range req.Filterers {
+		if f == nil {
+			continue
+		}
+		addKnown(f.Field)
+		if f.Type == types.FILTER_EXPRESSION && f.Expression != "" {
+			if !appendExprIdents(out, f.Expression, known) {
+				out.Widen()
+				return out
+			}
+		}
+	}
+
+	for _, a := range req.Aggregations {
+		if a == nil {
+			continue
+		}
+		addKnown(a.Field)
+	}
+
+	for _, a := range req.Attributes {
+		if a == nil {
+			continue
+		}
+		addKnown(a.Field)
+		addKnown(a.Target)
+		addAllKnown(a.Predictors)
+		if a.Type == types.ATTR_FORMULA && a.Expression != "" {
+			if !appendExprIdents(out, a.Expression, known) {
+				out.Widen()
+				return out
+			}
+		}
+	}
+
+	for _, g := range req.Groups {
+		if g == nil {
+			continue
+		}
+		addKnown(g.Field)
+	}
+
+	for _, w := range req.Windows {
+		if w == nil {
+			continue
+		}
+		addKnown(w.Field)
+		addAllKnown(w.PartitionBy)
+		for _, k := range w.OrderBy {
+			addKnown(k.Field)
+		}
+	}
+
+	for _, f := range req.Features {
+		if f == nil {
+			continue
+		}
+		addKnown(f.Field)
+		// Built-in features whose Params reference additional fields.
+		switch f.Type {
+		case types.FEAT_TRAIN_TEST_SPLIT:
+			if name, ok := jsonStringField(f.Params, "stratify"); ok {
+				addKnown(name)
+			}
+		case types.FEAT_TARGET_ENCODE:
+			if name, ok := jsonStringField(f.Params, "target"); ok {
+				addKnown(name)
+			}
+		}
+		// Extension features: defer to the registered FieldInputs hook
+		// if any; otherwise widen.
+		if ext != nil {
+			if _, custom := ext.Features[f.Type]; custom {
+				inputs, ok := ext.FieldInputsFor("feature", string(f.Type), f.Params)
+				if !ok {
+					out.Widen()
+					return out
+				}
+				addAllKnown(inputs)
+			}
+		}
+	}
+
+	for _, t := range req.Tests {
+		if t == nil {
+			continue
+		}
+		addKnown(t.Field)
+		addKnown(t.Field2)
+		addKnown(t.SplitBy)
+		addKnown(t.Rows)
+		addKnown(t.Cols)
+		addKnown(t.SubjectField)
+		for _, k := range t.OrderBy {
+			addKnown(k.Field)
+		}
+		if ext != nil {
+			if _, custom := ext.RowTests[t.Type]; custom {
+				inputs, ok := ext.FieldInputsFor("test", string(t.Type), t.Params)
+				if !ok {
+					out.Widen()
+					return out
+				}
+				addAllKnown(inputs)
+			}
+		}
+	}
+	// PostTests run on materialized result rows, not source records.
+
+	for _, r := range req.Regressions {
+		if r == nil {
+			continue
+		}
+		addKnown(r.Target)
+		addAllKnown(r.Predictors)
+	}
+
+	for _, k := range req.Sort {
+		// Sort keys may name output labels rather than schema fields;
+		// addKnown ignores non-schema names.
+		addKnown(k.Field)
+	}
+
+	// Extension operators in non-feature/test categories: widen when a
+	// custom operator is registered but offers no introspection hook.
+	if ext != nil {
+		for _, a := range req.Aggregations {
+			if a == nil {
+				continue
+			}
+			if _, custom := ext.Aggregators[a.Type]; custom {
+				inputs, ok := ext.FieldInputsFor("aggregator", string(a.Type), a.Params)
+				if !ok {
+					out.Widen()
+					return out
+				}
+				addAllKnown(inputs)
+			}
+		}
+		for _, a := range req.Attributes {
+			if a == nil {
+				continue
+			}
+			if _, custom := ext.Attributes[a.Type]; custom {
+				inputs, ok := ext.FieldInputsFor("attribute", string(a.Type), a.Params)
+				if !ok {
+					out.Widen()
+					return out
+				}
+				addAllKnown(inputs)
+			}
+		}
+		for _, f := range req.Filterers {
+			if f == nil {
+				continue
+			}
+			if _, custom := ext.Filterers[f.Type]; custom {
+				inputs, ok := ext.FieldInputsFor("filterer", string(f.Type), nil)
+				if !ok {
+					out.Widen()
+					return out
+				}
+				addAllKnown(inputs)
+			}
+		}
+		for _, g := range req.Groups {
+			if g == nil {
+				continue
+			}
+			if _, custom := ext.Groupers[g.Type]; custom {
+				inputs, ok := ext.FieldInputsFor("grouper", string(g.Type), g.Params)
+				if !ok {
+					out.Widen()
+					return out
+				}
+				addAllKnown(inputs)
+			}
+		}
+		for _, w := range req.Windows {
+			if w == nil {
+				continue
+			}
+			if _, custom := ext.Windows[w.Type]; custom {
+				inputs, ok := ext.FieldInputsFor("window", string(w.Type), w.Params)
+				if !ok {
+					out.Widen()
+					return out
+				}
+				addAllKnown(inputs)
+			}
+		}
+	}
+
+	return out
+}
+
+// schemaFieldSet returns the field-name set for the schema.
+func schemaFieldSet(schema *encoding.Schema) map[string]struct{} {
+	m := make(map[string]struct{}, len(schema.Fields))
+	for _, f := range schema.Fields {
+		m[f.Name] = struct{}{}
+	}
+	return m
+}
+
+// appendExprIdents parses src as an expr-lang expression and adds every
+// identifier that matches a schema field name to out. Returns false
+// when the expression fails to parse — caller must widen the set.
+func appendExprIdents(out FieldSet, src string, known map[string]struct{}) bool {
+	tree, err := exprparser.Parse(src)
+	if err != nil {
+		return false
+	}
+	exprast.Walk(&tree.Node, &exprIdentVisitor{out: out, known: known})
+	return true
+}
+
+// exprIdentVisitor collects IdentifierNode values that match schema
+// field names. Member access (e.g., date.year) is rooted at the base
+// identifier so the underlying source field is captured.
+type exprIdentVisitor struct {
+	out   FieldSet
+	known map[string]struct{}
+}
+
+func (v *exprIdentVisitor) Visit(node *exprast.Node) {
+	id, ok := (*node).(*exprast.IdentifierNode)
+	if !ok {
+		return
+	}
+	if _, ok := v.known[id.Value]; ok {
+		v.out.Add(id.Value)
+	}
+}
+
+// jsonStringField unmarshals a single string-valued key from a raw
+// JSON params block. Returns (value, true) on a clean match, ("",
+// false) on any decode failure or absence.
+func jsonStringField(raw json.RawMessage, key string) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", false
+	}
+	v, ok := m[key]
+	if !ok {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", false
+	}
+	if s == "" {
+		return "", false
+	}
+	return s, true
+}

--- a/processing/projection_test.go
+++ b/processing/projection_test.go
@@ -1,0 +1,299 @@
+package processing
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/types"
+)
+
+func mkSchema(names ...string) *encoding.Schema {
+	fields := make([]encoding.Field, len(names))
+	off := 0
+	for i, n := range names {
+		fields[i] = encoding.Field{Name: n, Type: encoding.FieldTypeF64, ByteOffset: off, CsvColumnIdx: i}
+		off += 8
+	}
+	return &encoding.Schema{Fields: fields}
+}
+
+func sortedFields(s FieldSet) []string {
+	out := make([]string, 0, len(s))
+	for name := range s {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestNeededFields_AggregationOnly(t *testing.T) {
+	schema := mkSchema("a", "b", "c")
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "b"},
+		},
+	}
+	got := NeededFields(req, schema, nil)
+	if got.IsWide() {
+		t.Fatalf("expected narrow set, got wide")
+	}
+	want := []string{"b"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_GroupAndFilter(t *testing.T) {
+	schema := mkSchema("a", "b", "c", "d")
+	req := &types.Request{
+		Filterers: []*types.Filterer{
+			{Type: types.FILTER_INCLUDE, Field: "a", Values: []string{"1"}},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_AVERAGE, Field: "b"},
+		},
+		Groups: []*types.Group{
+			{Type: types.GROUP_CATEGORY, Field: "c"},
+		},
+	}
+	got := NeededFields(req, schema, nil)
+	want := []string{"a", "b", "c"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_WindowReferencesPartitionAndOrder(t *testing.T) {
+	schema := mkSchema("a", "b", "ts", "cat", "v")
+	req := &types.Request{
+		Windows: []*types.Window{{
+			Type:        types.WIN_MOVING_AVG,
+			Field:       "v",
+			PartitionBy: []string{"cat"},
+			OrderBy:     []types.OrderKey{{Field: "ts"}},
+		}},
+	}
+	got := NeededFields(req, schema, nil)
+	want := []string{"cat", "ts", "v"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_AttributeFormulaExtractsIdents(t *testing.T) {
+	schema := mkSchema("a", "b", "c", "d")
+	req := &types.Request{
+		Attributes: []*types.Attribute{{
+			Type:       types.ATTR_FORMULA,
+			Field:      "a",
+			Expression: "a + b * c",
+		}},
+	}
+	got := NeededFields(req, schema, nil)
+	if got.IsWide() {
+		t.Fatalf("expected narrow set, got wide")
+	}
+	want := []string{"a", "b", "c"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_FilterExpressionExtractsIdents(t *testing.T) {
+	schema := mkSchema("price", "qty", "name", "unused")
+	req := &types.Request{
+		Filterers: []*types.Filterer{{
+			Type:       types.FILTER_EXPRESSION,
+			Expression: "price * qty > 100 && name == \"x\"",
+		}},
+	}
+	got := NeededFields(req, schema, nil)
+	if got.IsWide() {
+		t.Fatalf("expected narrow set, got wide")
+	}
+	want := []string{"name", "price", "qty"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_MalformedExpressionWidens(t *testing.T) {
+	schema := mkSchema("a", "b")
+	req := &types.Request{
+		Attributes: []*types.Attribute{{
+			Type:       types.ATTR_FORMULA,
+			Field:      "a",
+			Expression: "this is ( not parseable",
+		}},
+	}
+	got := NeededFields(req, schema, nil)
+	if !got.IsWide() {
+		t.Fatalf("expected wide set on malformed expression, got %v", sortedFields(got))
+	}
+}
+
+func TestNeededFields_TestFieldsCaptured(t *testing.T) {
+	schema := mkSchema("score", "group", "subject", "unused")
+	req := &types.Request{
+		Tests: []*types.Test{{
+			Type:         types.TEST_ANOVA_RM,
+			Field:        "score",
+			SplitBy:      "group",
+			SubjectField: "subject",
+		}},
+	}
+	got := NeededFields(req, schema, nil)
+	want := []string{"group", "score", "subject"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_RegressionTargetAndPredictors(t *testing.T) {
+	schema := mkSchema("y", "x1", "x2", "x3", "unused")
+	req := &types.Request{
+		Regressions: []*types.RegressionSpec{{
+			Type:       types.REG_OLS,
+			Target:     "y",
+			Predictors: []string{"x1", "x2"},
+		}},
+	}
+	got := NeededFields(req, schema, nil)
+	want := []string{"x1", "x2", "y"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_FeatureStratifyFromParams(t *testing.T) {
+	schema := mkSchema("a", "label", "unused")
+	req := &types.Request{
+		Features: []*types.Feature{{
+			Type:   types.FEAT_TRAIN_TEST_SPLIT,
+			Params: json.RawMessage(`{"ratios":[0.8,0.2],"seed":1,"stratify":"label"}`),
+		}},
+	}
+	got := NeededFields(req, schema, nil)
+	want := []string{"label"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_FeatureTargetEncodeFromParams(t *testing.T) {
+	schema := mkSchema("category", "outcome", "unused")
+	req := &types.Request{
+		Features: []*types.Feature{{
+			Type:   types.FEAT_TARGET_ENCODE,
+			Field:  "category",
+			Params: json.RawMessage(`{"target":"outcome","smoothing":0.5}`),
+		}},
+	}
+	got := NeededFields(req, schema, nil)
+	want := []string{"category", "outcome"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_UnknownExtensionWidens(t *testing.T) {
+	schema := mkSchema("a", "b")
+	ext := &ExtensionRegistry{
+		Aggregators: map[types.AggregationType]AggregatorFactory{
+			types.AggregationType("AGG_CUSTOM_X"): nil,
+		},
+		// No FieldInputs registered for AGG_CUSTOM_X.
+	}
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{
+			{Type: types.AggregationType("AGG_CUSTOM_X"), Field: "a", Params: json.RawMessage(`{}`)},
+		},
+	}
+	got := NeededFields(req, schema, ext)
+	if !got.IsWide() {
+		t.Fatalf("expected wide set when extension lacks FieldInputs, got %v", sortedFields(got))
+	}
+}
+
+func TestNeededFields_ExtensionWithFieldInputs(t *testing.T) {
+	schema := mkSchema("a", "b", "c", "d")
+	ext := &ExtensionRegistry{
+		Aggregators: map[types.AggregationType]AggregatorFactory{
+			types.AggregationType("AGG_CUSTOM_X"): nil,
+		},
+		FieldInputs: map[string]FieldInputsFunc{
+			StreamabilityKey("aggregator", "AGG_CUSTOM_X"): func(json.RawMessage) []string {
+				return []string{"b", "c"}
+			},
+		},
+	}
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{
+			{Type: types.AggregationType("AGG_CUSTOM_X"), Field: "a"},
+		},
+	}
+	got := NeededFields(req, schema, ext)
+	if got.IsWide() {
+		t.Fatalf("expected narrow set when FieldInputs registered, got wide")
+	}
+	want := []string{"a", "b", "c"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_UnknownNamesDropped(t *testing.T) {
+	schema := mkSchema("a", "b")
+	req := &types.Request{
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "not_in_schema"},
+			{Type: types.AGG_SUM, Field: "b"},
+		},
+	}
+	got := NeededFields(req, schema, nil)
+	want := []string{"b"}
+	if g := sortedFields(got); !equalStrings(g, want) {
+		t.Errorf("fields = %v, want %v", g, want)
+	}
+}
+
+func TestNeededFields_NilInputsWiden(t *testing.T) {
+	if !NeededFields(nil, mkSchema("a"), nil).IsWide() {
+		t.Errorf("nil request must widen")
+	}
+	if !NeededFields(&types.Request{}, nil, nil).IsWide() {
+		t.Errorf("nil schema must widen")
+	}
+}
+
+func TestFieldSet_HasAndWiden(t *testing.T) {
+	s := NewFieldSet(2)
+	s.Add("a")
+	if !s.Has("a") {
+		t.Error("expected Has(a) = true")
+	}
+	if s.Has("b") {
+		t.Error("expected Has(b) = false before widen")
+	}
+	s.Widen()
+	if !s.Has("anything") {
+		t.Error("expected Has = true after Widen")
+	}
+	if !s.IsWide() {
+		t.Error("expected IsWide = true after Widen")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pulse.go
+++ b/pulse.go
@@ -123,6 +123,22 @@ type Options struct {
 	// Zero value disables the extension path entirely. See
 	// extensions.go for the full surface.
 	Extensions Extensions
+
+	// ProjectBufferedFields enables buffered-decode field projection.
+	// When true the runtime walks each request to compute the set of
+	// schema fields the operators actually read (processing.NeededFields)
+	// and skips map writes for fields outside that set. Per-record
+	// memory drops proportional to the projection ratio. Decode CPU
+	// is unchanged.
+	//
+	// Defaults to false to preserve byte-identical behavior with the
+	// pre-projection codepath. Embedders with wide cohorts (many
+	// fields) and narrow requests (few referenced) see the largest
+	// win. Extension operators without a registered FieldInputs hook
+	// widen the projection automatically, so enabling this flag is
+	// always safe — the worst case degenerates to the full-decode
+	// behaviour.
+	ProjectBufferedFields bool
 }
 
 // Pulse is the top-level library facade. It wraps the service layer and
@@ -172,6 +188,7 @@ func New(opts Options) (*Pulse, error) {
 
 	svc := service.New(fsCfg)
 	svc.SetDisableDefaults(opts.DisableDefaults)
+	svc.SetProjectBufferedFields(opts.ProjectBufferedFields)
 	svc.SetExtensions(buildRuntimeExtensions(opts.Extensions))
 	svc.SetExtensionsSnapshot(buildExtensionsSnapshot(opts.Extensions))
 

--- a/service/projection_test.go
+++ b/service/projection_test.go
@@ -1,0 +1,256 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/types"
+)
+
+// sortRowsByKey returns a copy of rows sorted by the value at key. Used
+// to compare grouped query results that come back in non-deterministic
+// map-iteration order on both projection paths.
+func sortRowsByKey(rows []map[string]any, key string) []map[string]any {
+	out := make([]map[string]any, len(rows))
+	copy(out, rows)
+	sort.Slice(out, func(i, j int) bool {
+		return fmt.Sprint(out[i][key]) < fmt.Sprint(out[j][key])
+	})
+	return out
+}
+
+// wideSchema returns a 6-field schema covering scalar numeric and
+// categorical types. Used to exercise projection across heterogeneous
+// field-type advancement on the wire.
+func wideSchema() *encoding.Schema {
+	dict := encoding.NewDictionary()
+	for _, v := range []string{"red", "green", "blue", "yellow"} {
+		_, _ = dict.Add(v)
+	}
+	return &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "id", Type: encoding.FieldTypeU32, ByteOffset: 0, CsvColumnIdx: 0},
+			{Name: "v", Type: encoding.FieldTypeF64, ByteOffset: 4, CsvColumnIdx: 1},
+			{Name: "color", Type: encoding.FieldTypeCategoricalU8, ByteOffset: 12, CsvColumnIdx: 2, Dictionary: dict},
+			{Name: "x", Type: encoding.FieldTypeF64, ByteOffset: 13, CsvColumnIdx: 3},
+			{Name: "y", Type: encoding.FieldTypeU16, ByteOffset: 21, CsvColumnIdx: 4},
+			{Name: "z", Type: encoding.FieldTypeF32, ByteOffset: 23, CsvColumnIdx: 5},
+		},
+	}
+}
+
+func wideRecords() [][]uint64 {
+	out := make([][]uint64, 0, 12)
+	for i := uint64(0); i < 12; i++ {
+		out = append(out, []uint64{
+			i + 1,                            // id
+			math.Float64bits(float64(i)),     // v
+			i % 4,                            // color
+			math.Float64bits(float64(i * 2)), // x
+			i % 65535,                        // y
+			uint64(math.Float32bits(float32(i) * 0.5)),
+		})
+	}
+	return out
+}
+
+// runBoth runs the request twice — once with projection disabled, once with
+// it enabled — and returns the two responses. The caller compares them.
+func runBoth(t *testing.T, req *types.Request) (full, proj *types.Response) {
+	t.Helper()
+
+	schema := wideSchema()
+	cfg := setupTestFS(t, "wide.pulse", schema, wideRecords())
+
+	svcOff := New(cfg)
+	respOff, err := svcOff.Process(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Process (projection off): %v", err)
+	}
+
+	svcOn := New(cfg)
+	svcOn.SetProjectBufferedFields(true)
+	respOn, err := svcOn.Process(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Process (projection on): %v", err)
+	}
+
+	return respOff, respOn
+}
+
+func TestProjection_BufferedMatchesFullDecode_Aggregation(t *testing.T) {
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "wide.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "v", Label: "sum_v"},
+			{Type: types.AGG_AVERAGE, Field: "x", Label: "avg_x"},
+		},
+	}
+	full, proj := runBoth(t, req)
+	if !reflect.DeepEqual(full.Data, proj.Data) {
+		t.Errorf("data differs:\n full: %v\n proj: %v", full.Data, proj.Data)
+	}
+}
+
+func TestProjection_BufferedMatchesFullDecode_Grouped(t *testing.T) {
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "wide.pulse"},
+		Groups: []*types.Group{
+			{Type: types.GROUP_CATEGORY, Field: "color"},
+		},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_AVERAGE, Field: "v", Label: "avg_v"},
+			{Type: types.AGG_COUNT, Field: "v", Label: "n"},
+		},
+	}
+	full, proj := runBoth(t, req)
+	fullSorted := sortRowsByKey(full.Data, "color")
+	projSorted := sortRowsByKey(proj.Data, "color")
+	if !reflect.DeepEqual(fullSorted, projSorted) {
+		t.Errorf("grouped data differs:\n full: %v\n proj: %v", fullSorted, projSorted)
+	}
+}
+
+func TestProjection_BufferedMatchesFullDecode_FilterExpression(t *testing.T) {
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "wide.pulse"},
+		Filterers: []*types.Filterer{{
+			Type:       types.FILTER_EXPRESSION,
+			Expression: "v > 3 && x < 18",
+		}},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_COUNT, Field: "v", Label: "n"},
+		},
+	}
+	full, proj := runBoth(t, req)
+	if !reflect.DeepEqual(full.Data, proj.Data) {
+		t.Errorf("filter-expr data differs:\n full: %v\n proj: %v", full.Data, proj.Data)
+	}
+}
+
+func TestProjection_BufferedMatchesFullDecode_AttributeFormula(t *testing.T) {
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "wide.pulse"},
+		Attributes: []*types.Attribute{{
+			Type:       types.ATTR_FORMULA,
+			Field:      "v",
+			Expression: "v + x",
+			Label:      "sum_vx",
+		}},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "sum_vx", Label: "total"},
+		},
+	}
+	full, proj := runBoth(t, req)
+	if !reflect.DeepEqual(full.Data, proj.Data) {
+		t.Errorf("attribute-formula data differs:\n full: %v\n proj: %v", full.Data, proj.Data)
+	}
+}
+
+func TestProjection_ByteCursorAlignmentWhenSkipping(t *testing.T) {
+	// Request reads only y (16-bit field positioned AFTER a heterogeneous
+	// run of u32/f64/categorical/f64). Projection skips id/v/color/x but
+	// bytes for them still advance — y decodes correctly only when the
+	// byte cursor stays aligned.
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "wide.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "y", Label: "sum_y"},
+		},
+	}
+	full, proj := runBoth(t, req)
+	if !reflect.DeepEqual(full.Data, proj.Data) {
+		t.Fatalf("byte-cursor alignment broke when fields were skipped:\n full: %v\n proj: %v", full.Data, proj.Data)
+	}
+}
+
+func TestProjection_RespectsDisableFlag(t *testing.T) {
+	// With projection disabled, even narrow requests should decode every
+	// field — verified indirectly by stream iterator returning records
+	// whose values map contains every schema field.
+	schema := wideSchema()
+	cfg := setupTestFS(t, "wide.pulse", schema, wideRecords())
+	svc := New(cfg)
+	// projection NOT enabled.
+
+	iter := newStreamingIterator(cfg.Fs(), "wide.pulse", schema)
+	defer iter.Close()
+	svc.applyProjection(iter, &types.Request{
+		Cohort: &types.Cohort{Filename: "wide.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "v"},
+		},
+	}, schema)
+	if iter.project != nil {
+		t.Errorf("expected iter.project == nil when ProjectBufferedFields is off")
+	}
+}
+
+func TestProjection_ProjectsToNarrowSet(t *testing.T) {
+	schema := wideSchema()
+	cfg := setupTestFS(t, "wide.pulse", schema, wideRecords())
+	svc := New(cfg)
+	svc.SetProjectBufferedFields(true)
+
+	iter := newStreamingIterator(cfg.Fs(), "wide.pulse", schema)
+	defer iter.Close()
+	svc.applyProjection(iter, &types.Request{
+		Cohort: &types.Cohort{Filename: "wide.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "v"},
+		},
+	}, schema)
+	if iter.project == nil {
+		t.Fatalf("expected projection filter installed on iter")
+	}
+	if !iter.project("v") {
+		t.Error("filter should accept 'v'")
+	}
+	if iter.project("id") {
+		t.Error("filter should reject 'id'")
+	}
+	if !iter.Next() {
+		t.Fatalf("iter.Next: %v", iter.Err())
+	}
+	rec := iter.Record()
+	if _, ok := rec.NumericValue("v"); !ok {
+		t.Error("record should have 'v' populated")
+	}
+	if _, ok := rec.NumericValue("id"); ok {
+		t.Error("record should NOT have 'id' populated under projection")
+	}
+}
+
+func TestProjection_WideRequestSkipsProjection(t *testing.T) {
+	// A request touching every field shouldn't install projection (no
+	// point — full decode would do the same work without the filter
+	// indirection).
+	schema := wideSchema()
+	cfg := setupTestFS(t, "wide.pulse", schema, wideRecords())
+	svc := New(cfg)
+	svc.SetProjectBufferedFields(true)
+
+	req := &types.Request{
+		Cohort: &types.Cohort{Filename: "wide.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "id"},
+			{Type: types.AGG_SUM, Field: "v"},
+			{Type: types.AGG_SUM, Field: "color"},
+			{Type: types.AGG_SUM, Field: "x"},
+			{Type: types.AGG_SUM, Field: "y"},
+			{Type: types.AGG_SUM, Field: "z"},
+		},
+	}
+
+	iter := newStreamingIterator(cfg.Fs(), "wide.pulse", schema)
+	defer iter.Close()
+	svc.applyProjection(iter, req, schema)
+	if iter.project != nil {
+		t.Errorf("expected no projection installed when request touches every field")
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -20,6 +20,7 @@ import (
 type Service struct {
 	fs              *fs.Config
 	disableDefaults bool
+	projectBuffered bool
 	extensions      *processing.ExtensionRegistry
 	extensionsSnap  *descriptor.ExtensionsSnapshot
 }
@@ -37,6 +38,27 @@ func New(fsConfig *fs.Config) *Service {
 // only what the runtime mutates before Process / Compose execution.
 func (s *Service) SetDisableDefaults(disabled bool) {
 	s.disableDefaults = disabled
+}
+
+// SetProjectBufferedFields enables buffered-decode field projection.
+// When enabled the streaming iterator computes the set of fields a
+// request actually reads (NeededFields) and skips map writes for
+// fields outside that set. Per-record memory drops proportional to
+// the projection ratio; decode CPU is unchanged. Default is false;
+// pulse.Options{ProjectBufferedFields: true} opts in.
+//
+// Extension operators without a registered FieldInputs hook widen
+// the projection to "every field" automatically — projection is
+// always a strict superset of the fields actually consumed, so it
+// can never produce a wrong answer.
+func (s *Service) SetProjectBufferedFields(enabled bool) {
+	s.projectBuffered = enabled
+}
+
+// ProjectBufferedFields reports the current setting. Read by callers
+// that need to know whether to compute NeededFields ahead of time.
+func (s *Service) ProjectBufferedFields() bool {
+	return s.projectBuffered
 }
 
 // SetExtensions installs an ExtensionRegistry containing embedder-
@@ -127,6 +149,8 @@ func (s *Service) Process(ctx context.Context, req *types.Request) (*types.Respo
 	iter := newStreamingIterator(s.fs.Fs(), path, cohort.Schema())
 	defer iter.Close()
 
+	s.applyProjection(iter, req, cohort.Schema())
+
 	proc := processing.NewProcessorWithExtensions(cohort.Schema(), s.extensions)
 	resp, err := proc.Process(ctx, req, iter)
 	if err != nil {
@@ -141,6 +165,28 @@ func (s *Service) Process(ctx context.Context, req *types.Request) (*types.Respo
 	}
 
 	return resp, nil
+}
+
+// applyProjection installs a NeededFields-based projection filter on
+// the streaming iterator when ProjectBufferedFields is enabled and
+// the request's needed-field set is provably narrower than the
+// schema. A wide set (extraction couldn't introspect) leaves the
+// iterator on the full-decode path.
+func (s *Service) applyProjection(iter *streamingIterator, req *types.Request, schema *encoding.Schema) {
+	if !s.projectBuffered || iter == nil || req == nil || schema == nil {
+		return
+	}
+	needed := processing.NeededFields(req, schema, s.extensions)
+	if needed.IsWide() {
+		return
+	}
+	size := needed.Len()
+	if size == 0 || size >= len(schema.Fields) {
+		return
+	}
+	iter.SetProjection(func(name string) bool {
+		return needed.Has(name)
+	}, size)
 }
 
 // AskInput captures the per-call options the facade hands the service.

--- a/service/stream.go
+++ b/service/stream.go
@@ -52,6 +52,15 @@ type streamingIterator struct {
 	// non-OsFs filesystems, or platforms where mmap is unavailable).
 	mmapBytes   []byte
 	mmapCleanup func() error
+
+	// project, when non-nil, scopes the per-record value/null/wide
+	// maps to the names accepted by the filter. Bytes for excluded
+	// fields are still consumed from the reader so the cursor stays
+	// aligned; only the map writes are skipped. nil means full
+	// decode (the default). projectSize is a hint for the per-record
+	// map allocation when projection is active.
+	project     encoding.FieldFilter
+	projectSize int
 }
 
 // newStreamingIterator creates a streaming iterator for the given cohort.
@@ -162,10 +171,19 @@ func (it *streamingIterator) Next() bool {
 	// call, so each Record needs its own backing maps. Allocating once and
 	// having ReadRecord populate them in-place is cheaper than allocating
 	// reusable buffers and then range-copying out.
-	values := make(map[string]float64, len(it.schema.Fields))
+	mapHint := len(it.schema.Fields)
+	if it.project != nil && it.projectSize > 0 {
+		mapHint = it.projectSize
+	}
+	values := make(map[string]float64, mapHint)
 	nulls := make(map[string]bool)
 	wide := make(map[string]any)
-	err := it.reader.ReadRecordWithWide(values, nulls, wide)
+	var err error
+	if it.project != nil {
+		err = it.reader.ReadRecordWithWideProjected(values, nulls, wide, it.project)
+	} else {
+		err = it.reader.ReadRecordWithWide(values, nulls, wide)
+	}
 	if err == io.EOF {
 		it.done = true
 		return false
@@ -178,6 +196,19 @@ func (it *streamingIterator) Next() bool {
 
 	it.current = processing.NewRecordWithWide(it.schema, values, nulls, wide)
 	return true
+}
+
+// SetProjection installs a field-keep filter on the iterator. When
+// set, each Record's values/nulls/wide maps are populated only with
+// the fields keep accepts; excluded field bytes are still consumed
+// from the reader so byte offsets stay aligned. size is the expected
+// number of accepted fields, used to size the per-record map
+// allocation. Pass nil to clear (full decode).
+//
+// MUST be called before the first Next() call.
+func (it *streamingIterator) SetProjection(keep encoding.FieldFilter, size int) {
+	it.project = keep
+	it.projectSize = size
 }
 
 // SetReuse toggles per-row Record reuse. When true, Next returns the

--- a/skills/extension-points.md
+++ b/skills/extension-points.md
@@ -205,6 +205,50 @@ Embedders declare streamability at registration time; the runtime trusts that de
 
 Filterers are always row-local streamable today. Windows always run buffered.
 
+## FieldInputs hook (buffered-projection introspection)
+
+Every operator registration accepts an optional `FieldInputs FieldInputsFunc` callback:
+
+```go
+type FieldInputsFunc func(raw json.RawMessage) []string
+```
+
+When `pulse.Options.ProjectBufferedFields` is enabled, the runtime walks each request before opening the streaming iterator and calls `processing.NeededFields(req, schema, ext)` to compute the set of source fields that the operators actually read. Built-in operators are fully introspectable from their spec (`Field`, `Field2`, `PartitionBy`, `OrderBy`, `Target`, `Predictors`, plus expr-AST identifiers for `ATTR_FORMULA` / `FILTER_EXPRESSION`). Custom operators registered through this surface are opaque by default — the projection extractor widens to "every field" whenever it encounters a custom operator without a `FieldInputs` hook, so the runtime stays correct.
+
+To opt into projection on a custom operator, register `FieldInputs` and return every schema field the operator reads beyond its spec's explicit references:
+
+```go
+pulse.AggregatorRegistration{
+    Name:    "AGG_ACME_BLENDED_SCORE",
+    Factory: blendedScoreFactory,
+    Params:  []pulse.ParamMeta{{Name: "weight_field", JSONType: "string"}},
+    // Spec.Field carries the value field; weight_field names a second
+    // numeric field. Both must be in the projected map for the
+    // aggregator to compute correctly.
+    FieldInputs: func(raw json.RawMessage) []string {
+        var p struct {
+            WeightField string `json:"weight_field"`
+        }
+        _ = json.Unmarshal(raw, &p)
+        if p.WeightField == "" {
+            return nil
+        }
+        return []string{p.WeightField}
+    },
+}
+```
+
+Return value semantics:
+- `nil` / empty slice: no extra fields beyond the spec's `Field` (the operator reads only what the runtime can already infer).
+- Names not present in the schema are silently dropped by `NeededFields` — return-what-you-read; the extractor filters against the live schema.
+- Errors aren't part of the signature on purpose — `FieldInputs` runs on the hot path and should be allocation-free. Anything that needs decoding belongs in the factory.
+
+For filterers, the callback receives `nil` as `raw` (filterers don't carry a Params block today). Return the static set of extra fields the filterer reads beyond `Filterer.Field`.
+
+Tier-2 post-tests don't decode source records (they consume the materialized result row set after windows). Leave `FieldInputs` nil on tier-2 registrations.
+
+The hook is plumbed via `buildRuntimeExtensions` into `processing.ExtensionRegistry.FieldInputs`, keyed by `StreamabilityKey(category, name)`. `ExtensionRegistry.FieldInputsFor(category, name, raw)` returns `(inputs, true)` when the callback ran successfully, `(nil, false)` when the operator is custom but has no registered callback — that second case is what triggers the extractor to widen.
+
 ## Manifest discoverability
 
 `pulse manifest --json` and `pulse_manifest` include a top-level `Extensions` block whenever the host registered anything:


### PR DESCRIPTION
## Summary

- Adds opt-in `pulse.Options.ProjectBufferedFields` field-projection pass on the streaming iterator.
- New `processing.NeededFields(req, schema, ext)` extractor walks every request slot (Aggregations, Attributes including expr-AST identifiers for `ATTR_FORMULA`/`FILTER_EXPRESSION`, Filterers, Groups, Windows incl. PartitionBy+OrderBy, Features incl. `stratify`/`target` from Params, Tests, Regressions, Sort) and returns the `FieldSet` the operators actually consume.
- New `encoding.RecordReader.ReadRecordWithWideProjected(values, nulls, wide, keep)` advances byte cursors for every field but skips per-record map writes outside the keep set. Bit-packed neighbours stay aligned because on-wire byte advancement is preserved — only the map writes are guarded.
- Extension API: optional `FieldInputs FieldInputsFunc` on every registration (Aggregator/Attribute/Filterer/Grouper/Window/Feature/Test). Plumbed via `buildRuntimeExtensions` into `processing.ExtensionRegistry.FieldInputs` keyed by `StreamabilityKey(category, name)`. Absent hook on a custom operator widens projection to `*` so the runtime stays correct.
- Per-record memory drops proportional to the projection ratio (~20× drop on a 60-field schema with a 3-field request); decode CPU unchanged.
- Defaults to `false` to preserve byte-identical behavior with the pre-projection codepath. Worst case (extension without `FieldInputs`) degrades to today's full-decode path.

## Why

Buffered Process accumulates every `Record` into a slice, and each Record carries `values`/`nulls`/`wide` maps keyed by every field in the schema (`processing/processor.go:117-120`, `service/stream.go:165-179`). On wide cohorts (50+ fields) with narrow requests (3-5 fields), this dwarfs the actual computational footprint. Projection skips the map writes for unreferenced fields — same decode work, dramatically smaller heap.

## What changed

- `pulse.Options.ProjectBufferedFields bool` + `Service.SetProjectBufferedFields` plumb-through.
- `processing/projection.go` (`NeededFields`, `FieldSet`, expr-AST identifier walker via `expr-lang/expr/parser` + `expr-lang/expr/ast`).
- `encoding/reader.go` (`FieldFilter`, `ReadRecordWithWideProjected`).
- `service/stream.go` (`SetProjection` on the iterator).
- `service/service.go` (`applyProjection` runs after `applyDefaults`).
- `processing/extensions.go` (`FieldInputsFunc`, `ExtensionRegistry.FieldInputs`, `FieldInputsFor`).
- `extensions.go` (`FieldInputsFunc` + per-registration hook).
- `extensions_runtime.go` (wires registration hooks into the runtime registry).
- `CLAUDE.md` — new "Projected buffered decode" subsection, two Update Demand rows.
- `skills/extension-points.md` — new "FieldInputs hook" section.

## Test plan

- [x] `go test ./processing/ -run TestNeededFields -count=1` — extractor parity, malformed expr widens, extension introspection, unknown-name dropping.
- [x] `go test ./encoding/ -run TestReadRecordProjected -count=1` — byte-cursor alignment when skipping fields, packed_bool neighbour correctness, nil-filter fallthrough.
- [x] `go test ./service/ -run TestProjection -count=1` — end-to-end buffered-matches-full-decode for aggregations, grouped, filter-expr, attribute-formula; opt-in flag respected; wide-request skips projection.
- [x] `go test ./... -count=1 -timeout=300s` — full suite, no regressions across 30+ packages (descriptor, encoding, errors, examples, fs, imports, mcp, processing, regression, window, feature, service, skills, synth, types).
- [x] `make fmt`, `make vet`, `make lint`, `make build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)