### PR TITLE
fix(sharding): correct record stride for bit-packed schemas in shard rewrite

### DIFF
--- a/encoding/schema.go
+++ b/encoding/schema.go
@@ -30,6 +30,28 @@ type Schema struct {
 	Fields []Field
 }
 
+// RecordByteSize returns the on-wire stride of one record under this
+// schema. Bit-packed fields (PackedBool, NullableBool, NullableU4)
+// report ByteSize()==0 but the wire format still consumes one whole
+// byte per such field (synth/writer.go and io/import.go both advance
+// the byte cursor by one for these types and the RecordReader bit/
+// nibble helpers read one byte each). Summing ByteSize() directly
+// therefore undercounts the stride on any schema that mixes byte-
+// aligned and bit-packed fields — use this helper to keep stride
+// math consistent with the wire writers and reader.
+func (s *Schema) RecordByteSize() int {
+	stride := 0
+	for i := range s.Fields {
+		ft := s.Fields[i].Type
+		if ft == FieldTypePackedBool || ft == FieldTypeNullableBool || ft == FieldTypeNullableU4 {
+			stride++
+			continue
+		}
+		stride += ft.ByteSize()
+	}
+	return stride
+}
+
 // Field returns a pointer to the named field, or nil if not found.
 func (s *Schema) Field(name string) *Field {
 	for i := range s.Fields {

--- a/encoding/schema_doc.go
+++ b/encoding/schema_doc.go
@@ -140,15 +140,8 @@ func (a *Archive) PeekShardRecordCount(name string) (int64, error) {
 			map[string]any{"entry": name, "cause": err.Error()})
 	}
 
-	recordSize := 0
-	for _, f := range schema.Fields {
-		recordSize += f.Type.ByteSize()
-	}
+	recordSize := schema.RecordByteSize()
 	if recordSize == 0 {
-		// Schemas of only bit-packed fields have zero declared size;
-		// the wire format still allocates whole-byte blocks. For S2
-		// we conservatively report zero rather than guess — callers
-		// that need exact counts on such schemas can re-decode.
 		return 0, nil
 	}
 

--- a/encoding/shard_rewrite.go
+++ b/encoding/shard_rewrite.go
@@ -59,10 +59,7 @@ func RewriteShardCategoricals(shardBytes []byte, targetSchema *Schema, remap map
 		}
 	}
 
-	recordSize := 0
-	for _, f := range srcSchema.Fields {
-		recordSize += f.Type.ByteSize()
-	}
+	recordSize := srcSchema.RecordByteSize()
 
 	remaining := shardBytes[len(shardBytes)-src.Len():]
 

--- a/encoding/shard_rewrite_test.go
+++ b/encoding/shard_rewrite_test.go
@@ -215,3 +215,180 @@ func TestRewriteShardCategoricals_EmptyRemap_PreservesRecords(t *testing.T) {
 		}
 	}
 }
