### PR TITLE
feat(cohort): file-backed include-set on cohort filter

### DIFF
--- a/internal/cli/cohort.go
+++ b/internal/cli/cohort.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/frankbardon/pulse"
 	"github.com/frankbardon/pulse/descriptor"
 	cli "github.com/urfave/cli/v3"
 )
@@ -98,17 +99,41 @@ func cohortFilterCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "filter",
 		Usage: "Filter a .pulse file (single-file or shard archive) to a new .pulse file",
+		Description: "Filters records by either a filter expression (--filter), a file-backed " +
+			"include-set (--include-from + --include-field), or both. When both are " +
+			"supplied the predicates are AND-combined and the include-set is tested " +
+			"first so per-row work short-circuits on misses without paying the " +
+			"expression evaluation cost.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "input", Aliases: []string{"i"}, Usage: "Input .pulse file path", Required: true},
 			&cli.StringFlag{Name: "output", Aliases: []string{"o"}, Usage: "Output .pulse file path", Required: true},
-			&cli.StringFlag{Name: "filter", Usage: "Filter expression", Required: true},
+			&cli.StringFlag{Name: "filter", Usage: "Filter expression (FILTER_EXPRESSION semantics)"},
+			&cli.StringFlag{Name: "include-from", Usage: "Path to newline-delimited file of values to include"},
+			&cli.StringFlag{Name: "include-field", Usage: "Field name whose value is tested against --include-from"},
 			&cli.BoolFlag{Name: "json", Usage: "Output result as JSON envelope"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			input := cmd.String("input")
 			output := cmd.String("output")
 			filterExpr := cmd.String("filter")
+			includeFrom := cmd.String("include-from")
+			includeField := cmd.String("include-field")
 			jsonOut := cmd.Bool("json")
+
+			if filterExpr == "" && includeFrom == "" {
+				err := fmt.Errorf("pulse cohort filter requires at least one of --filter or --include-from")
+				if jsonOut {
+					return writeErrorEnvelope(cmd.Writer, "CLI_INPUT", err.Error())
+				}
+				return err
+			}
+			if (includeFrom == "") != (includeField == "") {
+				err := fmt.Errorf("--include-from and --include-field must be supplied together")
+				if jsonOut {
+					return writeErrorEnvelope(cmd.Writer, "CLI_INPUT", err.Error())
+				}
+				return err
+			}
 
 			p, err := newPulse()
 			if err != nil {
@@ -118,24 +143,89 @@ func cohortFilterCmd() *cli.Command {
 				return err
 			}
 
-			written, err := p.FilterToFile(ctx, input, output, filterExpr)
-			if err != nil {
-				if jsonOut {
-					return writeErrorEnvelope(cmd.Writer, "FILTER_ERROR", err.Error())
-				}
-				return err
+			if includeFrom == "" {
+				return runFilterByExpr(ctx, cmd, p, input, output, filterExpr, jsonOut)
 			}
-
-			if jsonOut {
-				return writeEnvelope(cmd.Writer, map[string]any{
-					"input":           input,
-					"output":          output,
-					"written_records": written,
-				})
-			}
-
-			writeText(cmd.Writer, "Filtered %d rows from %s to %s\n", written, input, output)
-			return nil
+			return runFilterByIncludeSet(ctx, cmd, p, input, output, includeFrom, includeField, filterExpr, jsonOut)
 		},
 	}
+}
+
+func runFilterByExpr(ctx context.Context, cmd *cli.Command, p *pulse.Pulse, input, output, filterExpr string, jsonOut bool) error {
+	written, err := p.FilterToFile(ctx, input, output, filterExpr)
+	if err != nil {
+		if jsonOut {
+			return writeErrorEnvelope(cmd.Writer, "FILTER_ERROR", err.Error())
+		}
+		return err
+	}
+	if jsonOut {
+		return writeEnvelope(cmd.Writer, map[string]any{
+			"input":           input,
+			"output":          output,
+			"written_records": written,
+		})
+	}
+	writeText(cmd.Writer, "Filtered %d rows from %s to %s\n", written, input, output)
+	return nil
+}
+
+func runFilterByIncludeSet(ctx context.Context, cmd *cli.Command, p *pulse.Pulse, input, output, includeFrom, includeField, filterExpr string, jsonOut bool) error {
+	schema, err := p.ResolveCanonicalSchema(ctx, input)
+	if err != nil {
+		if jsonOut {
+			return writeErrorEnvelope(cmd.Writer, "FILTER_ERROR", err.Error())
+		}
+		return err
+	}
+
+	f, err := os.Open(includeFrom)
+	if err != nil {
+		if jsonOut {
+			return writeErrorEnvelope(cmd.Writer, "CLI_INPUT", err.Error())
+		}
+		return fmt.Errorf("opening --include-from %s: %w", includeFrom, err)
+	}
+	defer f.Close()
+
+	load, err := pulse.LoadMemberSetFromReader(f, schema, includeField)
+	if err != nil {
+		if jsonOut {
+			return writeErrorEnvelope(cmd.Writer, "FILTER_ERROR", err.Error())
+		}
+		return err
+	}
+
+	written, err := p.FilterToFileBySetAndExpr(ctx, input, output, includeField, load.Set, filterExpr)
+	if err != nil {
+		if jsonOut {
+			return writeErrorEnvelope(cmd.Writer, "FILTER_ERROR", err.Error())
+		}
+		return err
+	}
+
+	if jsonOut {
+		return writeEnvelope(cmd.Writer, map[string]any{
+			"input":               input,
+			"output":              output,
+			"written_records":     written,
+			"include_field":       includeField,
+			"include_kind":        load.Set.Kind(),
+			"include_members":     load.Set.Len(),
+			"include_lines":       load.Lines,
+			"include_not_in_dict": load.NotInDictionary,
+			"include_invalid":     load.Invalid,
+		})
+	}
+
+	writeText(cmd.Writer, "Loaded %d include values (%s) from %s; field=%q",
+		load.Set.Len(), load.Set.Kind(), includeFrom, includeField)
+	if load.NotInDictionary > 0 {
+		writeText(cmd.Writer, "; %d not in dictionary (dropped)", load.NotInDictionary)
+	}
+	if load.Invalid > 0 {
+		writeText(cmd.Writer, "; %d invalid (dropped)", load.Invalid)
+	}
+	writeText(cmd.Writer, "\nFiltered %d rows from %s to %s\n", written, input, output)
+	return nil
 }

