### PR TITLE
feat(sharding): cohort filter supports shard archives + anchor syntax

### DIFF
--- a/internal/cli/cohort.go
+++ b/internal/cli/cohort.go
@@ -97,7 +97,7 @@ func printInspectResult(cmd *cli.Command, result *descriptor.InspectResult) {
 func cohortFilterCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "filter",
-		Usage: "Filter a .pulse file to a new .pulse file",
+		Usage: "Filter a .pulse file (single-file or shard archive) to a new .pulse file",
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "input", Aliases: []string{"i"}, Usage: "Input .pulse file path", Required: true},
 			&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Usage: "Output .pulse file path", Required: true},

--- a/pulse.go
+++ b/pulse.go
@@ -492,17 +492,26 @@ func (p *Pulse) Sample(ctx context.Context, path string, n int) ([]Record, error
 	return rows, err
 }
 
-// FilterToFile reads the single-file .pulse cohort at src, evaluates
-// filterExpr (FILTER_EXPRESSION semantics — same operators, identifiers,
-// expr functions, and lookup tables available to pulse.Process with a
+// FilterToFile reads the .pulse cohort at src, evaluates filterExpr
+// (FILTER_EXPRESSION semantics — same operators, identifiers, expr
+// functions, and lookup tables available to pulse.Process with a
 // FILTER_EXPRESSION filterer) against every record, and writes a new
-// single-file .pulse cohort at dst containing only matching records.
-// The header and schema bytes are copied byte-for-byte from src; only
-// the record payload differs.
+// .pulse cohort at dst containing only matching records.
 //