+
+// buildPackedShard emits a minimal valid single-file .pulse shard whose
+// schema mixes byte-aligned fields with bit-packed fields. Layout:
+//
+//	offset 0 : id              (u64,            8 bytes)
+//	offset 8 : brand           (categorical_u8, 1 byte)
+//	offset 9 : aware           (packed_bool,    1 byte on wire)
+//	offset 10: familiarity     (nullable_u4,    1 byte on wire)
+//	offset 11: weight          (f64,            8 bytes)
+//
+// True record stride is 19 bytes. The pre-fix recordSize calc that
+// summed FieldType.ByteSize() reported 17 (it dropped the two packed
+// bytes), which fired PULSE_SHARD_HEADER_INVALID on every shard whose
+// dictionary required a non-empty remap. This is the brand_respondent
+// layout from issue #42.
+func buildPackedShard(t *testing.T, brandValues []string, records []packedRec) ([]byte, *encoding.Schema) {
+	t.Helper()
+	d := encoding.NewDictionary()
+	for _, v := range brandValues {
+		if _, err := d.Add(v); err != nil {
+			t.Fatalf("dict add: %v", err)
+		}
+	}
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "id", Type: encoding.FieldTypeU64, ByteOffset: 0, CsvColumnIdx: 0},
+			{Name: "brand", Type: encoding.FieldTypeCategoricalU8, ByteOffset: 8,
+				CsvColumnIdx: 1, Dictionary: d},
+			{Name: "aware", Type: encoding.FieldTypePackedBool, ByteOffset: 9, BitPosition: 0, CsvColumnIdx: 2},
+			{Name: "familiarity", Type: encoding.FieldTypeNullableU4, ByteOffset: 10, BitPosition: 0, CsvColumnIdx: 3},
+			{Name: "weight", Type: encoding.FieldTypeF64, ByteOffset: 11, CsvColumnIdx: 4},
+		},
+	}
+	// True wire stride is 19 (8+1+1+1+8). Asserted via direct byte
+	// counts below, not via Schema.RecordByteSize, so the test
+	// exercises the rewrite codepath end-to-end even if the helper
+	// were ever regressed back to summing ByteSize().
+	const wireStride = 19
+	var buf bytes.Buffer
+	if err := encoding.WriteHeader(&buf); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+	if err := encoding.WriteSchema(&buf, schema); err != nil {
+		t.Fatalf("WriteSchema: %v", err)
+	}
+	for _, r := range records {
+		var rec [wireStride]byte
+		binary.LittleEndian.PutUint64(rec[0:8], r.id)
+		rec[8] = r.brandIdx
+		rec[9] = r.aware
+		rec[10] = r.familiarity
+		binary.LittleEndian.PutUint64(rec[11:19], r.weightBits)
+		buf.Write(rec[:])
+	}
+	return buf.Bytes(), schema
+}
+
+type packedRec struct {
+	id          uint64
+	brandIdx    byte
+	aware       byte // 0 or 1
+	familiarity byte // 0x00..0x0F (0x0F = null sentinel)
+	weightBits  uint64
+}
+
+func decodePackedShard(t *testing.T, b []byte) (*encoding.Schema, []packedRec) {
+	t.Helper()
+	r := bytes.NewReader(b)
+	if err := encoding.ReadHeader(r); err != nil {
+		t.Fatalf("ReadHeader: %v", err)
+	}
+	schema, err := encoding.ReadSchema(r)
+	if err != nil {
+		t.Fatalf("ReadSchema: %v", err)
+	}
+	tail := make([]byte, r.Len())
+	if _, err := r.Read(tail); err != nil {
+		t.Fatalf("read tail: %v", err)
+	}
+	if len(tail)%19 != 0 {
+		t.Fatalf("packed shard tail length %d not a multiple of 19", len(tail))
+	}
+	out := make([]packedRec, 0, len(tail)/19)
+	for i := 0; i < len(tail); i += 19 {
+		out = append(out, packedRec{
+			id:          binary.LittleEndian.Uint64(tail[i : i+8]),
+			brandIdx:    tail[i+8],
+			aware:       tail[i+9],
+			familiarity: tail[i+10],
+			weightBits:  binary.LittleEndian.Uint64(tail[i+11 : i+19]),
+		})
+	}
+	return schema, out
+}
+
+// Regression for issue #42: RewriteShardCategoricals must walk the
+// true wire stride (which includes the host byte of every bit-packed
+// field), not the sum of FieldType.ByteSize(). Before the fix the
+// non-empty remap path raised PULSE_SHARD_HEADER_INVALID on schemas
+// that mixed byte-aligned and bit-packed fields.
+func TestRewriteShardCategoricals_BitPackedSchema_NonEmptyRemap(t *testing.T) {
+	canonical := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "id", Type: encoding.FieldTypeU64, ByteOffset: 0, CsvColumnIdx: 0},
+			{Name: "brand", Type: encoding.FieldTypeCategoricalU8, ByteOffset: 8,
+				CsvColumnIdx: 1, Dictionary: dictOf(t, "Acme", "Globex", "Initech")},
+			{Name: "aware", Type: encoding.FieldTypePackedBool, ByteOffset: 9, BitPosition: 0, CsvColumnIdx: 2},
+			{Name: "familiarity", Type: encoding.FieldTypeNullableU4, ByteOffset: 10, BitPosition: 0, CsvColumnIdx: 3},
+			{Name: "weight", Type: encoding.FieldTypeF64, ByteOffset: 11, CsvColumnIdx: 4},
+		},
+	}
+
+	// Incoming dict introduces "Soylent" (idx 2) that's absent from
+	// canonical, forcing MergeDictUnion to emit a non-empty remap.
+	incomingBytes, incomingSchema := buildPackedShard(t,
+		[]string{"Acme", "Globex", "Soylent"},
+		[]packedRec{
+			{id: 100, brandIdx: 0, aware: 1, familiarity: 0x05, weightBits: 0x1111},
+			{id: 101, brandIdx: 2, aware: 0, familiarity: 0x0F, weightBits: 0x2222}, // null fam
+			{id: 102, brandIdx: 1, aware: 1, familiarity: 0x03, weightBits: 0x3333},
+			{id: 103, brandIdx: 2, aware: 0, familiarity: 0x07, weightBits: 0x4444},
+		})
+
+	extended, remap, err := encoding.MergeDictUnion(canonical, incomingSchema)
+	if err != nil {
+		t.Fatalf("MergeDictUnion: %v", err)
+	}
+	if len(remap) == 0 {
+		t.Fatalf("expected non-empty remap from divergent dict, got %v", remap)
+	}
+	if remap[1][2] != 3 { // Soylent: incoming 2 → canonical 3 (appended)
+		t.Errorf("expected remap[1][2]==3, got %v", remap[1])
+	}
+
+	// The bug under issue #42: this call returned
+	// PULSE_SHARD_HEADER_INVALID with record_size:17 (true stride is 19).
+	rewritten, err := encoding.RewriteShardCategoricals(incomingBytes, extended, remap)
+	if err != nil {
+		t.Fatalf("RewriteShardCategoricals returned %v; want nil", err)
+	}
+
+	_, recs := decodePackedShard(t, rewritten)
+	want := []packedRec{
+		{id: 100, brandIdx: 0, aware: 1, familiarity: 0x05, weightBits: 0x1111},
+		{id: 101, brandIdx: 3, aware: 0, familiarity: 0x0F, weightBits: 0x2222}, // remapped 2→3
+		{id: 102, brandIdx: 1, aware: 1, familiarity: 0x03, weightBits: 0x3333},
+		{id: 103, brandIdx: 3, aware: 0, familiarity: 0x07, weightBits: 0x4444}, // remapped 2→3
+	}
+	if len(recs) != len(want) {
+		t.Fatalf("rewritten record count: got %d, want %d", len(recs), len(want))
+	}
+	for i := range recs {
+		if recs[i] != want[i] {
+			t.Errorf("rec[%d]: got %+v, want %+v", i, recs[i], want[i])
+		}
+	}
+}
+
+// TestSchema_RecordByteSize_MixedPackedAndAligned asserts the helper
+// reports the true wire stride for the schema shape that broke shard
+// rewrite under issue #42.
+func TestSchema_RecordByteSize_MixedPackedAndAligned(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "id", Type: encoding.FieldTypeU64, ByteOffset: 0},
+			{Name: "brand", Type: encoding.FieldTypeCategoricalU16, ByteOffset: 8},
+			{Name: "aware", Type: encoding.FieldTypePackedBool, ByteOffset: 10, BitPosition: 0},
+			{Name: "familiarity", Type: encoding.FieldTypeNullableU4, ByteOffset: 11, BitPosition: 0},
+			{Name: "trust", Type: encoding.FieldTypeNullableBool, ByteOffset: 12, BitPosition: 0},
+			{Name: "weight", Type: encoding.FieldTypeF64, ByteOffset: 13},
+		},
+	}
+	got := schema.RecordByteSize()
+	if got != 21 {
+		t.Fatalf("RecordByteSize: got %d, want 21 (8+2+1+1+1+8)", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `encoding.RewriteShardCategoricals` and `encoding/schema_doc.PeekShardRecordCount` summed `FieldType.ByteSize()` to derive record stride. `ByteSize()` returns `0` for the bit-packed types (`PackedBool`, `NullableBool`, `NullableU4`), but each such field consumes one byte on the wire (per `synth/writer.go` and `io/import.go`). On mixed schemas, `recordSize` undercounted the true stride and the modulo check at `shard_rewrite.go:82` fired `PULSE_SHARD_HEADER_INVALID` on every shard whose dictionary required a non-empty remap — blocking `AddShard` / `CreateShardArchive` for cohorts with growing categorical spaces.
- Add `Schema.RecordByteSize()` that matches the wire format (+1 byte per bit-packed field, +`ByteSize()` otherwise) and call it from both sites.
- Regression test exercises the `brand_respondent` schema shape from issue #42 end-to-end and confirms the rewritten shard carries the correct remapped categorical indices.

Fixes #42

## Test plan

- [x] `make lint`
- [x] `make test` (all packages green)
- [x] `make build`
- [x] New test fails on pre-fix `encoding/schema.go` with `PULSE_SHARD_HEADER_INVALID: shard rewrite: payload length not a multiple of record size` (the exact error from the issue)
- [x] New test passes with the fix applied
- [x] `TestRewriteShardCategoricals_EmptyRemap_PreservesRecords` still passes (no regression on the empty-remap fast path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)