--- a/internal/cli/cohort_filter_test.go
+++ b/internal/cli/cohort_filter_test.go
@@ -1,0 +1,254 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/frankbardon/pulse"
+)
+
+// runCohortCLI drives a fresh CohortCommand with the supplied args.
+// Stdout is redirected to discard so tests assert side effects on disk
+// rather than captured stdout — mirrors runImportCLI's pattern.
+func runCohortCLI(t *testing.T, args ...string) error {
+	t.Helper()
+	root := CohortCommand()
+	root.Writer = io.Discard
+	return root.Run(context.Background(), append([]string{"cohort"}, args...))
+}
+
+// seedCohortViaImport rounds-trips a CSV through `pulse import auto` so
+// the test cohort lives at PULSE_DATA_DIR/imports/<base>.pulse with the
+// schema the importer chooses for the supplied data.
+func seedCohortViaImport(t *testing.T, dir, csvName, csv string) string {
+	t.Helper()
+	csvPath := filepath.Join(dir, csvName)
+	if err := os.WriteFile(csvPath, []byte(csv), 0o644); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+	if err := runImportCLI(t, "auto", csvName); err != nil {
+		t.Fatalf("import auto: %v", err)
+	}
+	base := csvName[:len(csvName)-len(".csv")]
+	return filepath.Join(dir, "imports", base+".pulse")
+}
+
+func writeInclude(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write include: %v", err)
+	}
+	return p
+}
+
+// inspectRecordCount opens the cohort at the absolute path through a
+// dedicated pulse.Pulse instance (rooted at the file's parent dir) and
+// returns Cohort.RecordCount. We don't reuse descriptor.InspectFromBytes
+// because the single-file inspect path doesn't populate RecordCount —
+// the value is derived from total bytes / record size, which Cohort
+// already computes.
+func inspectRecordCount(t *testing.T, path string) int64 {
+	t.Helper()
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	p, err := pulse.New(pulse.Options{DataDir: dir})
+	if err != nil {
+		t.Fatalf("pulse.New: %v", err)
+	}
+	cohort, err := p.Open(context.Background(), base)
+	if err != nil {
+		t.Fatalf("Open %s: %v", path, err)
+	}
+	n, err := cohort.RecordCount()
+	if err != nil {
+		t.Fatalf("RecordCount %s: %v", path, err)
+	}
+	return n
+}
+
+func TestCohortFilterCLI_IncludeOnly_Integer(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n101,10\n102,20\n103,30\n104,40\n105,50\n")
+	inc := writeInclude(t, dir, "ids.txt", "102\n104\n")
+	dst := filepath.Join(dir, "filtered.pulse")
+
+	if err := runCohortCLI(t,
+		"filter",
+		"-i", src,
+		"-o", dst,
+		"--include-from", inc,
+		"--include-field", "id",
+	); err != nil {
+		t.Fatalf("cohort filter: %v", err)
+	}
+	if n := inspectRecordCount(t, dst); n != 2 {
+		t.Errorf("filtered row count = %d, want 2", n)
+	}
+}
+
+func TestCohortFilterCLI_IncludePlusFilter_AND(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n101,10\n102,20\n103,30\n104,40\n105,50\n")
+	inc := writeInclude(t, dir, "ids.txt", "102\n104\n")
+	dst := filepath.Join(dir, "both.pulse")
+
+	if err := runCohortCLI(t,
+		"filter",
+		"-i", src,
+		"-o", dst,
+		"--include-from", inc,
+		"--include-field", "id",
+		"--filter", "score > 25.0",
+	); err != nil {
+		t.Fatalf("cohort filter (combined): %v", err)
+	}
+	if n := inspectRecordCount(t, dst); n != 1 {
+		t.Errorf("combined row count = %d, want 1 (id 104)", n)
+	}
+}
+
+func TestCohortFilterCLI_FilterOnly_RegressionPath(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n101,10\n102,20\n103,30\n104,40\n105,50\n")
+	dst := filepath.Join(dir, "filter_only.pulse")
+
+	if err := runCohortCLI(t,
+		"filter",
+		"-i", src,
+		"-o", dst,
+		"--filter", "score > 25.0",
+	); err != nil {
+		t.Fatalf("cohort filter (filter-only): %v", err)
+	}
+	if n := inspectRecordCount(t, dst); n != 3 {
+		t.Errorf("filter-only row count = %d, want 3", n)
+	}
+}
+
+func TestCohortFilterCLI_RequiresAtLeastOnePredicate(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n1,10\n2,20\n")
+	dst := filepath.Join(dir, "nope.pulse")
+
+	err := runCohortCLI(t, "filter", "-i", src, "-o", dst)
+	if err == nil {
+		t.Fatal("expected error when neither --filter nor --include-from supplied")
+	}
+	if _, statErr := os.Stat(dst); !os.IsNotExist(statErr) {
+		t.Errorf("dst written despite validation failure: %v", statErr)
+	}
+}
+
+func TestCohortFilterCLI_IncludeFromWithoutField(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n1,10\n2,20\n")
+	inc := writeInclude(t, dir, "ids.txt", "1\n")
+	dst := filepath.Join(dir, "nope.pulse")
+
+	err := runCohortCLI(t, "filter",
+		"-i", src,
+		"-o", dst,
+		"--include-from", inc,
+	)
+	if err == nil {
+		t.Fatal("expected error when --include-from set without --include-field")
+	}
+}
+
+func TestCohortFilterCLI_IncludeFieldWithoutFrom(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n1,10\n2,20\n")
+	dst := filepath.Join(dir, "nope.pulse")
+
+	err := runCohortCLI(t, "filter",
+		"-i", src,
+		"-o", dst,
+		"--include-field", "id",
+	)
+	if err == nil {
+		t.Fatal("expected error when --include-field set without --include-from")
+	}
+}
+
+func TestCohortFilterCLI_MissingIncludeFile(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n1,10\n2,20\n")
+	dst := filepath.Join(dir, "nope.pulse")
+
+	err := runCohortCLI(t, "filter",
+		"-i", src,
+		"-o", dst,
+		"--include-from", filepath.Join(dir, "does-not-exist.txt"),
+		"--include-field", "id",
+	)
+	if err == nil {
+		t.Fatal("expected error when --include-from path does not exist")
+	}
+}
+
+func TestCohortFilterCLI_UnknownIncludeField(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n1,10\n2,20\n")
+	inc := writeInclude(t, dir, "ids.txt", "1\n")
+	dst := filepath.Join(dir, "nope.pulse")
+
+	err := runCohortCLI(t, "filter",
+		"-i", src,
+		"-o", dst,
+		"--include-from", inc,
+		"--include-field", "no_such_field",
+	)
+	if err == nil {
+		t.Fatal("expected error when --include-field is not in cohort schema")
+	}
+}
+
+func TestCohortFilterCLI_FloatFieldRejected(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n1,10.5\n2,20.5\n3,30.5\n")
+	inc := writeInclude(t, dir, "scores.txt", "10.5\n")
+	dst := filepath.Join(dir, "nope.pulse")
+
+	err := runCohortCLI(t, "filter",
+		"-i", src,
+		"-o", dst,
+		"--include-from", inc,
+		"--include-field", "score",
+	)
+	if err == nil {
+		t.Fatal("expected error when --include-field is a float column")
+	}
+}
+
+func TestCohortFilterCLI_EmptyIncludeFileWritesZeroRows(t *testing.T) {
+	dir := withTempDataDir(t)
+	src := seedCohortViaImport(t, dir, "ids.csv",
+		"id,score\n1,10\n2,20\n3,30\n")
+	inc := writeInclude(t, dir, "empty.txt", "")
+	dst := filepath.Join(dir, "empty_out.pulse")
+
+	if err := runCohortCLI(t, "filter",
+		"-i", src,
+		"-o", dst,
+		"--include-from", inc,
+		"--include-field", "id",
+	); err != nil {
+		t.Fatalf("cohort filter empty include: %v", err)
+	}
+	if n := inspectRecordCount(t, dst); n != 0 {
+		t.Errorf("empty-include row count = %d, want 0", n)
+	}
+}

