### PR TITLE
feat(mcp): public mcpserve package to serve MCP from an embedder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Any change to Pulse code, configuration, file format, or public surface MUST upd
 | A registered MCP tool (add/remove) | `skills/mcp-integration.md` + `internal/mcp/mcptools/meta.go` | `TestSkillsCoverAllMCPTools`, `TestManifestMCPToolsComplete` |
 | Managed-import sidecar shape (`imports.Sidecar`) | `skills/mcp-integration.md` + CLAUDE.md "Build / Env" | reviewer enforcement |
 | A new MCP action tool with field-name params | `internal/mcp/schema_bind.go` + `skills/mcp-integration.md` | `TestMCPSchemaBinding_*` suite |
+| The public MCP-serve entry (`mcpserve.Serve` / `mcpserve.ServeStdio`) | `mcpserve/` + `skills/mcp-integration.md` (Embedding section) | reviewer enforcement |
 | The default operator table | CLAUDE.md "Smart defaults" + `skills/getting-started.md` | `TestDefaults_Applied` + reviewer |
 | A natural-query parsing route | `internal/query/query.go` + tests + `skills/query-router-prompt.md` + `skills/request-recipes.md` | `TestNaturalQuery_HeuristicGrammar` |
 | A request example under `examples/` | `_meta` block (kebab name, category=dir, canonical tags, alphabetized operators matching body) | `TestExamples_*` suite |

--- a/mcpserve/mcpserve.go
+++ b/mcpserve/mcpserve.go
@@ -1,0 +1,47 @@
+// Package mcpserve exposes Pulse's Model Context Protocol server as a public
+// entry point.
+//
+// The MCP wiring lives in internal/mcp (the library facade has no dependency
+// on it; the CLI invokes it to expose Pulse over stdio). This package lets an
+// embedder serve a Pulse MCP from its own process — including any operators,
+// expression functions, or label tables registered via the constructed
+// *pulse.Pulse's Options.Extensions — without shelling out to the `pulse`
+// binary. That is the only way a domain layer (e.g. a BERA-flavored Pulse)
+// can surface its in-process Go extensions over MCP, since the stock binary
+// cannot load them.
+package mcpserve
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/frankbardon/pulse"
+	"github.com/frankbardon/pulse/internal/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Options configures the served MCP server. It mirrors internal/mcp.Options.
+type Options struct {
+	// BindOnOpen registers session-scoped schema-bound tool variants on a
+	// successful pulse_inspect. True gives MCP clients typed enum constraints
+	// on field-name parameters; false leaves only the unbound global tools,
+	// which is useful for clients that bind tool schemas themselves.
+	BindOnOpen bool
+}
+
+// Serve runs an MCP server bound to p, reading JSON-RPC requests from in and
+// writing responses to out. It blocks until ctx is cancelled or a transport
+// error occurs. Extensions registered when p was constructed are exposed
+// verbatim.
+func Serve(ctx context.Context, p *pulse.Pulse, opts Options, in io.Reader, out io.Writer) error {
+	srv := mcp.NewWithOptions(p, mcp.Options{BindOnOpen: opts.BindOnOpen})
+	return server.NewStdioServer(srv).Listen(ctx, in, out)
+}
+
+// ServeStdio is Serve over the process's stdin/stdout — the transport MCP
+// clients use when they spawn the server as a subprocess. It blocks until
+// stdin closes or the client disconnects.
+func ServeStdio(p *pulse.Pulse, opts Options) error {
+	return Serve(context.Background(), p, opts, os.Stdin, os.Stdout)
+}

