### PR TITLE
fix(mcp): declare items schema on examples_search tags array

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -197,7 +197,7 @@ func registerTools(s *server.MCPServer, p *pulse.Pulse, bindOnOpen bool) {
 		mcpgo.NewTool(ToolExamplesSearch,
 			mcpgo.WithDescription(DescExamplesSearch),
 			mcpgo.WithString("query", mcpgo.Description("Optional case-insensitive substring (matched against name, description, operators)")),
-			mcpgo.WithArray("tags", mcpgo.Description("Optional list of canonical taxonomy tags; results must carry every tag (AND)")),
+			mcpgo.WithArray("tags", mcpgo.Description("Optional list of canonical taxonomy tags; results must carry every tag (AND)"), mcpgo.WithStringItems()),
 			mcpgo.WithString("category", mcpgo.Description("Optional exact directory: aggregations, attributes, features, filterers, groupers, tests, windows")),
 		),
 		handleExamplesSearch(p),


### PR DESCRIPTION
## Summary
- `pulse_examples_search` declared its `tags` parameter as an untyped array (`mcpgo.WithArray` with no item schema).
- Gemini's function-calling API rejects array params lacking `items` with `HTTP 400 INVALID_ARGUMENT: function_declarations[...].parameters.properties[tags].items: missing field`, which fails the entire tool list and silently stalls MCP clients running on Gemini.
- Add `mcpgo.WithStringItems()` so the emitted schema is `{"type":"array","items":{"type":"string"}}`. The handler already decodes `tags` as `[]string`, so behavior is unchanged for compliant clients.

## Context
Discovered while debugging an embedder (Orbit) whose Gemini-backed agent produced no output: every turn 400'd on the tool declarations and hung. This is the only `WithArray` in the MCP tool surface, so this one change unblocks Gemini clients.

## Test plan
- [x] `go build ./internal/mcp/`
- [x] End-to-end: Gemini agent turn over the MCP tool list now completes (streamed response received) instead of stalling on the 400.
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)