--- a/processing/member_set.go
+++ b/processing/member_set.go
@@ -1,0 +1,344 @@
+package processing
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/errors"
+)
+
+// MemberSet is a read-only set of field values used by the cohort
+// filter include-from path to test record membership. Three concrete
+// impls back this interface, picked by field type at load time so the
+// per-row lookup runs on the fastest path available:
+//
+//   - *BitsetSet — categorical fields. One bit per dictionary entry.
+//     Lookup is a single word load + bit test, no hashing, no compare.
+//   - *Uint64Set — integer / date / bit-packed integer fields. Backed
+//     by map[uint64]struct{}; avoids the per-row string allocation a
+//     string-keyed map would force.
+//   - *StringSet — fallback (decimal128, any non-categorical string
+//     surface). Backed by map[string]struct{}.
+//
+// Float fields (f32/f64) are rejected at load time. Exact-equality
+// membership on floats is a footgun; the caller is expected to use the
+// expression filter for numeric ranges.
+//
+// The interface itself carries only metadata; the per-row hot path
+// goes through the concrete type via the predicate built by
+// BuildMemberSetPredicate, which type-switches once at construction and
+// returns a closure with no interface dispatch in the loop.
+type MemberSet interface {
+	Len() int
+	Kind() string
+}
+
+// BitsetSet stores membership as a packed bit per dictionary id.
+//
+// Memory: dictSize bits, rounded up to a uint64 word. A categorical_u32
+// dict at its 4 294 967 295 cap would be ~512 MiB, but in practice
+// categorical dicts run much smaller — a 65 536-entry categorical_u16
+// is 8 KiB.
+type BitsetSet struct {
+	bits []uint64
+	n    int
+}
+
+func (b *BitsetSet) Len() int     { return b.n }
+func (b *BitsetSet) Kind() string { return "bitset" }
+
+// Contains reports whether id is set. Out-of-range ids return false
+// without panicking — the loader can build a bitset sized to the
+// dictionary, but records read against a later, larger dictionary on a
+// shard archive could in principle present an id beyond the bitset.
+func (b *BitsetSet) Contains(id uint32) bool {
+	w := int(id) >> 6
+	if w >= len(b.bits) {
+		return false
+	}
+	return b.bits[w]&(uint64(1)<<(uint(id)&63)) != 0
+}
+
+// Add marks id as present. Idempotent.
+func (b *BitsetSet) Add(id uint32) {
+	w := int(id) >> 6
+	if w >= len(b.bits) {
+		return
+	}
+	bit := uint64(1) << (uint(id) & 63)
+	if b.bits[w]&bit == 0 {
+		b.bits[w] |= bit
+		b.n++
+	}
+}
+
+func newBitsetSet(dictSize int) *BitsetSet {
+	if dictSize < 0 {
+		dictSize = 0
+	}
+	return &BitsetSet{bits: make([]uint64, (dictSize+63)>>6)}
+}
+
+// Uint64Set stores integer membership.
+type Uint64Set struct {
+	m map[uint64]struct{}
+}
+
+func (s *Uint64Set) Len() int               { return len(s.m) }
+func (s *Uint64Set) Kind() string           { return "uint64" }
+func (s *Uint64Set) Contains(v uint64) bool { _, ok := s.m[v]; return ok }
+func (s *Uint64Set) Add(v uint64)           { s.m[v] = struct{}{} }
+
+func newUint64Set(hint int) *Uint64Set {
+	if hint < 0 {
+		hint = 0
+	}
+	return &Uint64Set{m: make(map[uint64]struct{}, hint)}
+}
+
+// StringSet stores string membership (decimal128 fields, fallback path).
+type StringSet struct {
+	m map[string]struct{}
+}
+
+func (s *StringSet) Len() int     { return len(s.m) }
+func (s *StringSet) Kind() string { return "string" }
+func (s *StringSet) Contains(v string) bool {
+	_, ok := s.m[v]
+	return ok
+}
+func (s *StringSet) Add(v string) { s.m[v] = struct{}{} }
+
+func newStringSet(hint int) *StringSet {
+	if hint < 0 {
+		hint = 0
+	}
+	return &StringSet{m: make(map[string]struct{}, hint)}
+}
+
+// LoadMemberSetResult is the per-load report returned by
+// LoadMemberSetFromReader. Lines is total non-blank lines processed;
+// NotInDictionary counts categorical lookups whose value was absent
+// from the field's dictionary (those keys can never match a record so
+// they're dropped); Invalid counts numeric lines that failed to parse
+// on the integer path. Callers can decide whether to surface each
+// counter as a warning or hard error.
+type LoadMemberSetResult struct {
+	Set             MemberSet
+	Lines           int
+	NotInDictionary int
+	Invalid         int
+}
+
+// LoadMemberSetFromReader reads newline-delimited values from r and
+// builds the best MemberSet impl for the named field on schema. Lines
+// are trimmed of surrounding whitespace (covers CRLF). A UTF-8 BOM is
+// stripped from the very first line. Blank lines are skipped silently
+// — they don't count against Lines.
+//
+// Dispatch by field type:
+//
+//   - categorical_u{8,16,32}: parse line as string, resolve via
+//     dict.IDFor → BitsetSet. Lines not in the dictionary are counted
+//     in NotInDictionary and dropped — they can never match a record.
+//   - u8/u16/u32/u64, nullable_u4/u8/u16, nullable_bool, packed_bool,
+//     date: parse as uint64 → Uint64Set. ParseUint failures are
+//     counted in Invalid and dropped.
+//   - decimal128 / nullable_decimal128: parse as string → StringSet.
+//     The cohort filter compares the literal text against the
+//     decimal128 wide value's String() form; exact match required.
+//
+// Float fields are rejected with SERVICE_VALIDATION. Unknown field
+// names return SERVICE_VALIDATION.
+func LoadMemberSetFromReader(r io.Reader, schema *encoding.Schema, fieldName string) (LoadMemberSetResult, error) {
+	f := schema.Field(fieldName)
+	if f == nil {
+		return LoadMemberSetResult{}, errors.NewCodedErrorWithDetails(
+			errors.SERVICE_VALIDATION,
+			fmt.Sprintf("include field %q not present in cohort schema", fieldName),
+			map[string]any{"field": fieldName})
+	}
+	if f.Type == encoding.FieldTypeF32 || f.Type == encoding.FieldTypeF64 {
+		return LoadMemberSetResult{}, errors.NewCodedErrorWithDetails(
+			errors.SERVICE_VALIDATION,
+			fmt.Sprintf("include-set membership on float field %q is unsupported; use --filter for numeric ranges", fieldName),
+			map[string]any{"field": fieldName, "type": f.Type.String()})
+	}
+
+	var (
+		bitset *BitsetSet
+		uset   *Uint64Set
+		sset   *StringSet
+	)
+	switch {
+	case f.Type.IsCategorical() && f.Dictionary != nil:
+		bitset = newBitsetSet(f.Dictionary.Count())
+	case f.Type == encoding.FieldTypeU8, f.Type == encoding.FieldTypeU16,
+		f.Type == encoding.FieldTypeU32, f.Type == encoding.FieldTypeU64,
+		f.Type == encoding.FieldTypeNullableU4, f.Type == encoding.FieldTypeNullableU8,
+		f.Type == encoding.FieldTypeNullableU16, f.Type == encoding.FieldTypeNullableBool,
+		f.Type == encoding.FieldTypePackedBool, f.Type == encoding.FieldTypeDate:
+		uset = newUint64Set(1024)
+	default:
+		sset = newStringSet(1024)
+	}
+
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64<<10), 1<<20)
+	var (
+		lines     int
+		notInDict int
+		invalid   int
+		first     = true
+	)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if first {
+			first = false
+			if len(line) >= 3 && line[0] == 0xEF && line[1] == 0xBB && line[2] == 0xBF {
+				line = line[3:]
+			}
+		}
+		s := strings.TrimSpace(string(line))
+		if s == "" {
+			continue
+		}
+		lines++
+		switch {
+		case bitset != nil:
+			id, ok := f.Dictionary.IDFor(s)
+			if !ok {
+				notInDict++
+				continue
+			}
+			bitset.Add(id)
+		case uset != nil:
+			v, err := strconv.ParseUint(s, 10, 64)
+			if err != nil {
+				invalid++
+				continue
+			}
+			uset.Add(v)
+		default:
+			sset.Add(s)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return LoadMemberSetResult{}, errors.WrapCodedError(err, errors.SERVICE_RESOURCE,
+			"reading include-from values")
+	}
+
+	res := LoadMemberSetResult{Lines: lines, NotInDictionary: notInDict, Invalid: invalid}
+	switch {
+	case bitset != nil:
+		res.Set = bitset
+	case uset != nil:
+		res.Set = uset
+	default:
+		res.Set = sset
+	}
+	return res, nil
+}
+
+// BuildMemberSetPredicate returns a per-row FilterFunc that reports
+// whether the record's value for fieldName is a member of set. The
+// concrete predicate is selected once at construction by type-switching
+// on the set + schema field type — the returned closure carries no
+// interface dispatch on the hot path.
+//
+// Float fields are rejected, matching LoadMemberSetFromReader. Unknown
+// field names return SERVICE_VALIDATION.
+func BuildMemberSetPredicate(set MemberSet, schema *encoding.Schema, fieldName string) (FilterFunc, error) {
+	if set == nil {
+		return nil, errors.NewCodedError(errors.SERVICE_VALIDATION,
+			"BuildMemberSetPredicate requires a non-nil set")
+	}
+	f := schema.Field(fieldName)
+	if f == nil {
+		return nil, errors.NewCodedErrorWithDetails(
+			errors.SERVICE_VALIDATION,
+			fmt.Sprintf("include field %q not present in cohort schema", fieldName),
+			map[string]any{"field": fieldName})
+	}
+	if f.Type == encoding.FieldTypeF32 || f.Type == encoding.FieldTypeF64 {
+		return nil, errors.NewCodedErrorWithDetails(
+			errors.SERVICE_VALIDATION,
+			fmt.Sprintf("include-set membership on float field %q is unsupported", fieldName),
+			map[string]any{"field": fieldName, "type": f.Type.String()})
+	}
+
+	switch s := set.(type) {
+	case *BitsetSet:
+		if !f.Type.IsCategorical() {
+			return nil, errors.NewCodedErrorWithDetails(
+				errors.SERVICE_VALIDATION,
+				fmt.Sprintf("BitsetSet predicate requires a categorical field; %q is %s", fieldName, f.Type),
+				map[string]any{"field": fieldName, "type": f.Type.String()})
+		}
+		field := fieldName
+		return func(rec *Record) (bool, error) {
+			v, ok := rec.NumericValue(field)
+			if !ok {
+				return false, nil
+			}
+			return s.Contains(uint32(v)), nil
+		}, nil
+	case *Uint64Set:
+		field := fieldName
+		isCategorical := f.Type.IsCategorical()
+		return func(rec *Record) (bool, error) {
+			v, ok := rec.NumericValue(field)
+			if !ok {
+				return false, nil
+			}
+			if isCategorical {
+				// Categorical-but-loaded-as-uint64 means caller built
+				// the set against raw dict ids. Treat the float as the
+				// id directly.
+				return s.Contains(uint64(uint32(v))), nil
+			}
+			return s.Contains(uint64(v)), nil
+		}, nil
+	case *StringSet:
+		field := fieldName
+		if f.Type.IsCategorical() {
+			return func(rec *Record) (bool, error) {
+				sv, ok := rec.StringValue(field)
+				if !ok {
+					return false, nil
+				}
+				return s.Contains(sv), nil
+			}, nil
+		}
+		if f.Type.IsDecimal() {
+			scale := f.Scale
+			return func(rec *Record) (bool, error) {
+				wv, ok := rec.WideValue(field)
+				if !ok {
+					return false, nil
+				}
+				dec, isDec := wv.(encoding.Decimal128)
+				if !isDec {
+					return false, nil
+				}
+				return s.Contains(dec.String(scale)), nil
+			}, nil
+		}
+		return func(rec *Record) (bool, error) {
+			v, ok := rec.NumericValue(field)
+			if !ok {
+				return false, nil
+			}
+			return s.Contains(strconv.FormatUint(uint64(v), 10)), nil
+		}, nil
+	default:
+		return nil, errors.NewCodedErrorWithDetails(
+			errors.SERVICE_VALIDATION,
+			fmt.Sprintf("unsupported MemberSet impl: %T", set),
+			map[string]any{"kind": "unknown"})
+	}
+}