-// Shard archives are not supported in this entry — pass an anchored
-// single shard (`archive.pulse#shard.pulse`) or extract first. Returns
-// the number of records written to dst.
+// Dispatch matches the rest of the facade. Single-file inputs produce
+// single-file outputs whose header + schema bytes are copied byte-for-
+// byte from src. Shard archives produce shard archives that preserve
+// the per-shard layout: one input shard maps to one output shard at
+// the same basename, in central-directory (insertion) order, with
+// per-shard header + schema + categorical-dictionary bytes copied
+// verbatim. Empty shards survive so shard_count metadata stays stable;
+// the canonical `_schema.pulse` trailer's aggregate_record_count is
+// refreshed to the surviving total. The anchor form
+// `archive.pulse#shard.pulse` resolves a single shard and writes a
+// single-file output.
+//
+// Returns the number of records written to dst (sum across shards for
+// archive inputs).
 func (p *Pulse) FilterToFile(ctx context.Context, src, dst, filterExpr string) (int64, error) {
 	n, err := p.svc.FilterToFile(ctx, src, dst, filterExpr)
 	if err == nil {

--- a/service/filter_to_file.go
+++ b/service/filter_to_file.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"fmt"
@@ -13,17 +14,36 @@ import (
 	"github.com/spf13/afero"
 )
 
-// FilterToFile reads the single-file .pulse cohort at src, evaluates
-// filterExpr against every record using FILTER_EXPRESSION semantics,
-// and writes a new single-file .pulse cohort at dst containing only
-// records that pass. The header and schema bytes are copied byte-
-// for-byte from src — only the record payload differs. Custom expr
-// functions and lookup tables registered via pulse.Options.Extensions
-// are honored.
+// FilterToFile reads the .pulse cohort at src, evaluates filterExpr
+// against every record using FILTER_EXPRESSION semantics, and writes a
+// new .pulse cohort at dst containing only records that pass. Custom
+// expr functions and lookup tables registered via
+// pulse.Options.Extensions are honored.
 //
-// Shard archives are not supported in this entry. Open one shard via
-// the `archive.pulse#shard.pulse` anchor or use `pulse shard extract`
-// first. Returns the number of records written.
+// Three input shapes are supported, dispatched on the first four bytes:
+//
+//   - Single-file cohort (magic "PULSE\x00\x00\x00"): the dst is a
+//     single-file cohort whose header + schema bytes are copied
+//     byte-for-byte from src; only the record payload differs.
+//
+//   - Shard archive (magic "PK\x03\x04"): the dst is a new shard
+//     archive preserving the per-shard layout — one input shard maps
+//     to one output shard at the same basename, in central-directory
+//     (insertion) order. Per-shard header + schema + categorical
+//     dictionary bytes are copied byte-for-byte (records inside each
+//     shard reference that shard's local dictionary, which is preserved
+//     under the prefix-rule invariant). Shards with zero surviving
+//     records are written as empty payloads (header + schema + zero
+//     record bytes). The canonical `_schema.pulse` trailer is
+//     refreshed: aggregate_record_count = sum of surviving rows across
+//     shards, shard_count = unchanged.
+//
+//   - Anchor syntax `archive.pulse#shard.pulse`: resolves to a single
+//     shard inside an archive; dst is a single-file cohort built from
+//     that shard alone.
+//
+// Returns the number of records written to dst (sum across shards for
+// archive inputs).
 func (s *Service) FilterToFile(ctx context.Context, src, dst, filterExpr string) (int64, error) {
 	if src == "" {
 		return 0, errors.NewCodedError(errors.SERVICE_VALIDATION,
@@ -39,41 +59,167 @@ func (s *Service) FilterToFile(ctx context.Context, src, dst, filterExpr string)
 	}
 
 	fsys := s.fs.Fs()
+
+	// Anchor syntax: archive#shard → single-shard payload → single-file
+	// output. Reuses service.OpenAnchor's archive resolution path.
+	if archivePath, anchor, ok := splitAnchorPath(src); ok {
+		payload, err := s.readAnchoredShardBytes(archivePath, anchor)
+		if err != nil {
+			return 0, err
+		}
+		return s.filterSingleFileBytesToFile(ctx, fsys, payload, dst, filterExpr)
+	}
+
 	data, err := afero.ReadFile(fsys, src)
 	if err != nil {
 		return 0, errors.WrapCodedError(err, errors.SERVICE_RESOURCE,
 			fmt.Sprintf("opening cohort file: %s", src))
 	}
-	if len(data) >= 4 && data[0] == 'P' && data[1] == 'K' && data[2] == 0x03 && data[3] == 0x04 {
-		return 0, errors.NewCodedError(errors.SERVICE_VALIDATION,
-			"filter_to_file does not support shard archives; pass an anchored single shard or extract first")
+
+	if isShardArchiveMagic(data) {
+		return s.filterShardArchiveToFile(ctx, fsys, dst, filterExpr, data)
 	}
 
+	return s.filterSingleFileBytesToFile(ctx, fsys, data, dst, filterExpr)
+}
+
+// filterSingleFileBytesToFile runs the single-file filter loop over an
+// in-memory byte slice and writes the result to dst. Used both for
+// direct single-file inputs and for anchor-syntax inputs (where the
+// anchored shard's bytes form a complete standalone payload).
+func (s *Service) filterSingleFileBytesToFile(ctx context.Context, fsys afero.Fs, data []byte, dst, filterExpr string) (int64, error) {
 	br := bytes.NewReader(data)
 	if err := encoding.ReadHeader(br); err != nil {
 		return 0, errors.WrapCodedError(err, errors.ENCODING_INVALID,
-			fmt.Sprintf("invalid pulse file: %s", src))
+			"invalid pulse file header")
 	}
 	schema, err := encoding.ReadSchema(br)
 	if err != nil {
 		return 0, errors.WrapCodedError(err, errors.ENCODING_INVALID,
-			fmt.Sprintf("reading schema from: %s", src))
+			"reading schema")
 	}
 	headerSchemaEnd := int64(len(data)) - int64(br.Len())
 
-	filterFuncs, err := processing.BuildFilters(
-		[]*types.Filterer{{Type: types.FILTER_EXPRESSION, Expression: filterExpr}},
-		schema,
-		s.extensions,
-	)
+	filterFn, err := s.buildSingleFilter(schema, filterExpr)
 	if err != nil {
 		return 0, err
 	}
-	filterFn := filterFuncs[0]
 
 	out := bytes.NewBuffer(make([]byte, 0, len(data)))
 	out.Write(data[:headerSchemaEnd])
 
+	written, err := s.streamFilterRecords(ctx, data, br, schema, filterFn, out)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := afero.WriteFile(fsys, dst, out.Bytes(), 0644); err != nil {
+		return 0, errors.WrapCodedError(err, errors.SERVICE_RESOURCE,
+			fmt.Sprintf("writing filtered cohort to: %s", dst))
+	}
+	return written, nil
+}
+
+// filterShardArchiveToFile applies the filter to every shard in the
+// source archive and writes a new shard archive to dst. One input shard
+// → one output shard, basename preserved, central-directory order
+// preserved. Empty shards (zero surviving records) are kept so the
+// shard_count metadata stays stable across the filter.
+func (s *Service) filterShardArchiveToFile(ctx context.Context, fsys afero.Fs, dst, filterExpr string, data []byte) (int64, error) {
+	arch, err := encoding.OpenArchive(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return 0, err
+	}
+
+	canonicalDoc, err := readSchemaDocEntry(arch)
+	if err != nil {
+		return 0, err
+	}
+	canonicalSchema := canonicalDoc.Schema
+
+	filterFn, err := s.buildSingleFilter(canonicalSchema, filterExpr)
+	if err != nil {
+		return 0, err
+	}
+
+	// Per-shard filter + accumulate output payloads.
+	type filteredShard struct {
+		name    string
+		payload []byte
+		written int64
+	}
+	entries := arch.Entries()
+	out := make([]filteredShard, 0, len(entries))
+	var totalWritten int64
+	for _, e := range entries {
+		if e.Name == encoding.ReservedSchemaName {
+			continue
+		}
+		shardBytes, perr := readEntryBytes(arch, e.Name)
+		if perr != nil {
+			return 0, perr
+		}
+
+		// Parse this shard's local header + schema so we can copy those
+		// bytes verbatim into the output payload. Records are decoded
+		// against the canonical schema so filter expressions see a
+		// consistent dictionary across shards, but local schema bytes
+		// (with the local dictionary subset) stay on the output shard.
+		// The cohesion invariant guarantees record layout matches.
+		br := bytes.NewReader(shardBytes)
+		if err := encoding.ReadHeader(br); err != nil {
+			return 0, errors.WrapCodedError(err, errors.PULSE_SHARD_HEADER_INVALID,
+				fmt.Sprintf("reading shard %q header", e.Name))
+		}
+		if _, err := encoding.ReadSchema(br); err != nil {
+			return 0, errors.WrapCodedError(err, errors.PULSE_SHARD_HEADER_INVALID,
+				fmt.Sprintf("reading shard %q schema", e.Name))
+		}
+		localHeaderSchemaEnd := int64(len(shardBytes)) - int64(br.Len())
+
+		buf := bytes.NewBuffer(make([]byte, 0, len(shardBytes)))
+		buf.Write(shardBytes[:localHeaderSchemaEnd])
+		written, ferr := s.streamFilterRecords(ctx, shardBytes, br, canonicalSchema, filterFn, buf)
+		if ferr != nil {
+			return 0, ferr
+		}
+		out = append(out, filteredShard{name: e.Name, payload: buf.Bytes(), written: written})
+		totalWritten += written
+	}
+
+	// Rebuild the archive: refresh _schema.pulse trailer (aggregate +
+	// shard_count) then emit each filtered shard payload.
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	schemaPayload, err := buildSchemaDocPayload(canonicalSchema, uint64(totalWritten), uint16(len(out)))
+	if err != nil {
+		return 0, err
+	}
+	if err := writeArchiveEntry(zw, encoding.ReservedSchemaName, schemaPayload); err != nil {
+		return 0, err
+	}
+	for _, sh := range out {
+		if err := writeArchiveEntry(zw, sh.name, sh.payload); err != nil {
+			return 0, err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return 0, errors.WrapCodedError(err, errors.SERVICE_RESOURCE,
+			"FilterToFile: finalising shard archive zip writer")
+	}
+
+	if err := atomicWrite(fsys, dst, buf.Bytes()); err != nil {
+		return 0, err
+	}
+	return totalWritten, nil
+}
+
+// streamFilterRecords iterates records from br (positioned after
+// header+schema), applies filterFn against records decoded with schema,
+// and writes raw record-byte ranges from data into out for kept rows.
+// Returns the number of records written.
+func (s *Service) streamFilterRecords(ctx context.Context, data []byte, br *bytes.Reader, schema *encoding.Schema, filterFn processing.FilterFunc, out *bytes.Buffer) (int64, error) {
 	values := make(map[string]float64, len(schema.Fields))
 	nulls := make(map[string]bool, len(schema.Fields))
 	wide := make(map[string]any, len(schema.Fields))
@@ -105,10 +251,58 @@ func (s *Service) FilterToFile(ctx context.Context, src, dst, filterExpr string)
 		out.Write(data[posStart:posEnd])
 		written++
 	}
-
-	if err := afero.WriteFile(fsys, dst, out.Bytes(), 0644); err != nil {
-		return 0, errors.WrapCodedError(err, errors.SERVICE_RESOURCE,
-			fmt.Sprintf("writing filtered cohort to: %s", dst))
-	}
 	return written, nil
+}
+
+// buildSingleFilter resolves filterExpr into a single FilterFunc bound
+// to schema. Extensions (expr functions + lookup tables) registered on
+// the Service are honored.
+func (s *Service) buildSingleFilter(schema *encoding.Schema, filterExpr string) (processing.FilterFunc, error) {
+	fns, err := processing.BuildFilters(
+		[]*types.Filterer{{Type: types.FILTER_EXPRESSION, Expression: filterExpr}},
+		schema,
+		s.extensions,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return fns[0], nil
+}
+
+// readAnchoredShardBytes resolves an anchor (archivePath, entry) to the
+// shard's standalone single-file `.pulse` payload bytes. Used by
+// FilterToFile to support `archive.pulse#shard.pulse` syntax with the
+// same semantics as service.OpenAnchor.
+func (s *Service) readAnchoredShardBytes(archivePath, entry string) ([]byte, error) {
+	if entry == encoding.ReservedSchemaName {
+		return nil, errors.NewCodedErrorWithDetails(errors.PULSE_SHARD_RESERVED_NAME,
+			"cannot filter the reserved canonical schema entry",
+			map[string]any{"entry": entry})
+	}
+	data, err := afero.ReadFile(s.fs.Fs(), archivePath)
+	if err != nil {
+		return nil, errors.WrapCodedError(err, errors.SERVICE_RESOURCE,
+			fmt.Sprintf("opening cohort file for anchor: %s", archivePath))
+	}
+	arch, err := encoding.OpenArchive(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, err
+	}
+	rc, err := arch.Open(entry)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	payload, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, errors.WrapCodedError(err, errors.ENCODING_IO,
+			fmt.Sprintf("reading anchored shard %q from %s", entry, archivePath))
+	}
+	return payload, nil
+}
+
+// isShardArchiveMagic reports whether data begins with the zip magic
+// "PK\x03\x04". Mirrors the dispatch check in service.Open.
+func isShardArchiveMagic(data []byte) bool {
+	return len(data) >= 4 && data[0] == 'P' && data[1] == 'K' && data[2] == 0x03 && data[3] == 0x04
 }

--- a/service/filter_to_file_shard_test.go
+++ b/service/filter_to_file_shard_test.go
@@ -1,0 +1,457 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/errors"
+	"github.com/frankbardon/pulse/fs"
+	"github.com/frankbardon/pulse/types"
+	"github.com/spf13/afero"
+)
+
+// filterArchiveFixture writes a fresh multi-shard archive plus the
+// matching concatenated single-file cohort and returns a Service wired
+// to a memfs containing both. Mirrors setupShardArchive but keeps the
+// fixture local to filter-specific tests for readability.
+func filterArchiveFixture(t *testing.T, archivePath string) (svc *Service, cfg *fs.Config, schema *encoding.Schema) {
+	t.Helper()
+	schema, shards, concat := canonicalThreeShards()
+	svc, cfg = setupShardArchive(t, archivePath, schema, shards, concat)
+	return svc, cfg, schema
+}
+
+// TestFilterToFile_ShardArchive_PreservesPerShardStructure — given an
+// archive with three score shards (10..40, 50..80, 90..120) and the
+// filter `score > 50`, the output archive must:
+//   - keep all three shards (zero-record shards survive so shard_count
+//     stays stable),
+//   - report aggregate_record_count == 7 (b:3 + c:4),
+//   - return the matching shards in central-directory (insertion) order,
+//   - re-open through Service.Open + RecordCount cleanly.
+func TestFilterToFile_ShardArchive_PreservesPerShardStructure(t *testing.T) {
+	svc, cfg, _ := filterArchiveFixture(t, "src.pulse")
+
+	written, err := svc.FilterToFile(context.Background(), "src.pulse", "dst.pulse", "score > 50.0")
+	if err != nil {
+		t.Fatalf("FilterToFile: %v", err)
+	}
+	if written != 7 {
+		t.Fatalf("written = %d, want 7", written)
+	}
+
+	exists, _ := afero.Exists(cfg.Fs(), "dst.pulse")
+	if !exists {
+		t.Fatal("dst.pulse missing")
+	}
+
+	cohort, err := svc.Open(context.Background(), "dst.pulse")
+	if err != nil {
+		t.Fatalf("Open dst: %v", err)
+	}
+	if len(cohort.Shards()) != 3 {
+		t.Errorf("dst shard count = %d, want 3", len(cohort.Shards()))
+	}
+	names := make([]string, 0, len(cohort.Shards()))
+	for _, sh := range cohort.Shards() {
+		names = append(names, sh.Filename)
+	}
+	wantNames := []string{"a.pulse", "b.pulse", "c.pulse"}
+	for i, want := range wantNames {
+		if i >= len(names) || names[i] != want {
+			t.Errorf("dst shards[%d] = %q, want %q (full=%v)", i, names[i], want, names)
+		}
+	}
+	// Cohort.RecordCount currently parses the archive as a single-file
+	// cohort and errors on the zip magic (pre-sharding API limitation).
+	// Use the per-shard counts populated on Cohort.Shards() instead,
+	// which mirror the on-disk shard headers.
+	var rc int64
+	for _, sh := range cohort.Shards() {
+		rc += sh.RecordCount
+	}
+	if rc != 7 {
+		t.Errorf("dst aggregate record count = %d, want 7", rc)
+	}
+
+	// Confirm filter parity through Process: count over the output
+	// archive equals the cross-shard count over the input archive
+	// after the same filter.
+	resOut, err := svc.Process(context.Background(), &types.Request{
+		Cohort:       &types.Cohort{Filename: "dst.pulse"},
+		Aggregations: []*types.Aggregation{{Type: types.AGG_COUNT, Field: "score", Label: "n"}},
+	})
+	if err != nil {
+		t.Fatalf("Process dst: %v", err)
+	}
+	if resOut.Data[0]["n"].(float64) != 7 {
+		t.Errorf("Process(dst).count = %v, want 7", resOut.Data[0]["n"])
+	}
+
+	resIn, err := svc.Process(context.Background(), &types.Request{
+		Cohort:       &types.Cohort{Filename: "src.pulse"},
+		Filterers:    []*types.Filterer{{Type: types.FILTER_EXPRESSION, Expression: "score > 50.0"}},
+		Aggregations: []*types.Aggregation{{Type: types.AGG_COUNT, Field: "score", Label: "n"}},
+	})
+	if err != nil {
+		t.Fatalf("Process src filtered: %v", err)
+	}
+	if resIn.Data[0]["n"].(float64) != 7 {
+		t.Errorf("Process(src, filtered).count = %v, want 7", resIn.Data[0]["n"])
+	}
+}
+
+// TestFilterToFile_ShardArchive_ZeroMatches — a filter that excludes
+// every row keeps the shard_count metadata stable and emits empty
+// shards. The output archive remains valid and re-openable; aggregate
+// is zero.
+func TestFilterToFile_ShardArchive_ZeroMatches(t *testing.T) {
+	svc, cfg, _ := filterArchiveFixture(t, "src.pulse")
+
+	written, err := svc.FilterToFile(context.Background(), "src.pulse", "dst.pulse", "score > 999.0")
+	if err != nil {
+		t.Fatalf("FilterToFile: %v", err)
+	}
+	if written != 0 {
+		t.Fatalf("written = %d, want 0", written)
+	}
+
+	cohort, err := svc.Open(context.Background(), "dst.pulse")
+	if err != nil {
+		t.Fatalf("Open dst: %v", err)
+	}
+	if len(cohort.Shards()) != 3 {
+		t.Errorf("dst shard count = %d, want 3 (zero-record shards retained)", len(cohort.Shards()))
+	}
+
+	// Each output shard's own header+schema bytes must equal the
+	// corresponding source shard's prefix. Walk the central directory
+	// pair-wise and compare the byte range up to the first record.
+	srcBytes, _ := afero.ReadFile(cfg.Fs(), "src.pulse")
+	dstBytes, _ := afero.ReadFile(cfg.Fs(), "dst.pulse")
+	srcArch, err := encoding.OpenArchive(bytes.NewReader(srcBytes), int64(len(srcBytes)))
+	if err != nil {
+		t.Fatalf("OpenArchive src: %v", err)
+	}
+	dstArch, err := encoding.OpenArchive(bytes.NewReader(dstBytes), int64(len(dstBytes)))
+	if err != nil {
+		t.Fatalf("OpenArchive dst: %v", err)
+	}
+	for _, name := range []string{"a.pulse", "b.pulse", "c.pulse"} {
+		srcShard := readShardOrFatal(t, srcArch, name)
+		dstShard := readShardOrFatal(t, dstArch, name)
+		prefixLen := headerSchemaPrefixLen(t, srcShard)
+		if int64(len(dstShard)) != prefixLen {
+			t.Errorf("dst shard %q: payload length = %d, want %d (header+schema, zero records)",
+				name, len(dstShard), prefixLen)
+		}
+		for i := range prefixLen {
+			if srcShard[i] != dstShard[i] {
+				t.Fatalf("dst shard %q diverges at byte %d (header+schema must be verbatim)",
+					name, i)
+			}
+		}
+	}
+
+	// Trailer aggregate must reflect zero rows kept.
+	doc := readSchemaDocOrFatal(t, dstArch)
+	if doc.AggregateRecordCount != 0 {
+		t.Errorf("aggregate_record_count = %d, want 0", doc.AggregateRecordCount)
+	}
+	if doc.ShardCount != 3 {
+		t.Errorf("shard_count = %d, want 3", doc.ShardCount)
+	}
+}
+
+// TestFilterToFile_ShardArchive_AllMatch — when every row passes the
+// filter the per-shard payloads must be byte-equal to the source (the
+// only changes are the refreshed _schema.pulse trailer, which is
+// already byte-equal under our fixture because the aggregate is the
+// same).
+func TestFilterToFile_ShardArchive_AllMatch(t *testing.T) {
+	svc, cfg, _ := filterArchiveFixture(t, "src.pulse")
+
+	written, err := svc.FilterToFile(context.Background(), "src.pulse", "dst.pulse", "id >= 1")
+	if err != nil {
+		t.Fatalf("FilterToFile: %v", err)
+	}
+	if written != 12 {
+		t.Fatalf("written = %d, want 12", written)
+	}
+
+	srcBytes, _ := afero.ReadFile(cfg.Fs(), "src.pulse")
+	dstBytes, _ := afero.ReadFile(cfg.Fs(), "dst.pulse")
+	srcArch, _ := encoding.OpenArchive(bytes.NewReader(srcBytes), int64(len(srcBytes)))
+	dstArch, _ := encoding.OpenArchive(bytes.NewReader(dstBytes), int64(len(dstBytes)))
+
+	for _, name := range []string{"a.pulse", "b.pulse", "c.pulse"} {
+		src := readShardOrFatal(t, srcArch, name)
+		dst := readShardOrFatal(t, dstArch, name)
+		if !bytes.Equal(src, dst) {
+			t.Errorf("shard %q payload diverged under all-match filter", name)
+		}
+	}
+
+	// Trailer aggregate matches source's.
+	srcDoc := readSchemaDocOrFatal(t, srcArch)
+	dstDoc := readSchemaDocOrFatal(t, dstArch)
+	if srcDoc.AggregateRecordCount != dstDoc.AggregateRecordCount {
+		t.Errorf("all-match aggregate diverged: src=%d dst=%d",
+			srcDoc.AggregateRecordCount, dstDoc.AggregateRecordCount)
+	}
+	if dstDoc.ShardCount != srcDoc.ShardCount {
+		t.Errorf("all-match shard_count diverged: src=%d dst=%d",
+			srcDoc.ShardCount, dstDoc.ShardCount)
+	}
+}
+
+// TestFilterToFile_ShardArchive_TrailerRefreshed — partial filter
+// updates aggregate_record_count to the surviving total and leaves
+// shard_count unchanged.
+func TestFilterToFile_ShardArchive_TrailerRefreshed(t *testing.T) {
+	svc, cfg, _ := filterArchiveFixture(t, "src.pulse")
+
+	if _, err := svc.FilterToFile(context.Background(), "src.pulse", "dst.pulse", "score >= 60.0"); err != nil {
+		t.Fatalf("FilterToFile: %v", err)
+	}
+	dstBytes, _ := afero.ReadFile(cfg.Fs(), "dst.pulse")
+	arch, err := encoding.OpenArchive(bytes.NewReader(dstBytes), int64(len(dstBytes)))
+	if err != nil {
+		t.Fatalf("OpenArchive dst: %v", err)
+	}
+	doc := readSchemaDocOrFatal(t, arch)
+	// score >= 60 keeps {60,70,80,90,100,110,120} = 7 rows.
+	if doc.AggregateRecordCount != 7 {
+		t.Errorf("aggregate_record_count = %d, want 7", doc.AggregateRecordCount)
+	}
+	if doc.ShardCount != 3 {
+		t.Errorf("shard_count = %d, want 3", doc.ShardCount)
+	}
+}
+
+// TestFilterToFile_ShardArchive_PerShardRecordRanges — verify the
+// record-byte ranges inside each output shard are pulled verbatim from
+// the source shard. This is the byte-for-byte payload guarantee that
+// matches single-file FilterToFile semantics, extended per-shard.
+func TestFilterToFile_ShardArchive_PerShardRecordRanges(t *testing.T) {
+	svc, cfg, schema := filterArchiveFixture(t, "src.pulse")
+
+	if _, err := svc.FilterToFile(context.Background(), "src.pulse", "dst.pulse", "score > 50.0"); err != nil {
+		t.Fatalf("FilterToFile: %v", err)
+	}
+
+	srcBytes, _ := afero.ReadFile(cfg.Fs(), "src.pulse")
+	dstBytes, _ := afero.ReadFile(cfg.Fs(), "dst.pulse")
+	srcArch, _ := encoding.OpenArchive(bytes.NewReader(srcBytes), int64(len(srcBytes)))
+	dstArch, _ := encoding.OpenArchive(bytes.NewReader(dstBytes), int64(len(dstBytes)))
+
+	recordSize := 0
+	for _, f := range schema.Fields {
+		recordSize += f.Type.ByteSize()
+	}
+
+	wantKept := map[string]int{
+		"a.pulse": 0, // 10,20,30,40 — none survive `> 50`
+		"b.pulse": 3, // 60,70,80
+		"c.pulse": 4, // 90,100,110,120
+	}
+	for name, want := range wantKept {
+		src := readShardOrFatal(t, srcArch, name)
+		dst := readShardOrFatal(t, dstArch, name)
+		prefix := headerSchemaPrefixLen(t, src)
+		wantLen := prefix + int64(want*recordSize)
+		if int64(len(dst)) != wantLen {
+			t.Errorf("shard %q dst length = %d, want %d (header+schema + %d records)",
+				name, len(dst), wantLen, want)
+		}
+		// Header+schema verbatim.
+		for i := range prefix {
+			if src[i] != dst[i] {
+				t.Fatalf("shard %q header/schema diverges at byte %d", name, i)
+			}
+		}
+	}
+}
+
+// TestFilterToFile_ShardArchive_OpenableThroughOpen — end-to-end:
+// filter, open the output, process it, confirm parity with the
+// in-place filter applied at process time.
+func TestFilterToFile_ShardArchive_OpenableThroughOpen(t *testing.T) {
+	svc, _, _ := filterArchiveFixture(t, "src.pulse")
+
+	if _, err := svc.FilterToFile(context.Background(), "src.pulse", "dst.pulse", "score < 75.0"); err != nil {
+		t.Fatalf("FilterToFile: %v", err)
+	}
+
+	// Process(dst, no filter) == Process(src, filter).
+	dstRes, err := svc.Process(context.Background(), &types.Request{
+		Cohort: &types.Cohort{Filename: "dst.pulse"},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "score", Label: "sum"},
+			{Type: types.AGG_COUNT, Field: "score", Label: "n"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Process dst: %v", err)
+	}
+	srcRes, err := svc.Process(context.Background(), &types.Request{
+		Cohort:    &types.Cohort{Filename: "src.pulse"},
+		Filterers: []*types.Filterer{{Type: types.FILTER_EXPRESSION, Expression: "score < 75.0"}},
+		Aggregations: []*types.Aggregation{
+			{Type: types.AGG_SUM, Field: "score", Label: "sum"},
+			{Type: types.AGG_COUNT, Field: "score", Label: "n"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Process src filtered: %v", err)
+	}
+	if dstRes.Data[0]["sum"] != srcRes.Data[0]["sum"] || dstRes.Data[0]["n"] != srcRes.Data[0]["n"] {
+		t.Errorf("dst(no filter) vs src(filtered) diverge: dst=%+v src=%+v",
+			dstRes.Data[0], srcRes.Data[0])
+	}
+}
+
+// TestFilterToFile_AnchorSyntax — `archive.pulse#shard.pulse` produces
+// a single-file output containing only matching rows from the anchored
+// shard.
+func TestFilterToFile_AnchorSyntax(t *testing.T) {
+	svc, cfg, _ := filterArchiveFixture(t, "arch.pulse")
+
+	written, err := svc.FilterToFile(context.Background(), "arch.pulse#b.pulse", "dst.pulse", "score > 60.0")
+	if err != nil {
+		t.Fatalf("FilterToFile anchor: %v", err)
+	}
+	// Shard b = {50,60,70,80}; `> 60` keeps {70,80}.
+	if written != 2 {
+		t.Fatalf("written = %d, want 2", written)
+	}
+
+	// dst is a single-file (no zip magic).
+	dstBytes, _ := afero.ReadFile(cfg.Fs(), "dst.pulse")
+	if isShardArchiveMagic(dstBytes) {
+		t.Error("anchor-filter dst should be single-file, got zip archive")
+	}
+	cohort, err := svc.Open(context.Background(), "dst.pulse")
+	if err != nil {
+		t.Fatalf("Open dst: %v", err)
+	}
+	if len(cohort.Shards()) != 0 {
+		t.Errorf("anchor-filter dst is single-file: Shards = %d, want 0", len(cohort.Shards()))
+	}
+	rc, _ := cohort.RecordCount()
+	if rc != 2 {
+		t.Errorf("dst record count = %d, want 2", rc)
+	}
+}
+
+// TestFilterToFile_AnchorSyntax_ReservedRejected — anchoring on the
+// reserved `_schema.pulse` entry must surface PULSE_SHARD_RESERVED_NAME.
+func TestFilterToFile_AnchorSyntax_ReservedRejected(t *testing.T) {
+	svc, _, _ := filterArchiveFixture(t, "arch.pulse")
+	_, err := svc.FilterToFile(context.Background(),
+		"arch.pulse#"+encoding.ReservedSchemaName, "dst.pulse", "id > 0")
+	if err == nil {
+		t.Fatal("expected reserved-name rejection, got nil")
+	}
+	if !errors.HasCode(err, errors.PULSE_SHARD_RESERVED_NAME) {
+		t.Errorf("err = %v, want PULSE_SHARD_RESERVED_NAME", err)
+	}
+}
+
+// TestFilterToFile_AnchorSyntax_MissingShard — anchoring on a
+// non-existent shard name surfaces PULSE_SHARD_MISSING.
+func TestFilterToFile_AnchorSyntax_MissingShard(t *testing.T) {
+	svc, _, _ := filterArchiveFixture(t, "arch.pulse")
+	_, err := svc.FilterToFile(context.Background(),
+		"arch.pulse#nope.pulse", "dst.pulse", "id > 0")
+	if err == nil {
+		t.Fatal("expected missing-shard error, got nil")
+	}
+	if !errors.HasCode(err, errors.PULSE_SHARD_MISSING) {
+		t.Errorf("err = %v, want PULSE_SHARD_MISSING", err)
+	}
+}
+
+// TestFilterToFile_ShardArchive_RoundTripIdempotent — running the same
+// filter twice (src → mid → dst) yields a final archive whose per-
+// shard payloads match the first-pass output byte-for-byte. Confirms
+// the operation has no hidden state on the canonical schema or
+// record bytes.
+func TestFilterToFile_ShardArchive_RoundTripIdempotent(t *testing.T) {
+	svc, cfg, _ := filterArchiveFixture(t, "src.pulse")
+
+	if _, err := svc.FilterToFile(context.Background(), "src.pulse", "mid.pulse", "score > 30.0"); err != nil {
+		t.Fatalf("FilterToFile pass 1: %v", err)
+	}
+	if _, err := svc.FilterToFile(context.Background(), "mid.pulse", "dst.pulse", "score > 30.0"); err != nil {
+		t.Fatalf("FilterToFile pass 2: %v", err)
+	}
+	midBytes, _ := afero.ReadFile(cfg.Fs(), "mid.pulse")
+	dstBytes, _ := afero.ReadFile(cfg.Fs(), "dst.pulse")
+	if !bytes.Equal(midBytes, dstBytes) {
+		t.Error("idempotent filter: mid and dst archives diverge")
+	}
+}
+
+// TestFilterToFile_ShardArchive_BadExpressionFailsBeforeWrite —
+// invalid filter expression returns an error and leaves dst untouched.
+func TestFilterToFile_ShardArchive_BadExpressionFailsBeforeWrite(t *testing.T) {
+	svc, cfg, _ := filterArchiveFixture(t, "src.pulse")
+
+	_, err := svc.FilterToFile(context.Background(), "src.pulse", "dst.pulse", "score + 1")
+	if err == nil {
+		t.Fatal("expected error for non-bool expression")
+	}
+	exists, _ := afero.Exists(cfg.Fs(), "dst.pulse")
+	if exists {
+		t.Error("dst was written despite filter compilation failure")
+	}
+}
+
+// --- helpers ---
+
+func readShardOrFatal(t *testing.T, arch *encoding.Archive, name string) []byte {
+	t.Helper()
+	rc, err := arch.Open(name)
+	if err != nil {
+		t.Fatalf("archive Open %q: %v", name, err)
+	}
+	defer rc.Close()
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read shard %q: %v", name, err)
+	}
+	return b
+}
+
+func readSchemaDocOrFatal(t *testing.T, arch *encoding.Archive) *encoding.SchemaDoc {
+	t.Helper()
+	rc, err := arch.Open(encoding.ReservedSchemaName)
+	if err != nil {
+		t.Fatalf("Open _schema.pulse: %v", err)
+	}
+	defer rc.Close()
+	doc, err := encoding.ReadSchemaDoc(rc)
+	if err != nil {
+		t.Fatalf("ReadSchemaDoc: %v", err)
+	}
+	return doc
+}
+
+// headerSchemaPrefixLen returns the byte length of the header + schema
+// prefix of a single-file shard payload (i.e. the offset at which the
+// first record begins).
+func headerSchemaPrefixLen(t *testing.T, payload []byte) int64 {
+	t.Helper()
+	r := bytes.NewReader(payload)
+	if err := encoding.ReadHeader(r); err != nil {
+		t.Fatalf("ReadHeader: %v", err)
+	}
+	if _, err := encoding.ReadSchema(r); err != nil {
+		t.Fatalf("ReadSchema: %v", err)
+	}
+	return int64(len(payload)) - int64(r.Len())
+}


### PR DESCRIPTION
## Summary

- `FilterToFile` now dispatches on the first four magic bytes. Shard archives (`PK\x03\x04`) produce shard archives that preserve the per-shard layout — one input shard maps to one output shard at the same basename, in central-directory (insertion) order, with per-shard header + schema + categorical dictionary bytes copied verbatim. Single-file inputs keep the existing byte-for-byte path.
- Empty shards survive (no row passed the filter) so the archive's `shard_count` metadata stays stable across the operation. The canonical `_schema.pulse` trailer's `aggregate_record_count` is refreshed to the surviving total.
- Anchor syntax `archive.pulse#shard.pulse` is also handled — the anchored shard is resolved as a standalone single-file payload and written as a single-file output, matching the semantics every other facade method already exposes for anchored shards.
- The previous \"shard archives are not supported in this entry\" rejection is gone; the godoc + CLI usage strings reflect the new shape.

## Behavior matrix

| Input | Output | Trailer |
|---|---|---|
| Single-file `.pulse` | Single-file `.pulse` (header+schema verbatim, filtered records) | — |
| Shard archive | Shard archive (per-shard header+schema verbatim, filtered records per shard; empty shards retained) | `aggregate_record_count` refreshed, `shard_count` unchanged |
| `archive#shard.pulse` (anchor) | Single-file `.pulse` from one shard | — |

## Test plan

- [x] `go test ./service/...` (new + existing FilterToFile tests, full shard-archive contract suite)
- [x] `go test ./...` full suite green (no regressions)
- [x] `go vet ./...`
- [x] `gofmt` clean on changed files

New tests under `service/filter_to_file_shard_test.go`:

- `TestFilterToFile_ShardArchive_PreservesPerShardStructure` — 3-shard fixture (10..40, 50..80, 90..120), filter `score > 50`, asserts dst has 3 shards in insertion order, aggregate sums to 7, and `Process(dst)` matches `Process(src, filtered)`.
- `TestFilterToFile_ShardArchive_ZeroMatches` — zero-row archive keeps 3 shards as header+schema-only payloads, trailer `aggregate_record_count = 0`.
- `TestFilterToFile_ShardArchive_AllMatch` — every shard's payload byte-equal to source; trailer matches.
- `TestFilterToFile_ShardArchive_TrailerRefreshed` — partial filter refreshes aggregate, preserves shard_count.
- `TestFilterToFile_ShardArchive_PerShardRecordRanges` — per-shard byte-length matches `header+schema + N*recordSize`; header+schema prefix verbatim.
- `TestFilterToFile_ShardArchive_OpenableThroughOpen` — end-to-end Process parity dst-vs-src(filtered).
- `TestFilterToFile_AnchorSyntax` — anchor → single-file output (no zip magic), expected row count.
- `TestFilterToFile_AnchorSyntax_ReservedRejected` — `_schema.pulse` anchor surfaces `PULSE_SHARD_RESERVED_NAME`.
- `TestFilterToFile_AnchorSyntax_MissingShard` — missing anchor surfaces `PULSE_SHARD_MISSING`.
- `TestFilterToFile_ShardArchive_RoundTripIdempotent` — src→mid→dst byte-equal to mid.
- `TestFilterToFile_ShardArchive_BadExpressionFailsBeforeWrite` — compilation failure leaves dst absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)