--- a/mcpserve/mcpserve_test.go
+++ b/mcpserve/mcpserve_test.go
@@ -1,0 +1,66 @@
+package mcpserve_test
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/pulse"
+	"github.com/frankbardon/pulse/mcpserve"
+)
+
+// TestServe_InitializeRoundTrip drives the public facade end-to-end: it sends
+// an MCP initialize request over an in-memory transport and asserts the
+// server identifies itself. This proves Serve wires internal/mcp through to a
+// working JSON-RPC loop.
+func TestServe_InitializeRoundTrip(t *testing.T) {
+	p, err := pulse.New(pulse.Options{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("pulse.New: %v", err)
+	}
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- mcpserve.Serve(ctx, p, mcpserve.Options{BindOnOpen: true}, inR, outW) }()
+
+	initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":` +
+		`{"protocolVersion":"2024-11-05","capabilities":{},` +
+		`"clientInfo":{"name":"mcpserve-test","version":"0"}}}` + "\n"
+	go func() { _, _ = inW.Write([]byte(initReq)) }()
+
+	type readResult struct {
+		line string
+		err  error
+	}
+	lines := make(chan readResult, 1)
+	go func() {
+		line, err := bufio.NewReader(outR).ReadString('\n')
+		lines <- readResult{line, err}
+	}()
+
+	select {
+	case got := <-lines:
+		if got.err != nil {
+			t.Fatalf("read initialize response: %v", got.err)
+		}
+		if !strings.Contains(got.line, `"result"`) {
+			t.Fatalf("response is not a result: %s", got.line)
+		}
+		if !strings.Contains(got.line, "pulse") {
+			t.Fatalf("response does not identify the pulse server: %s", got.line)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initialize response")
+	}
+
+	cancel()
+	_ = inW.Close()
+	_ = outW.Close()
+}

--- a/skills/mcp-integration.md
+++ b/skills/mcp-integration.md
@@ -232,6 +232,27 @@ The handler accepts either a JSON-encoded string (above) or a structured object 
 - **Stdout discipline:** in stdio mode, stdout is the JSON-RPC transport. The server logs to stderr. This is invisible to you but affects what a host can show in its UI.
 </reference>
 
+<embedding>
+## Embedding the MCP server (for host applications)
+
+`pulse mcp` is the standalone path. A host that has already constructed a
+`*pulse.Pulse` — especially one configured with `Options.Extensions` (custom
+operators, expression functions, label tables) — serves the same MCP surface
+from its own process via the public `mcpserve` package:
+
+```go
+p, _ := pulse.New(pulse.Options{DataDir: dir, Extensions: myExtensions})
+// Over the process's stdin/stdout (what an MCP client spawns as a subprocess):
+_ = mcpserve.ServeStdio(p, mcpserve.Options{BindOnOpen: true})
+// Or with an injected transport (tests, custom pipes):
+_ = mcpserve.Serve(ctx, p, mcpserve.Options{BindOnOpen: true}, in, out)
+```
+
+This is the only way a domain layer's in-process Go extensions reach MCP
+clients — the stock `pulse` binary cannot load them. The tool surface,
+schema-binding, and resource schemes are identical to `pulse mcp`.
+</embedding>
+
 <see_also>
 - getting-started — Pulse vocabulary and the 10 MCP tools
 - request-recipes — copy-pasteable request JSON skeletons keyed by intent


### PR DESCRIPTION
## Summary
- Adds a public `mcpserve` package exposing Pulse's MCP server to embedders. `internal/mcp` is unexported (the CLI is its only caller), so a host that constructs a `*pulse.Pulse` with `Options.Extensions` currently has no way to surface those in-process Go extensions over MCP — the stock `pulse` binary cannot load them.
- `mcpserve.Serve(ctx, p, opts, in, out)` takes an injected transport; `mcpserve.ServeStdio(p, opts)` runs over the process stdin/stdout that MCP clients spawn as a subprocess. Both delegate to `internal/mcp`, so the tool surface, schema-binding, and resource schemes are identical to `pulse mcp`.
- Lives outside the root `pulse` package to avoid the `pulse -> internal/mcp -> pulse` import cycle; being under the module root it may still import `internal/mcp`.

## Motivation
Unblocks the Orbit platform: Orbit serves a BERA-flavored Pulse MCP (wormhole expression functions + label tables, registered via `Options.Extensions`) from its own `orbit mcp` subprocess for a Nexus `mcp.client` to consume.

## Docs
- `skills/mcp-integration.md` gains an "Embedding the MCP server" section.
- Update Demand table gains a row for the new public entry.

## Test plan
- [x] `go test ./mcpserve/` — initialize round-trip over an in-memory transport asserts the server identifies itself
- [x] `go test ./...` — full suite green, no Update Demand / skills / CLAUDE.md hygiene gate tripped
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)