--- a/processing/member_set_bench_test.go
+++ b/processing/member_set_bench_test.go
@@ -1,0 +1,146 @@
+package processing
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+)
+
+// Per-lookup latency benchmarks for the three MemberSet impls. Run via:
+//
+//	go test ./processing/ -run=^$ -bench=BenchmarkMemberSet -benchmem
+//
+// Each Contains call should land in the low-nanosecond range:
+//
+//   - BitsetSet:  ~1 ns  (single word load + bit test)
+//   - Uint64Set:  ~7-15 ns (Go map[uint64]struct{})
+//   - StringSet:  ~15-25 ns (Go map[string]struct{}, key hash)
+//
+// The numbers above are guidance, not asserted bounds — Go's bench
+// machinery has too much variance across hosts to gate on absolutes.
+
+const benchSetSize = 1_000_000
+
+func benchKeys(n int) []uint64 {
+	keys := make([]uint64, n)
+	for i := range keys {
+		keys[i] = uint64(i)
+	}
+	return keys
+}
+
+func benchStrKeys(n int) []string {
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = strconv.FormatInt(int64(i), 10)
+	}
+	return keys
+}
+
+func BenchmarkMemberSet_Bitset_Contains(b *testing.B) {
+	bs := newBitsetSet(benchSetSize)
+	for i := 0; i < benchSetSize; i += 2 { // half the keys present
+		bs.Add(uint32(i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = bs.Contains(uint32(i % benchSetSize))
+	}
+}
+
+func BenchmarkMemberSet_Uint64_Contains(b *testing.B) {
+	us := newUint64Set(benchSetSize)
+	for _, k := range benchKeys(benchSetSize / 2) {
+		us.Add(k)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = us.Contains(uint64(i % benchSetSize))
+	}
+}
+
+func BenchmarkMemberSet_String_Contains(b *testing.B) {
+	ss := newStringSet(benchSetSize)
+	keys := benchStrKeys(benchSetSize / 2)
+	for _, k := range keys {
+		ss.Add(k)
+	}
+	probe := benchStrKeys(benchSetSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ss.Contains(probe[i%benchSetSize])
+	}
+}
+
+// BenchmarkMemberSet_LoadIntegerFromReader measures end-to-end loader
+// throughput for a 1M-line uint64 include file. Reports ns/line.
+func BenchmarkMemberSet_LoadIntegerFromReader(b *testing.B) {
+	const n = 100_000
+	var buf []byte
+	for i := 0; i < n; i++ {
+		buf = strconv.AppendUint(buf, uint64(i), 10)
+		buf = append(buf, '\n')
+	}
+	schema := &encoding.Schema{Fields: []encoding.Field{
+		{Name: "id", Type: encoding.FieldTypeU64},
+	}}
+	b.SetBytes(int64(len(buf)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := LoadMemberSetFromReader(bytes.NewReader(buf), schema, "id")
+		if err != nil {
+			b.Fatalf("LoadMemberSetFromReader: %v", err)
+		}
+	}
+}
+
+// BenchmarkMemberSet_BuildPredicate_Bitset measures the per-row cost of
+// the closure returned by BuildMemberSetPredicate when applied to a
+// fresh Record. Compares the categorical-bitset hot path against a
+// uint64-map path for the same record shape.
+func BenchmarkMemberSet_BuildPredicate_Bitset(b *testing.B) {
+	dict := encoding.NewDictionary()
+	for i := 0; i < 1024; i++ {
+		dict.Add(strconv.Itoa(i))
+	}
+	schema := &encoding.Schema{Fields: []encoding.Field{
+		{Name: "k", Type: encoding.FieldTypeCategoricalU16, Dictionary: dict},
+	}}
+	bs := newBitsetSet(1024)
+	for i := 0; i < 512; i++ {
+		bs.Add(uint32(i))
+	}
+	fn, err := BuildMemberSetPredicate(bs, schema, "k")
+	if err != nil {
+		b.Fatalf("BuildMemberSetPredicate: %v", err)
+	}
+	rec := NewRecord(schema, map[string]float64{"k": 0})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rec.values["k"] = float64(i & 1023)
+		_, _ = fn(rec)
+	}
+}
+
+func BenchmarkMemberSet_BuildPredicate_Uint64(b *testing.B) {
+	schema := &encoding.Schema{Fields: []encoding.Field{
+		{Name: "k", Type: encoding.FieldTypeU64},
+	}}
+	us := newUint64Set(1024)
+	for i := uint64(0); i < 512; i++ {
+		us.Add(i)
+	}
+	fn, err := BuildMemberSetPredicate(us, schema, "k")
+	if err != nil {
+		b.Fatalf("BuildMemberSetPredicate: %v", err)
+	}
+	rec := NewRecord(schema, map[string]float64{"k": 0})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rec.values["k"] = float64(uint64(i) & 1023)
+		_, _ = fn(rec)
+	}
+}
+

--- a/processing/member_set_test.go
+++ b/processing/member_set_test.go
@@ -1,0 +1,306 @@
+package processing
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/errors"
+)
+
+func memberSetCategoricalSchema(t *testing.T, name string, ft encoding.FieldType, entries ...string) *encoding.Schema {
+	t.Helper()
+	dict := encoding.NewDictionary()
+	for _, e := range entries {
+		if _, err := dict.Add(e); err != nil {
+			t.Fatalf("dict.Add: %v", err)
+		}
+	}
+	return &encoding.Schema{Fields: []encoding.Field{
+		{Name: name, Type: ft, Dictionary: dict},
+	}}
+}
+
+func u64Schema(name string, ft encoding.FieldType) *encoding.Schema {
+	return &encoding.Schema{Fields: []encoding.Field{{Name: name, Type: ft}}}
+}
+
+func TestLoadMemberSet_Categorical_Bitset(t *testing.T) {
+	schema := memberSetCategoricalSchema(t, "color", encoding.FieldTypeCategoricalU8, "red", "green", "blue")
+	r := strings.NewReader("red\nblue\nred\n")
+	res, err := LoadMemberSetFromReader(r, schema, "color")
+	if err != nil {
+		t.Fatalf("LoadMemberSetFromReader: %v", err)
+	}
+	bs, ok := res.Set.(*BitsetSet)
+	if !ok {
+		t.Fatalf("set is %T, want *BitsetSet", res.Set)
+	}
+	if bs.Len() != 2 {
+		t.Errorf("Len = %d, want 2 (red dedup)", bs.Len())
+	}
+	if !bs.Contains(0) {
+		t.Error("red (id 0) missing")
+	}
+	if bs.Contains(1) {
+		t.Error("green (id 1) should not be present")
+	}
+	if !bs.Contains(2) {
+		t.Error("blue (id 2) missing")
+	}
+	if res.Lines != 3 {
+		t.Errorf("Lines = %d, want 3", res.Lines)
+	}
+}
+
+func TestLoadMemberSet_CategoricalDrops_NotInDictionary(t *testing.T) {
+	schema := memberSetCategoricalSchema(t, "color", encoding.FieldTypeCategoricalU8, "red", "green")
+	r := strings.NewReader("red\norange\nyellow\n")
+	res, err := LoadMemberSetFromReader(r, schema, "color")
+	if err != nil {
+		t.Fatalf("LoadMemberSetFromReader: %v", err)
+	}
+	if res.NotInDictionary != 2 {
+		t.Errorf("NotInDictionary = %d, want 2", res.NotInDictionary)
+	}
+	if res.Set.Len() != 1 {
+		t.Errorf("Set.Len = %d, want 1", res.Set.Len())
+	}
+}
+
+func TestLoadMemberSet_Integer_Uint64(t *testing.T) {
+	schema := u64Schema("id", encoding.FieldTypeU64)
+	r := strings.NewReader("1\n2\n2\n42\n9999999999\n")
+	res, err := LoadMemberSetFromReader(r, schema, "id")
+	if err != nil {
+		t.Fatalf("LoadMemberSetFromReader: %v", err)
+	}
+	us, ok := res.Set.(*Uint64Set)
+	if !ok {
+		t.Fatalf("set is %T, want *Uint64Set", res.Set)
+	}
+	if us.Len() != 4 {
+		t.Errorf("Len = %d, want 4 (dedup)", us.Len())
+	}
+	for _, want := range []uint64{1, 2, 42, 9999999999} {
+		if !us.Contains(want) {
+			t.Errorf("missing %d", want)
+		}
+	}
+	if us.Contains(3) {
+		t.Error("unexpected 3 in set")
+	}
+}
+
+func TestLoadMemberSet_IntegerInvalid(t *testing.T) {
+	schema := u64Schema("id", encoding.FieldTypeU32)
+	r := strings.NewReader("1\nabc\n2\n-3\n4\n")
+	res, err := LoadMemberSetFromReader(r, schema, "id")
+	if err != nil {
+		t.Fatalf("LoadMemberSetFromReader: %v", err)
+	}
+	if res.Invalid != 2 {
+		t.Errorf("Invalid = %d, want 2", res.Invalid)
+	}
+	if res.Set.Len() != 3 {
+		t.Errorf("Set.Len = %d, want 3 (1,2,4)", res.Set.Len())
+	}
+}
+
+func TestLoadMemberSet_FloatRejected(t *testing.T) {
+	schema := u64Schema("x", encoding.FieldTypeF64)
+	_, err := LoadMemberSetFromReader(strings.NewReader("1.0\n"), schema, "x")
+	if err == nil {
+		t.Fatal("expected error for f64 field")
+	}
+	if !errors.HasCode(err, errors.SERVICE_VALIDATION) {
+		t.Errorf("err = %v, want SERVICE_VALIDATION", err)
+	}
+	_, err = LoadMemberSetFromReader(strings.NewReader("1.0\n"), u64Schema("x", encoding.FieldTypeF32), "x")
+	if err == nil {
+		t.Fatal("expected error for f32 field")
+	}
+}
+
+func TestLoadMemberSet_UnknownField(t *testing.T) {
+	schema := u64Schema("id", encoding.FieldTypeU32)
+	_, err := LoadMemberSetFromReader(strings.NewReader("1\n"), schema, "nope")
+	if err == nil {
+		t.Fatal("expected unknown-field error")
+	}
+	if !errors.HasCode(err, errors.SERVICE_VALIDATION) {
+		t.Errorf("err = %v, want SERVICE_VALIDATION", err)
+	}
+}
+
+func TestLoadMemberSet_BlanksBOM_CRLF(t *testing.T) {
+	schema := u64Schema("id", encoding.FieldTypeU64)
+	r := strings.NewReader("\xEF\xBB\xBF1\r\n\r\n2\n\n   3   \n")
+	res, err := LoadMemberSetFromReader(r, schema, "id")
+	if err != nil {
+		t.Fatalf("LoadMemberSetFromReader: %v", err)
+	}
+	if res.Set.Len() != 3 {
+		t.Errorf("Set.Len = %d, want 3 (1,2,3)", res.Set.Len())
+	}
+	if res.Lines != 3 {
+		t.Errorf("Lines = %d, want 3", res.Lines)
+	}
+	us := res.Set.(*Uint64Set)
+	for _, v := range []uint64{1, 2, 3} {
+		if !us.Contains(v) {
+			t.Errorf("missing %d after CRLF/BOM/whitespace stripping", v)
+		}
+	}
+}
+
+func TestLoadMemberSet_DecimalIsStringSet(t *testing.T) {
+	schema := &encoding.Schema{Fields: []encoding.Field{
+		{Name: "amt", Type: encoding.FieldTypeDecimal128, Precision: 18, Scale: 2},
+	}}
+	r := strings.NewReader("12.34\n0.01\n12.34\n")
+	res, err := LoadMemberSetFromReader(r, schema, "amt")
+	if err != nil {
+		t.Fatalf("LoadMemberSetFromReader: %v", err)
+	}
+	if _, ok := res.Set.(*StringSet); !ok {
+		t.Fatalf("set is %T, want *StringSet", res.Set)
+	}
+	if res.Set.Len() != 2 {
+		t.Errorf("Set.Len = %d, want 2", res.Set.Len())
+	}
+}
+
+func TestLoadMemberSet_EmptyFile(t *testing.T) {
+	schema := u64Schema("id", encoding.FieldTypeU32)
+	res, err := LoadMemberSetFromReader(strings.NewReader(""), schema, "id")
+	if err != nil {
+		t.Fatalf("LoadMemberSetFromReader: %v", err)
+	}
+	if res.Set.Len() != 0 {
+		t.Errorf("Set.Len = %d, want 0", res.Set.Len())
+	}
+	if res.Lines != 0 {
+		t.Errorf("Lines = %d, want 0", res.Lines)
+	}
+}
+
+func TestBuildMemberSetPredicate_Bitset_Categorical(t *testing.T) {
+	schema := memberSetCategoricalSchema(t, "color", encoding.FieldTypeCategoricalU8, "red", "green", "blue")
+	bs := newBitsetSet(3)
+	bs.Add(0) // red
+	bs.Add(2) // blue
+
+	fn, err := BuildMemberSetPredicate(bs, schema, "color")
+	if err != nil {
+		t.Fatalf("BuildMemberSetPredicate: %v", err)
+	}
+
+	rec := NewRecord(schema, map[string]float64{"color": 0})
+	keep, err := fn(rec)
+	if err != nil {
+		t.Fatalf("fn: %v", err)
+	}
+	if !keep {
+		t.Error("red should be kept")
+	}
+
+	rec = NewRecord(schema, map[string]float64{"color": 1})
+	keep, _ = fn(rec)
+	if keep {
+		t.Error("green should be dropped")
+	}
+
+	rec = NewRecord(schema, map[string]float64{"color": 2})
+	keep, _ = fn(rec)
+	if !keep {
+		t.Error("blue should be kept")
+	}
+}
+
+func TestBuildMemberSetPredicate_Bitset_NonCategoricalRejected(t *testing.T) {
+	schema := u64Schema("id", encoding.FieldTypeU32)
+	bs := newBitsetSet(4)
+	_, err := BuildMemberSetPredicate(bs, schema, "id")
+	if err == nil {
+		t.Fatal("expected error for bitset on non-categorical field")
+	}
+}
+
+func TestBuildMemberSetPredicate_Uint64Set(t *testing.T) {
+	schema := u64Schema("id", encoding.FieldTypeU32)
+	us := newUint64Set(4)
+	us.Add(1)
+	us.Add(7)
+
+	fn, err := BuildMemberSetPredicate(us, schema, "id")
+	if err != nil {
+		t.Fatalf("BuildMemberSetPredicate: %v", err)
+	}
+
+	for _, c := range []struct {
+		v    float64
+		want bool
+	}{{1, true}, {2, false}, {7, true}, {0, false}} {
+		keep, _ := fn(NewRecord(schema, map[string]float64{"id": c.v}))
+		if keep != c.want {
+			t.Errorf("id=%v: keep=%v want=%v", c.v, keep, c.want)
+		}
+	}
+}
+
+func TestBuildMemberSetPredicate_StringSet_Categorical(t *testing.T) {
+	schema := memberSetCategoricalSchema(t, "color", encoding.FieldTypeCategoricalU8, "red", "green", "blue")
+	ss := newStringSet(2)
+	ss.Add("green")
+
+	fn, err := BuildMemberSetPredicate(ss, schema, "color")
+	if err != nil {
+		t.Fatalf("BuildMemberSetPredicate: %v", err)
+	}
+
+	rec := NewRecord(schema, map[string]float64{"color": 1})
+	keep, _ := fn(rec)
+	if !keep {
+		t.Error("green should be kept (string lookup via dict)")
+	}
+	rec = NewRecord(schema, map[string]float64{"color": 0})
+	keep, _ = fn(rec)
+	if keep {
+		t.Error("red should be dropped")
+	}
+}
+
+func TestBuildMemberSetPredicate_FloatRejected(t *testing.T) {
+	schema := u64Schema("x", encoding.FieldTypeF64)
+	_, err := BuildMemberSetPredicate(newUint64Set(0), schema, "x")
+	if err == nil {
+		t.Fatal("expected float rejection")
+	}
+}
+
+func TestBuildMemberSetPredicate_NullValueDrops(t *testing.T) {
+	schema := u64Schema("id", encoding.FieldTypeU32)
+	us := newUint64Set(2)
+	us.Add(1)
+	fn, err := BuildMemberSetPredicate(us, schema, "id")
+	if err != nil {
+		t.Fatalf("BuildMemberSetPredicate: %v", err)
+	}
+	rec := NewRecordWithNulls(schema, map[string]float64{}, map[string]bool{"id": true})
+	keep, _ := fn(rec)
+	if keep {
+		t.Error("null record value must not match set")
+	}
+}
+
+func TestBitsetSet_ContainsOutOfRange(t *testing.T) {
+	bs := newBitsetSet(8)
+	if bs.Contains(99) {
+		t.Error("out-of-range id should return false without panic")
+	}
+}
+
+// silence "math" import if all f-math removed during refactor
+var _ = math.Pi

--- a/pulse.go
+++ b/pulse.go
@@ -1104,3 +1104,14 @@ func (c *Cohort) Categorical(name string) (*encoding.Dictionary, bool) {
 func (c *Cohort) Shards() []ShardEntry {
 	return c.inner.Shards()
 }
+
+// RecordCount returns the number of records in the cohort. For
+// single-file cohorts this is derived from the byte length of the
+// record region divided by the per-record size implied by the schema.
+// For archive-backed cohorts the caller should sum per-shard
+// RecordCount values from Shards() — the underlying service Cohort
+// errors on RecordCount for archives because the byte-region path
+// doesn't apply across shards.
+func (c *Cohort) RecordCount() (int64, error) {
+	return c.inner.RecordCount()
+}

--- a/pulse.go
+++ b/pulse.go
@@ -19,11 +19,31 @@ import (
 	"github.com/frankbardon/pulse/imports"
 	"github.com/frankbardon/pulse/internal/query"
 	pio "github.com/frankbardon/pulse/io"
+	"github.com/frankbardon/pulse/processing"
 	"github.com/frankbardon/pulse/service"
 	"github.com/frankbardon/pulse/synth"
 	"github.com/frankbardon/pulse/types"
 	"github.com/spf13/afero"
 )
+
+// MemberSet is the public alias for processing.MemberSet — the
+// read-only set type consumed by FilterToFileBySetAndExpr. Build one
+// via LoadMemberSetFromReader (recommended for newline-delimited files)
+// or by constructing a concrete impl directly.
+type MemberSet = processing.MemberSet
+
+// LoadMemberSetResult mirrors processing.LoadMemberSetResult so callers
+// can inspect drop counts after loading an include-set file.
+type LoadMemberSetResult = processing.LoadMemberSetResult
+
+// LoadMemberSetFromReader is the public alias for the underlying
+// processing-package loader. It reads newline-delimited values from r
+// and returns the best MemberSet impl for the named field on schema
+// (bitset for categorical, uint64 map for integer / date, string map
+// for decimal / fallback). Float fields are rejected.
+func LoadMemberSetFromReader(r io.Reader, schema *encoding.Schema, fieldName string) (LoadMemberSetResult, error) {
+	return processing.LoadMemberSetFromReader(r, schema, fieldName)
+}
 
 // Type aliases re-exported from the types package so embedders can use
 // pulse.Request instead of types.Request.
@@ -514,6 +534,41 @@ func (p *Pulse) Sample(ctx context.Context, path string, n int) ([]Record, error
 // archive inputs).
 func (p *Pulse) FilterToFile(ctx context.Context, src, dst, filterExpr string) (int64, error) {
 	n, err := p.svc.FilterToFile(ctx, src, dst, filterExpr)
+	if err == nil {
+		p.touchManaged(ctx, src)
+	}
+	return n, err
+}
+
+// ResolveCanonicalSchema returns the canonical encoding.Schema for the
+// cohort at src without streaming records. Resolves single-file,
+// shard-archive, and `archive#shard` anchor inputs identically to the
+// rest of the facade.
+//
+// Useful for callers that need to build an include-set before invoking
+// FilterToFileBySetAndExpr: the set loader requires the schema to pick
+// the best MemberSet impl (bitset / uint64 / string) for the field's
+// type.
+func (p *Pulse) ResolveCanonicalSchema(ctx context.Context, src string) (*encoding.Schema, error) {
+	return p.svc.ResolveCanonicalSchema(ctx, src)
+}
+
+// FilterToFileBySetAndExpr applies an optional MemberSet membership
+// test (record's value for includeField must be in set) combined with
+// an optional FILTER_EXPRESSION (filterExpr) to every record in src,
+// writing the survivors to dst. At least one of (set, filterExpr) must
+// be supplied; if both are present they are AND-combined and the set
+// is tested first so per-row work short-circuits on misses without
+// paying the expr eval cost.
+//
+// Input-shape dispatch is identical to FilterToFile (single-file,
+// shard archive, anchor). The set must be built against the same
+// canonical schema as src.
+//
+// Returns the number of records written to dst (sum across shards for
+// archive inputs).
+func (p *Pulse) FilterToFileBySetAndExpr(ctx context.Context, src, dst, includeField string, set MemberSet, filterExpr string) (int64, error) {
+	n, err := p.svc.FilterToFileBySetAndExpr(ctx, src, dst, includeField, set, filterExpr)
 	if err == nil {
 		p.touchManaged(ctx, src)
 	}

--- a/service/filter_to_file.go
+++ b/service/filter_to_file.go
@@ -45,6 +45,110 @@ import (
 // Returns the number of records written to dst (sum across shards for
 // archive inputs).
 func (s *Service) FilterToFile(ctx context.Context, src, dst, filterExpr string) (int64, error) {
+	if filterExpr == "" {
+		return 0, errors.NewCodedError(errors.SERVICE_VALIDATION,
+			"filter_to_file requires a non-empty filter expression")
+	}
+	return s.filterToFile(ctx, src, dst, filterPlan{filterExpr: filterExpr})
+}
+
+// FilterToFileBySetAndExpr applies an include-set predicate (membership
+// test against an externally-supplied list of values) and optionally a
+// filter expression to every record in src, writing the survivors to
+// dst. At least one of (set, filterExpr) must be supplied — if both,
+// the set is tested first and the expression evaluated only on
+// surviving rows (cheap-check-first short-circuit).
+//
+// Input-shape dispatch matches FilterToFile (single-file, shard
+// archive, anchor). includeField names the field whose value is tested
+// for membership in set; the set must have been built against the same
+// canonical schema as src (the field is resolved per-call to keep the
+// predicate schema-coherent across shards).
+//
+// Returns the number of records written to dst.
+func (s *Service) FilterToFileBySetAndExpr(ctx context.Context, src, dst, includeField string, set processing.MemberSet, filterExpr string) (int64, error) {
+	if set == nil && filterExpr == "" {
+		return 0, errors.NewCodedError(errors.SERVICE_VALIDATION,
+			"filter_to_file requires at least one of include-set or filter expression")
+	}
+	if set != nil && includeField == "" {
+		return 0, errors.NewCodedError(errors.SERVICE_VALIDATION,
+			"filter_to_file include-set requires a non-empty include field name")
+	}
+	return s.filterToFile(ctx, src, dst, filterPlan{
+		set:          set,
+		includeField: includeField,
+		filterExpr:   filterExpr,
+	})
+}
+
+// filterPlan captures the per-call predicate inputs so the input-shape
+// dispatch (single-file, shard archive, anchor) doesn't have to take a
+// growing list of optional arguments.
+type filterPlan struct {
+	set          processing.MemberSet
+	includeField string
+	filterExpr   string
+}
+
+// ResolveCanonicalSchema reads the canonical schema for src without
+// streaming the record payload. Single-file cohorts return their own
+// schema; shard archives return the canonical `_schema.pulse` schema;
+// anchored shards return the anchored shard's local schema. Used by
+// callers (notably the CLI cohort-filter include-from path) that need
+// schema introspection to build an include-set before invoking
+// FilterToFileBySetAndExpr.
+func (s *Service) ResolveCanonicalSchema(_ context.Context, src string) (*encoding.Schema, error) {
+	if src == "" {
+		return nil, errors.NewCodedError(errors.SERVICE_VALIDATION,
+			"ResolveCanonicalSchema requires a non-empty path")
+	}
+	fsys := s.fs.Fs()
+
+	if archivePath, anchor, ok := splitAnchorPath(src); ok {
+		payload, err := s.readAnchoredShardBytes(archivePath, anchor)
+		if err != nil {
+			return nil, err
+		}
+		return readSchemaFromBytes(payload)
+	}
+
+	data, err := afero.ReadFile(fsys, src)
+	if err != nil {
+		return nil, errors.WrapCodedError(err, errors.SERVICE_RESOURCE,
+			fmt.Sprintf("opening cohort file: %s", src))
+	}
+
+	if isShardArchiveMagic(data) {
+		arch, err := encoding.OpenArchive(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			return nil, err
+		}
+		doc, err := readSchemaDocEntry(arch)
+		if err != nil {
+			return nil, err
+		}
+		return doc.Schema, nil
+	}
+
+	return readSchemaFromBytes(data)
+}
+
+func readSchemaFromBytes(data []byte) (*encoding.Schema, error) {
+	br := bytes.NewReader(data)
+	if err := encoding.ReadHeader(br); err != nil {
+		return nil, errors.WrapCodedError(err, errors.ENCODING_INVALID,
+			"invalid pulse file header")
+	}
+	schema, err := encoding.ReadSchema(br)
+	if err != nil {
+		return nil, errors.WrapCodedError(err, errors.ENCODING_INVALID,
+			"reading schema")
+	}
+	return schema, nil
+}
+
+func (s *Service) filterToFile(ctx context.Context, src, dst string, plan filterPlan) (int64, error) {
 	if src == "" {
 		return 0, errors.NewCodedError(errors.SERVICE_VALIDATION,
 			"filter_to_file requires a non-empty input path")
@@ -52,10 +156,6 @@ func (s *Service) FilterToFile(ctx context.Context, src, dst, filterExpr string)
 	if dst == "" {
 		return 0, errors.NewCodedError(errors.SERVICE_VALIDATION,
 			"filter_to_file requires a non-empty output path")
-	}
-	if filterExpr == "" {
-		return 0, errors.NewCodedError(errors.SERVICE_VALIDATION,
-			"filter_to_file requires a non-empty filter expression")
 	}
 
 	fsys := s.fs.Fs()
@@ -67,7 +167,7 @@ func (s *Service) FilterToFile(ctx context.Context, src, dst, filterExpr string)
 		if err != nil {
 			return 0, err
 		}
-		return s.filterSingleFileBytesToFile(ctx, fsys, payload, dst, filterExpr)
+		return s.filterSingleFileBytesToFile(ctx, fsys, payload, dst, plan)
 	}
 
 	data, err := afero.ReadFile(fsys, src)
@@ -77,17 +177,17 @@ func (s *Service) FilterToFile(ctx context.Context, src, dst, filterExpr string)
 	}
 
 	if isShardArchiveMagic(data) {
-		return s.filterShardArchiveToFile(ctx, fsys, dst, filterExpr, data)
+		return s.filterShardArchiveToFile(ctx, fsys, dst, plan, data)
 	}
 
-	return s.filterSingleFileBytesToFile(ctx, fsys, data, dst, filterExpr)
+	return s.filterSingleFileBytesToFile(ctx, fsys, data, dst, plan)
 }
 
 // filterSingleFileBytesToFile runs the single-file filter loop over an
 // in-memory byte slice and writes the result to dst. Used both for
 // direct single-file inputs and for anchor-syntax inputs (where the
 // anchored shard's bytes form a complete standalone payload).
-func (s *Service) filterSingleFileBytesToFile(ctx context.Context, fsys afero.Fs, data []byte, dst, filterExpr string) (int64, error) {
+func (s *Service) filterSingleFileBytesToFile(ctx context.Context, fsys afero.Fs, data []byte, dst string, plan filterPlan) (int64, error) {
 	br := bytes.NewReader(data)
 	if err := encoding.ReadHeader(br); err != nil {
 		return 0, errors.WrapCodedError(err, errors.ENCODING_INVALID,
@@ -100,7 +200,7 @@ func (s *Service) filterSingleFileBytesToFile(ctx context.Context, fsys afero.Fs
 	}
 	headerSchemaEnd := int64(len(data)) - int64(br.Len())
 
-	filterFn, err := s.buildSingleFilter(schema, filterExpr)
+	filterFn, err := s.buildCombinedFilter(schema, plan)
 	if err != nil {
 		return 0, err
 	}
@@ -125,7 +225,7 @@ func (s *Service) filterSingleFileBytesToFile(ctx context.Context, fsys afero.Fs
 // → one output shard, basename preserved, central-directory order
 // preserved. Empty shards (zero surviving records) are kept so the
 // shard_count metadata stays stable across the filter.
-func (s *Service) filterShardArchiveToFile(ctx context.Context, fsys afero.Fs, dst, filterExpr string, data []byte) (int64, error) {
+func (s *Service) filterShardArchiveToFile(ctx context.Context, fsys afero.Fs, dst string, plan filterPlan, data []byte) (int64, error) {
 	arch, err := encoding.OpenArchive(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return 0, err
@@ -137,7 +237,7 @@ func (s *Service) filterShardArchiveToFile(ctx context.Context, fsys afero.Fs, d
 	}
 	canonicalSchema := canonicalDoc.Schema
 
-	filterFn, err := s.buildSingleFilter(canonicalSchema, filterExpr)
+	filterFn, err := s.buildCombinedFilter(canonicalSchema, plan)
 	if err != nil {
 		return 0, err
 	}
@@ -267,6 +367,48 @@ func (s *Service) buildSingleFilter(schema *encoding.Schema, filterExpr string) 
 		return nil, err
 	}
 	return fns[0], nil
+}
+
+// buildCombinedFilter composes an optional MemberSet membership test
+// with an optional FILTER_EXPRESSION into one FilterFunc. The set
+// predicate runs first when both are present, so per-row work
+// short-circuits on misses without paying the expr eval cost.
+func (s *Service) buildCombinedFilter(schema *encoding.Schema, plan filterPlan) (processing.FilterFunc, error) {
+	var setFn processing.FilterFunc
+	if plan.set != nil {
+		fn, err := processing.BuildMemberSetPredicate(plan.set, schema, plan.includeField)
+		if err != nil {
+			return nil, err
+		}
+		setFn = fn
+	}
+
+	var exprFn processing.FilterFunc
+	if plan.filterExpr != "" {
+		fn, err := s.buildSingleFilter(schema, plan.filterExpr)
+		if err != nil {
+			return nil, err
+		}
+		exprFn = fn
+	}
+
+	switch {
+	case setFn != nil && exprFn != nil:
+		return func(rec *processing.Record) (bool, error) {
+			ok, err := setFn(rec)
+			if err != nil || !ok {
+				return false, err
+			}
+			return exprFn(rec)
+		}, nil
+	case setFn != nil:
+		return setFn, nil
+	case exprFn != nil:
+		return exprFn, nil
+	default:
+		return nil, errors.NewCodedError(errors.SERVICE_VALIDATION,
+			"filter_to_file requires at least one of include-set or filter expression")
+	}
 }
 
 // readAnchoredShardBytes resolves an anchor (archivePath, entry) to the

--- a/service/filter_to_file_set_test.go
+++ b/service/filter_to_file_set_test.go
@@ -1,0 +1,306 @@
+package service
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/errors"
+	"github.com/frankbardon/pulse/processing"
+	"github.com/spf13/afero"
+)
+
+// idScoreRecords builds a small fixture with deterministic ids and
+// scores so include-set filters can be reasoned about exactly.
+func idScoreSchemaAndRecords() (*encoding.Schema, [][]uint64) {
+	schema := &encoding.Schema{Fields: []encoding.Field{
+		{Name: "id", Type: encoding.FieldTypeU32, ByteOffset: 0, CsvColumnIdx: 0},
+		{Name: "score", Type: encoding.FieldTypeF64, ByteOffset: 4, CsvColumnIdx: 1},
+	}}
+	records := [][]uint64{
+		{101, math.Float64bits(10.0)},
+		{102, math.Float64bits(20.0)},
+		{103, math.Float64bits(30.0)},
+		{104, math.Float64bits(40.0)},
+		{105, math.Float64bits(50.0)},
+	}
+	return schema, records
+}
+
+// loadSet loads an include-set against the file at path using svc's
+// schema-resolution helper. Mirrors what the CLI does for callers.
+func loadSet(t *testing.T, svc *Service, path string, field string, raw string) processing.MemberSet {
+	t.Helper()
+	schema, err := svc.ResolveCanonicalSchema(context.Background(), path)
+	if err != nil {
+		t.Fatalf("ResolveCanonicalSchema: %v", err)
+	}
+	res, err := processing.LoadMemberSetFromReader(strings.NewReader(raw), schema, field)
+	if err != nil {
+		t.Fatalf("LoadMemberSetFromReader: %v", err)
+	}
+	return res.Set
+}
+
+func TestFilterToFileBySet_SingleFile_IntegerField(t *testing.T) {
+	schema, records := idScoreSchemaAndRecords()
+	cfg := setupTestFS(t, "src.pulse", schema, records)
+	svc := New(cfg)
+
+	set := loadSet(t, svc, "src.pulse", "id", "102\n104\n")
+	written, err := svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "id", set, "")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr: %v", err)
+	}
+	if written != 2 {
+		t.Errorf("written = %d, want 2", written)
+	}
+
+	// Re-process the output and confirm only ids 102 and 104 made it.
+	cohort, err := svc.Open(context.Background(), "dst.pulse")
+	if err != nil {
+		t.Fatalf("Open dst: %v", err)
+	}
+	count, err := cohort.RecordCount()
+	if err != nil {
+		t.Fatalf("RecordCount: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("dst RecordCount = %d, want 2", count)
+	}
+}
+
+func TestFilterToFileBySet_SingleFile_CategoricalField(t *testing.T) {
+	dict := encoding.NewDictionary()
+	dict.Add("red")
+	dict.Add("green")
+	dict.Add("blue")
+	schema := &encoding.Schema{Fields: []encoding.Field{
+		{Name: "color", Type: encoding.FieldTypeCategoricalU8, ByteOffset: 0, CsvColumnIdx: 0, Dictionary: dict},
+		{Name: "score", Type: encoding.FieldTypeF64, ByteOffset: 1, CsvColumnIdx: 1},
+	}}
+	records := [][]uint64{
+		{0, math.Float64bits(10.0)}, // red
+		{1, math.Float64bits(20.0)}, // green
+		{0, math.Float64bits(30.0)}, // red
+		{2, math.Float64bits(40.0)}, // blue
+		{1, math.Float64bits(50.0)}, // green
+	}
+	cfg := setupTestFS(t, "src.pulse", schema, records)
+	svc := New(cfg)
+
+	set := loadSet(t, svc, "src.pulse", "color", "red\nblue\n")
+	if _, ok := set.(*processing.BitsetSet); !ok {
+		t.Fatalf("set is %T, want *BitsetSet", set)
+	}
+
+	written, err := svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "color", set, "")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr: %v", err)
+	}
+	if written != 3 {
+		t.Errorf("written = %d, want 3 (2 red + 1 blue)", written)
+	}
+}
+
+func TestFilterToFileBySet_CombinedWithFilter(t *testing.T) {
+	schema, records := idScoreSchemaAndRecords()
+	cfg := setupTestFS(t, "src.pulse", schema, records)
+	svc := New(cfg)
+
+	// Set says {101,102,103,104,105} → all rows match the set; expression
+	// narrows to score > 25. Surviving ids: 103 (30), 104 (40), 105 (50).
+	set := loadSet(t, svc, "src.pulse", "id", "101\n102\n103\n104\n105\n")
+	written, err := svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "id", set, "score > 25.0")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr: %v", err)
+	}
+	if written != 3 {
+		t.Errorf("written = %d, want 3", written)
+	}
+
+	// Set narrows to {101,103} ∩ score > 25 ⇒ {103}.
+	set = loadSet(t, svc, "src.pulse", "id", "101\n103\n")
+	written, err = svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "id", set, "score > 25.0")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr (narrowed): %v", err)
+	}
+	if written != 1 {
+		t.Errorf("written = %d, want 1", written)
+	}
+}
+
+func TestFilterToFileBySet_EmptySet_ZeroRows(t *testing.T) {
+	schema, records := idScoreSchemaAndRecords()
+	cfg := setupTestFS(t, "src.pulse", schema, records)
+	svc := New(cfg)
+
+	set := loadSet(t, svc, "src.pulse", "id", "")
+	written, err := svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "id", set, "")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr: %v", err)
+	}
+	if written != 0 {
+		t.Errorf("written = %d, want 0", written)
+	}
+}
+
+func TestFilterToFileBySet_RequiresAtLeastOnePredicate(t *testing.T) {
+	cfg := setupTestFS(t, "src.pulse", testSchema(), testRecords())
+	svc := New(cfg)
+
+	_, err := svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "", nil, "")
+	if err == nil {
+		t.Fatal("expected error when both set and filterExpr are empty")
+	}
+	if !errors.HasCode(err, errors.SERVICE_VALIDATION) {
+		t.Errorf("err = %v, want SERVICE_VALIDATION", err)
+	}
+}
+
+func TestFilterToFileBySet_RequiresIncludeField(t *testing.T) {
+	schema, records := idScoreSchemaAndRecords()
+	cfg := setupTestFS(t, "src.pulse", schema, records)
+	svc := New(cfg)
+
+	set := loadSet(t, svc, "src.pulse", "id", "101\n")
+	_, err := svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "", set, "")
+	if err == nil {
+		t.Fatal("expected error when include field is empty but set is non-nil")
+	}
+}
+
+func TestFilterToFileBySet_UnknownField(t *testing.T) {
+	schema, records := idScoreSchemaAndRecords()
+	cfg := setupTestFS(t, "src.pulse", schema, records)
+	svc := New(cfg)
+
+	// Build a set against a real field, then try to filter against a
+	// different unknown field — service-side BuildMemberSetPredicate
+	// must reject it.
+	set := loadSet(t, svc, "src.pulse", "id", "101\n")
+	_, err := svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "nope", set, "")
+	if err == nil {
+		t.Fatal("expected error for unknown include field")
+	}
+}
+
+func TestFilterToFileBySet_FilterExprOnlyMatchesOldPath(t *testing.T) {
+	// Empty set + non-empty filter expr should behave like the existing
+	// FilterToFile path (regression coverage).
+	schema, records := idScoreSchemaAndRecords()
+	cfg := setupTestFS(t, "src.pulse", schema, records)
+	svc := New(cfg)
+
+	written, err := svc.FilterToFileBySetAndExpr(context.Background(), "src.pulse", "dst.pulse", "", nil, "score > 25.0")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr: %v", err)
+	}
+	if written != 3 {
+		t.Errorf("written = %d, want 3", written)
+	}
+}
+
+func TestFilterToFileBySet_ShardArchive_IntegerField(t *testing.T) {
+	schema, shards, concat := canonicalThreeShards()
+	svc, cfg := setupShardArchive(t, "arch.pulse", schema, shards, concat)
+	_ = cfg
+
+	// Include set on `id` across all three shards: pick one row per shard.
+	set := loadSet(t, svc, "arch.pulse", "id", "2\n6\n11\n")
+	written, err := svc.FilterToFileBySetAndExpr(context.Background(), "arch.pulse", "dst.pulse", "id", set, "")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr: %v", err)
+	}
+	if written != 3 {
+		t.Errorf("written = %d, want 3 (one per shard)", written)
+	}
+
+	// Confirm the output archive is a shard archive with three shards.
+	dstBytes, _ := afero.ReadFile(cfg.Fs(), "dst.pulse")
+	if !isShardArchiveMagic(dstBytes) {
+		t.Fatal("dst should be shard archive (input is archive)")
+	}
+	cohort, err := svc.Open(context.Background(), "dst.pulse")
+	if err != nil {
+		t.Fatalf("Open dst: %v", err)
+	}
+	if len(cohort.Shards()) != 3 {
+		t.Errorf("dst shard count = %d, want 3", len(cohort.Shards()))
+	}
+}
+
+func TestFilterToFileBySet_ShardArchive_CombinedWithFilter(t *testing.T) {
+	schema, shards, concat := canonicalThreeShards()
+	svc, _ := setupShardArchive(t, "arch.pulse", schema, shards, concat)
+
+	// Set: ids 1..12 (all rows); expr: score > 90.
+	// Survivors: 100, 110, 120 (ids 10, 11, 12) = 3 rows in shard c.
+	set := loadSet(t, svc, "arch.pulse", "id",
+		"1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n")
+	written, err := svc.FilterToFileBySetAndExpr(context.Background(), "arch.pulse", "dst.pulse", "id", set, "score > 90.0")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr: %v", err)
+	}
+	if written != 3 {
+		t.Errorf("written = %d, want 3", written)
+	}
+}
+
+func TestFilterToFileBySet_Anchor_SingleShard(t *testing.T) {
+	schema, shards, concat := canonicalThreeShards()
+	svc, _ := setupShardArchive(t, "arch.pulse", schema, shards, concat)
+
+	// Anchor on shard b (ids 5..8); set picks {5, 7}.
+	set := loadSet(t, svc, "arch.pulse#b.pulse", "id", "5\n7\n")
+	written, err := svc.FilterToFileBySetAndExpr(context.Background(), "arch.pulse#b.pulse", "dst.pulse", "id", set, "")
+	if err != nil {
+		t.Fatalf("FilterToFileBySetAndExpr anchor: %v", err)
+	}
+	if written != 2 {
+		t.Errorf("written = %d, want 2", written)
+	}
+}
+
+func TestResolveCanonicalSchema_SingleFile(t *testing.T) {
+	schema, records := idScoreSchemaAndRecords()
+	cfg := setupTestFS(t, "src.pulse", schema, records)
+	svc := New(cfg)
+
+	got, err := svc.ResolveCanonicalSchema(context.Background(), "src.pulse")
+	if err != nil {
+		t.Fatalf("ResolveCanonicalSchema: %v", err)
+	}
+	if len(got.Fields) != 2 || got.Fields[0].Name != "id" || got.Fields[1].Name != "score" {
+		t.Errorf("schema mismatch: %+v", got.Fields)
+	}
+}
+
+func TestResolveCanonicalSchema_ShardArchive(t *testing.T) {
+	schema, shards, concat := canonicalThreeShards()
+	svc, _ := setupShardArchive(t, "arch.pulse", schema, shards, concat)
+
+	got, err := svc.ResolveCanonicalSchema(context.Background(), "arch.pulse")
+	if err != nil {
+		t.Fatalf("ResolveCanonicalSchema: %v", err)
+	}
+	if len(got.Fields) == 0 {
+		t.Fatal("schema fields empty")
+	}
+}
+
+func TestResolveCanonicalSchema_Anchor(t *testing.T) {
+	schema, shards, concat := canonicalThreeShards()
+	svc, _ := setupShardArchive(t, "arch.pulse", schema, shards, concat)
+
+	got, err := svc.ResolveCanonicalSchema(context.Background(), "arch.pulse#b.pulse")
+	if err != nil {
+		t.Fatalf("ResolveCanonicalSchema: %v", err)
+	}
+	if len(got.Fields) == 0 {
+		t.Fatal("anchor schema fields empty")
+	}
+	_ = schema
+}

--- a/skills/getting-started.md
+++ b/skills/getting-started.md
@@ -79,6 +79,7 @@ For pointing a human at the right chapter. The MCP tool list above is the LLM-fa
 | `compose` | Execute a ComposedRequest batch | https://frankbardon.github.io/pulse/cli/api-compose.html |
 | `predict` | Validate a request against the schema | https://frankbardon.github.io/pulse/cli/api-predict.html |
 | `cohort inspect` | Print schema and descriptions of a `.pulse` file | https://frankbardon.github.io/pulse/cli/cohort-inspect.html |
+| `cohort filter` | Filter a `.pulse` cohort (single-file, shard archive, or `archive.pulse#shard.pulse` anchor) to a new `.pulse` file. Accepts `--filter EXPR` (FILTER_EXPRESSION semantics), a file-backed include-set via `--include-from PATH --include-field NAME`, or both AND-combined (include-set tested first to short-circuit on misses). Include-set picks the most performant impl for the field type: bitset for categorical, `map[uint64]struct{}` for integer / date, `map[string]struct{}` for decimal / fallback. Float fields rejected — use `--filter` for numeric ranges. | https://frankbardon.github.io/pulse/cli/cohort-filter.html |
 | `sample` | Print N rows from a cohort | https://frankbardon.github.io/pulse/cli/api-sample.html |
 | `facet` | Print distinct values for one field (or a rich multi-field summary via `--request` / repeat `--field` / `--top-k` / `--percentile` / `--histogram` / `--additive`). | https://frankbardon.github.io/pulse/cli/api-facet.html |
 | `manifest` | Print the self-description manifest | https://frankbardon.github.io/pulse/cli/manifest.html |


### PR DESCRIPTION
## Summary

- Adds `--include-from PATH --include-field NAME` to `pulse cohort filter`, AND-combinable with `--filter`.
- Schema-aware `MemberSet` picks the fastest lookup impl per field type:
  - `*BitsetSet` for categorical — bit per dict id, ~1 ns/lookup, no hashing, no compare
  - `*Uint64Set` for u8..u64 / nullable_u* / date — `map[uint64]struct{}`, avoids per-row string alloc
  - `*StringSet` for decimal128 + fallback — `map[string]struct{}`
- Float fields rejected at load time (exact-equality footgun). Use `--filter` for ranges.
- Combined predicate tests the set first so per-row work short-circuits on misses before the expression eval.

## Public surface

- `pulse.MemberSet`, `pulse.LoadMemberSetResult`, `pulse.LoadMemberSetFromReader`
- `pulse.Pulse.FilterToFileBySetAndExpr(ctx, src, dst, includeField, set, filterExpr)`
- `pulse.Pulse.ResolveCanonicalSchema(ctx, src)` — needed to build a set against any input shape (single-file, shard archive, anchor) without streaming records.

## Input-shape coverage

Single-file, shard archive, `archive.pulse#shard.pulse` anchor — all flow through the same `filterPlan`. Per-shard header + schema + categorical dict bytes are copied verbatim; canonical `_schema.pulse` aggregate refreshed.

## Tests

- `processing/member_set_test.go` — loader dispatch, bitset / uint64 / string paths, BOM + CRLF + whitespace tolerance, blank-line skipping, invalid-integer counting, not-in-dictionary counting, float rejection, unknown field, predicate construction, null record handling.
- `service/filter_to_file_set_test.go` — set-only / filter-only / set+filter on single-file × integer × categorical; shard-archive integer field; shard-archive combined predicate; anchor single-shard; empty set; missing predicate; missing include field; unknown field; canonical-schema resolution across all three shapes.

End-to-end smoke confirmed via the built CLI binary: include={2,4} ∩ score>25 ⇒ {4}.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] Manual CLI smoke: include-only, combined include+filter, shard archive
- [x] `TestSkillsCoverAllCliLeaves` still passes (no new CLI leaf; existing `cohort filter` row updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)