### PR TITLE
feat(envelope): opt-in echo of normalized request

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Any change to Pulse code, configuration, file format, or public surface MUST upd
 | `FilterToFileRequest` / `FilterToFileResult` shape, deterministic-naming rule, or `Pulse.FilterToFileWithRequest` dedup contract | `filter_to_file_request.go` + `descriptor/manifest.go` (Operations) | `TestFilterToFileWithRequest_*` |
 | Manifest `CommandAnnotations` field or `Manifest.Operations` slot | `descriptor/manifest.go` + `descriptor/testdata/manifest.json` | `TestManifest_CommandAnnotationsPopulated`, `TestManifest_OperationsPopulated`, `TestManifest_AnnotationSemantics` |
 | `Request.Crosstab` slot, `CrosstabSpec` / `MatrixPayload` / `CrosstabResult` shape, or `AggregationType.MarginReducibility` classification | `types/crosstab.go` + `types/streamability.go` + `types/types.go` + `processing/crosstab.go` + `service/crosstab.go` + `descriptor/crosstab.go` + `descriptor/capabilities_crosstab.go` + `descriptor/manifest.go` + `internal/mcp/schema_bind.go` + `skills/crosstab-guide.md` + `skills/index.json` | `TestCrosstab_CountCellByteEqualToManual`, `TestCrosstab_MedianMarginRecomputesFromRaw`, `TestCrosstab_NormalizeRow_SumsToOne`, `TestCrosstab_NormalizeColumn_SumsToOne`, `TestCrosstab_NormalizeTotal_SumsToOne`, `TestCrosstab_NestedAxes`, `TestCrosstab_BinningGrouperOnAxis`, `TestCrosstab_LongShape`, `TestCrosstab_ConflictsWithGroupsRejected`, `TestCrosstab_AllAggregatorsClassified`, `TestPredict_Crosstab_MatrixForcesBuffered`, `TestPredict_Crosstab_LongNoMarginsStreamable`, `TestManifest_CrosstabCapabilityPopulated` |
+| `descriptor.Envelope.Request` field, `pulse.Options.EchoRequest`, `PredictOptions.EchoRequest`, `ChainResponse.NormalizedRequest`, or the `--echo-request` CLI surface | `descriptor/envelope.go` + `descriptor/predict.go` + `pulse.go` + `service/service.go` + `service/chain.go` + `types/chain.go` + `internal/cli/api.go` + `internal/cli/json.go` + CLAUDE.md "Output Format Contract" | `TestEnvelope_RequestOmittedByDefault`, `TestEnvelope_RequestPopulatedWhenSet`, `TestPredict_EchoRequest_Normalized`, `TestProcessChain_NormalizedRequest_PerStage` |
 
 Table is self-referential — new trigger rows require updating this table in the same PR. `TestUpdateDemandTableCovers` parses this section and asserts every component category and contract type has a row.
 
@@ -160,6 +161,7 @@ All `--json` CLI output + descriptor operations use `descriptor.Envelope`:
 {
   "format_version": "1.0",
   "data": { ... },
+  "request": { ... },
   "errors": [],
   "warnings": []
 }
@@ -167,14 +169,15 @@ All `--json` CLI output + descriptor operations use `descriptor.Envelope`:
 
 - `format_version` always `"1.0"`. Changes MUST update this section.
 - `errors` / `warnings` use `{"code", "message", "details"}`. Empty array (never null) when absent.
+- `request` is opt-in echo of the *normalized* request that produced `data`. Omitted entirely (the `omitempty` rule) unless `pulse.Options.EchoRequest` is true or the CLI was invoked with `--echo-request`. Shape varies by operation: `Request` for process/predict, `ComposedRequest` for compose, `ChainRequest` for process-chain (per-stage normalized form captured during execution), `FacetRequest` for facet, `SampleRequest` for sample. Streaming output (`--stream`, `ProcessStream`) skips the echo by construction — NDJSON has no envelope. Use `descriptor.NewEnvelopeWithRequest(data, req)` or `env.WithRequest(req)` to populate it.
 
-Additive-only: bump `format_version` only on backward-incompatible shape changes. New `data` fields don't bump; renames/removals do.
+Additive-only: bump `format_version` only on backward-incompatible shape changes. New `data` fields don't bump; renames/removals do. The `request` field is additive (omitempty) and does NOT bump `format_version`.
 
 ### Structural defense bans
 
 - **No `fmt.Sprintf`-built JSON.** All structured output through `encoding/json`. Grep-gated by `TestDescriptorNoFmtSprintf`.
 - **No hand-built XML/CDATA.** Use `encoding/xml`.
-- Use `descriptor.NewEnvelope(data)` — auto-sets `format_version`, empty `errors`, empty `warnings`.
+- Use `descriptor.NewEnvelope(data)` — auto-sets `format_version`, empty `errors`, empty `warnings`. Use `descriptor.NewEnvelopeWithRequest(data, req)` (or `env.WithRequest(req)`) when echo is enabled at the call site.
 
 ### Manifest payload
 

--- a/descriptor/defaults.go
+++ b/descriptor/defaults.go
@@ -177,6 +177,25 @@ func applyDefaultGroupParams(grp *types.Group) {
 	}
 }
 
+// NormalizeRequest returns a clone of req with smart defaults resolved
+// against schema. Caller-side ergonomic for envelope.Request echo —
+// produces the exact request the engine would execute (post-defaults)
+// without mutating the input. Returns nil when req is nil; returns the
+// clone unchanged when schema is nil or no defaults applied.
+//
+// The clone is a shallow-deep hybrid identical to the one Predict uses
+// internally: Aggregations and Groups are deep-cloned (the slots
+// ResolveDefaults mutates), every other slot is shared with the input.
+// Safe to expose on read-only paths.
+func NormalizeRequest(req *types.Request, schema *encoding.Schema) *types.Request {
+	if req == nil {
+		return nil
+	}
+	clone := cloneRequestForDefaults(req)
+	ResolveDefaults(clone, schema)
+	return clone
+}
+
 // cloneRequestForDefaults returns a shallow-deep hybrid copy of req
 // sufficient for ResolveDefaults to mutate without touching the caller's
 // request. Only the slots ResolveDefaults inspects (Aggregations, Groups)

--- a/descriptor/defaults_test.go
+++ b/descriptor/defaults_test.go
@@ -311,6 +311,61 @@ func TestDefaults_UnknownFieldLeftAlone(t *testing.T) {
 	}
 }
 
+// TestPredict_EchoRequest_Normalized verifies the opt-in envelope echo
+// surfaces the *normalized* request (defaults resolved) on
+// envelope.Request, leaving PredictResult.Request untouched as the raw
+// input. With the flag off the envelope field stays absent.
+func TestPredict_EchoRequest_Normalized(t *testing.T) {
+	schema := &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "revenue", Type: encoding.FieldTypeF64, Description: "Revenue in USD."},
+		},
+	}
+	data := buildTestPulseFile(t, schema)
+
+	// Defaulted request — field set, no Type.
+	makeReq := func() *types.Request {
+		return &types.Request{Aggregations: []*types.Aggregation{{Field: "revenue"}}}
+	}
+
+	// Flag off: envelope.Request must be nil.
+	envOff := PredictFromBytes(data, makeReq(), &PredictOptions{})
+	if envOff.Request != nil {
+		t.Fatalf("EchoRequest=false produced envelope.Request: %#v", envOff.Request)
+	}
+
+	// Flag on: envelope.Request is the normalized clone; its first
+	// aggregation has the inferred Type populated.
+	rawReq := makeReq()
+	envOn := PredictFromBytes(data, rawReq, &PredictOptions{EchoRequest: true})
+	if envOn.Request == nil {
+		t.Fatal("EchoRequest=true did not populate envelope.Request")
+	}
+	normalized, ok := envOn.Request.(*types.Request)
+	if !ok {
+		t.Fatalf("envelope.Request type = %T; want *types.Request", envOn.Request)
+	}
+	if len(normalized.Aggregations) != 1 {
+		t.Fatalf("normalized.Aggregations length = %d; want 1", len(normalized.Aggregations))
+	}
+	if normalized.Aggregations[0].Type != types.AGG_SUM {
+		t.Errorf("normalized aggregation Type = %q; want %q",
+			normalized.Aggregations[0].Type, types.AGG_SUM)
+	}
+	// Raw input must remain untouched — predict never mutates the caller's request.
+	if rawReq.Aggregations[0].Type != "" {
+		t.Errorf("raw request mutated: Type = %q", rawReq.Aggregations[0].Type)
+	}
+	// PredictResult.Request stays the raw form (back-compat).
+	result, ok := envOn.Data.(*PredictResult)
+	if !ok {
+		t.Fatal("Data is not *PredictResult")
+	}
+	if result.Request != rawReq {
+		t.Error("PredictResult.Request is not the raw input")
+	}
+}
+
 // TestDefaults_NilInputs verifies that ResolveDefaults is safe against
 // nil requests and nil schemas (returns nil, no panic).
 func TestDefaults_NilInputs(t *testing.T) {

--- a/descriptor/envelope.go
+++ b/descriptor/envelope.go
@@ -4,9 +4,20 @@ import "encoding/json"
 
 // Envelope is the standard JSON output wrapper for all descriptor operations.
 // All --json output follows this shape.
+//
+// Request, when non-nil, carries the *normalized* request the operation
+// executed — smart defaults resolved, label bindings expanded, per-stage
+// requests captured for chains. Opt-in via pulse.Options.EchoRequest /
+// CLI --echo-request; absent (and omitted from JSON) by default so the
+// envelope shape is unchanged for callers that do not need it. The
+// shape varies by operation: *types.Request for process/predict,
+// *types.ComposedRequest for compose, *types.ChainRequest for
+// process-chain, *types.FacetRequest for facet, *types.SampleRequest
+// for sample.
 type Envelope struct {
 	FormatVersion string           `json:"format_version"`
 	Data          any              `json:"data"`
+	Request       any              `json:"request,omitempty"`
 	Errors        []*EnvelopeEntry `json:"errors"`
 	Warnings      []*EnvelopeEntry `json:"warnings"`
 }
@@ -26,6 +37,25 @@ func NewEnvelope(data any) *Envelope {
 		Errors:        []*EnvelopeEntry{},
 		Warnings:      []*EnvelopeEntry{},
 	}
+}
+
+// NewEnvelopeWithRequest creates an envelope with both data and the
+// normalized request that produced it. Use when EchoRequest is enabled
+// at the operation boundary. Passing a nil request degrades to
+// NewEnvelope semantics (the field is omitted from JSON via omitempty).
+func NewEnvelopeWithRequest(data, request any) *Envelope {
+	env := NewEnvelope(data)
+	env.Request = request
+	return env
+}
+
+// WithRequest attaches a normalized request to an existing envelope.
+// Returns the receiver for fluent use. Nil-safe.
+func (e *Envelope) WithRequest(request any) *Envelope {
+	if e != nil {
+		e.Request = request
+	}
+	return e
 }
 
 // AddError appends a structured error to the envelope.

--- a/descriptor/envelope_test.go
+++ b/descriptor/envelope_test.go
@@ -66,3 +66,57 @@ func TestEnvelope_MarshalJSON(t *testing.T) {
 		t.Error("format_version missing or wrong")
 	}
 }
+
+// TestEnvelope_RequestOmittedByDefault verifies the new opt-in echo
+// surface does not change the wire shape for existing callers — the
+// "request" key must be absent from JSON when Request is nil.
+func TestEnvelope_RequestOmittedByDefault(t *testing.T) {
+	env := NewEnvelope("data")
+	if env.Request != nil {
+		t.Fatalf("Request defaulted non-nil: %#v", env.Request)
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if _, present := parsed["request"]; present {
+		t.Errorf("request key present when Request was nil: %s", string(data))
+	}
+}
+
+// TestEnvelope_RequestPopulatedWhenSet verifies the echo field surfaces
+// the value the caller attached via NewEnvelopeWithRequest / WithRequest.
+func TestEnvelope_RequestPopulatedWhenSet(t *testing.T) {
+	req := map[string]any{"name": "demo"}
+	env := NewEnvelopeWithRequest("data", req)
+	if env.Request == nil {
+		t.Fatal("Request nil after NewEnvelopeWithRequest")
+	}
+
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	got, present := parsed["request"]
+	if !present {
+		t.Fatalf("request key missing: %s", string(data))
+	}
+	gotMap, ok := got.(map[string]any)
+	if !ok || gotMap["name"] != "demo" {
+		t.Errorf("request payload = %#v, want {name: demo}", got)
+	}
+
+	// WithRequest fluent form should produce the same surface.
+	env2 := NewEnvelope("data").WithRequest(req)
+	if env2.Request == nil {
+		t.Fatal("WithRequest did not attach request")
+	}
+}

--- a/descriptor/predict.go
+++ b/descriptor/predict.go
@@ -90,6 +90,12 @@ type PredictOptions struct {
 	// embedder-registered ops as unknown, and feeds streamability
 	// overrides into computeStreamable.
 	Extensions *ExtensionsSnapshot
+
+	// EchoRequest causes Predict to populate envelope.Request with the
+	// normalized (post-defaults) request. PredictResult.Request stays
+	// the raw input request — the envelope field is the new uniform
+	// surface across all envelope-producing endpoints. Off by default.
+	EchoRequest bool
 }
 
 // PredictResult holds the validated request and any diagnostics.
@@ -217,6 +223,14 @@ func Predict(fileData io.ReadSeeker, req *types.Request, opts *PredictOptions) *
 		result.DefaultsApplied = applied
 	}
 	req = resolved
+
+	// EchoRequest publishes the normalized clone on the envelope. The
+	// clone is the same struct downstream validators see, so what the
+	// caller gets on env.Request is exactly what an engine run would
+	// execute. PredictResult.Request remains the raw input (back-compat).
+	if opts.EchoRequest {
+		env.Request = resolved
+	}
 
 	// Validate pre-filter feature operators and compute the post-feature
 	// column set so downstream stages can reference derived columns.

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -39,6 +39,7 @@ func apiProcessCmd() *cli.Command {
 			&cli.BoolFlag{Name: "stream", Usage: "Stream rows as NDJSON (one row per line) instead of buffering"},
 			&cli.BoolFlag{Name: "no-defaults", Usage: "Disable smart operator defaults; require an explicit Type on every aggregation and grouper"},
 			&cli.BoolFlag{Name: "strict", Usage: "Promote request-validation warnings into hard errors (e.g. numeric aggregation on a categorical field)"},
+			&cli.BoolFlag{Name: "echo-request", Usage: "Include the normalized (post-defaults) request on the envelope under \"request\". Streaming output skips this — NDJSON has no envelope."},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			reqPath := cmd.String("request")
@@ -46,6 +47,7 @@ func apiProcessCmd() *cli.Command {
 			stream := cmd.Bool("stream")
 			noDefaults := cmd.Bool("no-defaults")
 			strict := cmd.Bool("strict")
+			echoRequest := cmd.Bool("echo-request")
 
 			req, err := loadRequest(reqPath)
 			if err != nil {
@@ -55,7 +57,7 @@ func apiProcessCmd() *cli.Command {
 				return err
 			}
 
-			p, err := newPulseOpts(pulse.Options{DisableDefaults: noDefaults, Strict: strict})
+			p, err := newPulseOpts(pulse.Options{DisableDefaults: noDefaults, Strict: strict, EchoRequest: echoRequest})
 			if err != nil {
 				if jsonOut {
 					return writeErrorEnvelope(cmd.Writer, "CLI_ERROR", err.Error())
@@ -113,6 +115,13 @@ func apiProcessCmd() *cli.Command {
 						}
 					}
 				}
+				// Process mutates req in place via service.applyDefaults,
+				// so by the time we reach here req is the normalized
+				// (post-defaults) form. Echo it verbatim — what the
+				// caller sees is exactly what the engine ran.
+				if echoRequest {
+					env.WithRequest(req)
+				}
 				return writeJSON(cmd.Writer, env)
 			}
 
@@ -129,11 +138,13 @@ func apiProcessChainCmd() *cli.Command {
 			&cli.StringFlag{Name: "request", Aliases: []string{"r"}, Usage: "Chain request JSON file path", Required: true},
 			&cli.BoolFlag{Name: "json", Usage: "Output result as JSON envelope"},
 			&cli.BoolFlag{Name: "no-defaults", Usage: "Disable smart operator defaults"},
+			&cli.BoolFlag{Name: "echo-request", Usage: "Include the normalized ChainRequest on the envelope under \"request\". Each stage's Request reflects the per-stage post-defaults form captured during execution."},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			reqPath := cmd.String("request")
 			jsonOut := cmd.Bool("json")
 			noDefaults := cmd.Bool("no-defaults")
+			echoRequest := cmd.Bool("echo-request")
 
 			chain, err := loadChainRequest(reqPath)
 			if err != nil {
@@ -143,7 +154,7 @@ func apiProcessChainCmd() *cli.Command {
 				return err
 			}
 
-			p, err := newPulseOpts(pulse.Options{DisableDefaults: noDefaults})
+			p, err := newPulseOpts(pulse.Options{DisableDefaults: noDefaults, EchoRequest: echoRequest})
 			if err != nil {
 				if jsonOut {
 					return writeErrorEnvelope(cmd.Writer, "CLI_ERROR", err.Error())
@@ -160,7 +171,11 @@ func apiProcessChainCmd() *cli.Command {
 			}
 
 			if jsonOut {
-				return writeEnvelope(cmd.Writer, resp)
+				var echoed any
+				if echoRequest && resp != nil && resp.NormalizedRequest != nil {
+					echoed = resp.NormalizedRequest
+				}
+				return writeEnvelopeWithRequest(cmd.Writer, resp, echoed)
 			}
 			return writeJSON(cmd.Writer, resp)
 		},
@@ -178,6 +193,7 @@ func apiComposeCmd() *cli.Command {
 			&cli.IntFlag{Name: "parallel", Usage: "Run requests concurrently with up to N workers (0 = GOMAXPROCS); 1 forces sequential", Value: 1},
 			&cli.BoolFlag{Name: "no-fail-fast", Usage: "Aggregate errors instead of cancelling on first failure (parallel only)"},
 			&cli.BoolFlag{Name: "no-defaults", Usage: "Disable smart operator defaults; require an explicit Type on every aggregation and grouper"},
+			&cli.BoolFlag{Name: "echo-request", Usage: "Include the normalized ComposedRequest on the envelope under \"request\". Each slot reflects its post-defaults form. Streaming output skips this."},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			reqPath := cmd.String("request")
@@ -186,6 +202,7 @@ func apiComposeCmd() *cli.Command {
 			workers := int(cmd.Int("parallel"))
 			noFailFast := cmd.Bool("no-fail-fast")
 			noDefaults := cmd.Bool("no-defaults")
+			echoRequest := cmd.Bool("echo-request")
 
 			composed, err := loadComposedRequest(reqPath)
 			if err != nil {
@@ -195,7 +212,7 @@ func apiComposeCmd() *cli.Command {
 				return err
 			}
 
-			p, err := newPulseOpts(pulse.Options{DisableDefaults: noDefaults})
+			p, err := newPulseOpts(pulse.Options{DisableDefaults: noDefaults, EchoRequest: echoRequest})
 			if err != nil {
 				if jsonOut {
 					return writeErrorEnvelope(cmd.Writer, "CLI_ERROR", err.Error())
@@ -235,7 +252,14 @@ func apiComposeCmd() *cli.Command {
 			}
 
 			if jsonOut {
-				return writeEnvelope(cmd.Writer, responses)
+				var echoed any
+				if echoRequest {
+					// Each sub-request was mutated in place by service
+					// during execution. Echo the composed request as a
+					// whole — each slot is the post-defaults form.
+					echoed = composed
+				}
+				return writeEnvelopeWithRequest(cmd.Writer, responses, echoed)
 			}
 
 			return writeJSON(cmd.Writer, responses)
@@ -252,12 +276,14 @@ func apiSampleCmd() *cli.Command {
 			&cli.IntFlag{Name: "count", Aliases: []string{"n"}, Value: 10, Usage: "Number of rows to sample"},
 			&cli.BoolFlag{Name: "json", Usage: "Output result as JSON envelope"},
 			&cli.StringSliceFlag{Name: "labels", Usage: "Categorical label binding: field=table[:replace|augment]. Repeatable. Requires PULSE_LABEL_TABLES_DIR or programmatic table registration."},
+			&cli.BoolFlag{Name: "echo-request", Usage: "Include the resolved SampleRequest on the envelope under \"request\"."},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			input := cmd.String("input")
 			count := int(cmd.Int("count"))
 			jsonOut := cmd.Bool("json")
 			labelArgs := cmd.StringSlice("labels")
+			echoRequest := cmd.Bool("echo-request")
 
 			p, err := newPulse()
 			if err != nil {
@@ -276,7 +302,14 @@ func apiSampleCmd() *cli.Command {
 					return err
 				}
 				if jsonOut {
-					return writeEnvelope(cmd.Writer, rows)
+					var echoed any
+					if echoRequest {
+						echoed = &pulse.SampleRequest{
+							Cohort: &types.Cohort{Filename: input},
+							N:      count,
+						}
+					}
+					return writeEnvelopeWithRequest(cmd.Writer, rows, echoed)
 				}
 				return writeJSON(cmd.Writer, rows)
 			}
@@ -288,9 +321,10 @@ func apiSampleCmd() *cli.Command {
 				}
 				return perr
 			}
-			result, err := p.SampleWithRequest(ctx, &pulse.SampleRequest{
+			sampleReq := &pulse.SampleRequest{
 				Cohort: &types.Cohort{Filename: input}, N: count, Labels: bindings,
-			})
+			}
+			result, err := p.SampleWithRequest(ctx, sampleReq)
 			if err != nil {
 				if jsonOut {
 					return writeErrorEnvelope(cmd.Writer, "SAMPLE_ERROR", err.Error())
@@ -299,6 +333,9 @@ func apiSampleCmd() *cli.Command {
 			}
 			if jsonOut {
 				env := descriptor.NewEnvelope(result.Rows)
+				if echoRequest {
+					env.WithRequest(sampleReq)
+				}
 				for _, w := range result.Warnings {
 					env.AddWarning(w.Code, w.Message, w.Details)
 				}
@@ -326,6 +363,7 @@ func apiFacetCmd() *cli.Command {
 			&cli.StringSliceFlag{Name: "additive", Usage: "Compute additive contribution counts for this field (repeatable)"},
 			&cli.StringSliceFlag{Name: "labels", Usage: "Categorical label binding: field=table[:replace|augment]. Repeatable."},
 			&cli.BoolFlag{Name: "json", Usage: "Output result as JSON envelope"},
+			&cli.BoolFlag{Name: "echo-request", Usage: "Include the resolved FacetRequest on the envelope under \"request\"."},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			input := cmd.String("input")
@@ -340,6 +378,7 @@ func apiFacetCmd() *cli.Command {
 			additive := cmd.StringSlice("additive")
 			labelArgs := cmd.StringSlice("labels")
 			jsonOut := cmd.Bool("json")
+			echoRequest := cmd.Bool("echo-request")
 
 			rich := reqPath != "" || len(fields) > 1 || topK > 0 || len(pcts) > 0 || includeHist || len(additive) > 0 || len(labelArgs) > 0
 
@@ -367,7 +406,14 @@ func apiFacetCmd() *cli.Command {
 					return err
 				}
 				if jsonOut {
-					return writeEnvelope(cmd.Writer, values)
+					var echoed any
+					if echoRequest {
+						echoed = &pulse.FacetRequest{
+							Cohort: &types.Cohort{Filename: input},
+							Fields: []string{fields[0]},
+						}
+					}
+					return writeEnvelopeWithRequest(cmd.Writer, values, echoed)
 				}
 				for _, v := range values {
 					writeText(cmd.Writer, "%s\n", v)
@@ -400,7 +446,11 @@ func apiFacetCmd() *cli.Command {
 				return err
 			}
 			if jsonOut {
-				return writeEnvelope(cmd.Writer, result)
+				var echoed any
+				if echoRequest {
+					echoed = req
+				}
+				return writeEnvelopeWithRequest(cmd.Writer, result, echoed)
 			}
 			return writeJSON(cmd.Writer, result)
 		},
@@ -466,11 +516,13 @@ func apiPredictCmd() *cli.Command {
 			&cli.StringFlag{Name: "request", Aliases: []string{"r"}, Usage: "Request JSON file path", Required: true},
 			&cli.BoolFlag{Name: "json", Usage: "Output result as JSON envelope"},
 			&cli.BoolFlag{Name: "strict", Usage: "Treat warnings as errors"},
+			&cli.BoolFlag{Name: "echo-request", Usage: "Include the normalized request on the envelope under \"request\" (distinct from PredictResult.Request, which echoes the raw input)."},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			reqPath := cmd.String("request")
 			jsonOut := cmd.Bool("json")
 			strict := cmd.Bool("strict")
+			echoRequest := cmd.Bool("echo-request")
 
 			req, err := loadRequest(reqPath)
 			if err != nil {
@@ -502,7 +554,7 @@ func apiPredictCmd() *cli.Command {
 				return err
 			}
 
-			opts := &descriptor.PredictOptions{Strict: strict}
+			opts := &descriptor.PredictOptions{Strict: strict, EchoRequest: echoRequest}
 			env := descriptor.PredictFromBytes(data, req, opts)
 
 			if jsonOut {

--- a/internal/cli/json.go
+++ b/internal/cli/json.go
@@ -21,6 +21,14 @@ func writeEnvelope(w io.Writer, data any) error {
 	return writeJSON(w, env)
 }
 
+// writeEnvelopeWithRequest wraps data + the normalized request in a
+// descriptor.Envelope and writes JSON to w. Pass nil for request to fall
+// back to the writeEnvelope shape (the field is omitted via omitempty).
+func writeEnvelopeWithRequest(w io.Writer, data, request any) error {
+	env := descriptor.NewEnvelopeWithRequest(data, request)
+	return writeJSON(w, env)
+}
+
 // writeErrorEnvelope writes an error envelope to w.
 func writeErrorEnvelope(w io.Writer, code, message string) error {
 	env := descriptor.NewEnvelope(nil)

--- a/pulse.go
+++ b/pulse.go
@@ -223,6 +223,21 @@ type Options struct {
 	// PULSE_EXTENSION_DUPLICATE.
 	LabelTablesDir string
 
+	// EchoRequest causes execution paths and descriptor operations to
+	// populate descriptor.Envelope.Request with the *normalized* request
+	// that was executed — smart defaults resolved, per-stage forms
+	// captured for ProcessChain. Off by default to keep wire size
+	// unchanged for hot paths and existing callers. The streaming
+	// process / compose paths skip the echo unconditionally (NDJSON
+	// emit per row, no envelope construction). Predict / inspect /
+	// facet / chain / join descriptor endpoints honor the flag via
+	// PredictOptions and the equivalent option structs.
+	//
+	// Intended for automation callers that want to log or replay the
+	// exact request the engine ran without re-deriving defaults
+	// themselves.
+	EchoRequest bool
+
 	// AutoLabels are default LabelBindings the engine injects into every
 	// read request (Process / Compose / Facet / Sample) before
 	// validation, so registered label tables render display strings
@@ -299,6 +314,7 @@ func New(opts Options) (*Pulse, error) {
 	svc.SetShardWorkers(opts.ShardWorkers)
 	svc.SetStrict(opts.Strict)
 	svc.SetAutoLabels(autoLabelPtrs(opts.AutoLabels))
+	svc.SetEchoRequest(opts.EchoRequest)
 
 	importsMgr, err := imports.New(fsCfg.Fs(), imports.Options{
 		ImportsDir:     opts.ImportsDir,

--- a/service/chain.go
+++ b/service/chain.go
@@ -53,6 +53,19 @@ func (s *Service) ProcessChain(ctx context.Context, req *types.ChainRequest) (*t
 			map[string]any{"stage_index": 0, "stage_name": req.Stages[0].Name})
 	}
 
+	// Capture the post-defaults form of every stage when echo is on so
+	// the boundary (CLI / MCP) can publish a normalized request alongside
+	// the response. The capture is a snapshot taken *after* applyDefaults
+	// so it reflects exactly what the engine ran.
+	var normStages []*types.ChainStage
+	if s.echoRequest {
+		normStages = make([]*types.ChainStage, 0, len(req.Stages))
+		normStages = append(normStages, &types.ChainStage{
+			Name:    req.Stages[0].Name,
+			Request: snapshotRequest(stage0),
+		})
+	}
+
 	firstResp, err := s.Process(ctx, stage0)
 	if err != nil {
 		return nil, err
@@ -87,6 +100,13 @@ func (s *Service) ProcessChain(ctx context.Context, req *types.ChainRequest) (*t
 				map[string]any{"stage_index": i, "stage_name": req.Stages[i].Name})
 		}
 
+		if s.echoRequest {
+			normStages = append(normStages, &types.ChainStage{
+				Name:    req.Stages[i].Name,
+				Request: snapshotRequest(stage),
+			})
+		}
+
 		resp, err := s.runChainStage(ctx, stage, synthSchema, records)
 		if err != nil {
 			return nil, err
@@ -99,7 +119,45 @@ func (s *Service) ProcessChain(ctx context.Context, req *types.ChainRequest) (*t
 	if len(out.Stages) > 0 {
 		out.Final = out.Stages[len(out.Stages)-1]
 	}
+	if s.echoRequest {
+		out.NormalizedRequest = &types.ChainRequest{
+			Cohort: req.Cohort,
+			Stages: normStages,
+		}
+	}
 	return out, nil
+}
+
+// snapshotRequest returns a value-level copy of req with the same
+// aggregator and grouper deep-clone the predict path uses. Used by
+// ProcessChain to capture per-stage normalized requests without holding
+// a reference to the live (still-executing) Request struct.
+func snapshotRequest(req *types.Request) *types.Request {
+	if req == nil {
+		return nil
+	}
+	clone := *req
+	if len(req.Aggregations) > 0 {
+		clone.Aggregations = make([]*types.Aggregation, len(req.Aggregations))
+		for i, a := range req.Aggregations {
+			if a == nil {
+				continue
+			}
+			ac := *a
+			clone.Aggregations[i] = &ac
+		}
+	}
+	if len(req.Groups) > 0 {
+		clone.Groups = make([]*types.Group, len(req.Groups))
+		for i, g := range req.Groups {
+			if g == nil {
+				continue
+			}
+			gc := *g
+			clone.Groups[i] = &gc
+		}
+	}
+	return &clone
 }
 
 // runChainStage runs the processor against an in-memory record set

--- a/service/chain_test.go
+++ b/service/chain_test.go
@@ -69,6 +69,84 @@ func TestProcessChain_TwoStageByteEqualToManual(t *testing.T) {
 	}
 }
 
+// TestProcessChain_NormalizedRequest_PerStage validates the per-stage
+// normalized echo: ChainResponse.NormalizedRequest is nil when echo is
+// off, and when on it carries each stage's post-defaults form. Stage 0
+// runs against the on-disk schema; later stages against the synthesized
+// stage-output schema. Both must show defaults resolved.
+func TestProcessChain_NormalizedRequest_PerStage(t *testing.T) {
+	schema := testSchema()
+	cfg := setupTestFS(t, "test.pulse", schema, testRecords())
+	ctx := context.Background()
+
+	// Build a chain where stage 0 omits the aggregator Type (numeric
+	// default → AGG_SUM) and stage 1 references the aggregate output
+	// without a Type (numeric f64 default → AGG_SUM).
+	makeChain := func() *types.ChainRequest {
+		return &types.ChainRequest{
+			Cohort: &types.Cohort{Filename: "test.pulse"},
+			Stages: []*types.ChainStage{
+				{
+					Name: "stage0",
+					Request: &types.Request{
+						Cohort:       &types.Cohort{Filename: "test.pulse"},
+						Aggregations: []*types.Aggregation{{Field: "score", Label: "sum_score"}},
+					},
+				},
+				{
+					Name: "stage1",
+					Request: &types.Request{
+						Aggregations: []*types.Aggregation{{Field: "sum_score", Label: "total"}},
+					},
+				},
+			},
+		}
+	}
+
+	// Echo off: NormalizedRequest must be nil.
+	svcOff := New(cfg)
+	respOff, err := svcOff.ProcessChain(ctx, makeChain())
+	if err != nil {
+		t.Fatalf("echo-off ProcessChain: %v", err)
+	}
+	if respOff.NormalizedRequest != nil {
+		t.Errorf("NormalizedRequest set with EchoRequest=false: %#v", respOff.NormalizedRequest)
+	}
+
+	// Echo on: per-stage capture, each stage shows AGG_SUM defaulted.
+	svcOn := New(cfg)
+	svcOn.SetEchoRequest(true)
+	respOn, err := svcOn.ProcessChain(ctx, makeChain())
+	if err != nil {
+		t.Fatalf("echo-on ProcessChain: %v", err)
+	}
+	if respOn.NormalizedRequest == nil {
+		t.Fatal("NormalizedRequest nil with EchoRequest=true")
+	}
+	if got := len(respOn.NormalizedRequest.Stages); got != 2 {
+		t.Fatalf("NormalizedRequest.Stages length = %d; want 2", got)
+	}
+	for i, st := range respOn.NormalizedRequest.Stages {
+		if st == nil || st.Request == nil {
+			t.Fatalf("stage %d normalized form nil", i)
+		}
+		if len(st.Request.Aggregations) != 1 {
+			t.Fatalf("stage %d Aggregations = %d; want 1", i, len(st.Request.Aggregations))
+		}
+		if got := st.Request.Aggregations[0].Type; got != types.AGG_SUM {
+			t.Errorf("stage %d normalized Type = %q; want %q (per-stage default)",
+				i, got, types.AGG_SUM)
+		}
+	}
+	// Names propagated unchanged.
+	if respOn.NormalizedRequest.Stages[0].Name != "stage0" {
+		t.Errorf("stage 0 Name = %q; want stage0", respOn.NormalizedRequest.Stages[0].Name)
+	}
+	if respOn.NormalizedRequest.Stages[1].Name != "stage1" {
+		t.Errorf("stage 1 Name = %q; want stage1", respOn.NormalizedRequest.Stages[1].Name)
+	}
+}
+
 // TestProcessChain_NonMergeableMiddleStageReturnsError validates that
 // the chain executor refuses a non-mergeable stage and surfaces the
 // offending stage index.

--- a/service/service.go
+++ b/service/service.go
@@ -44,6 +44,14 @@ type Service struct {
 	// given cohort is silently skipped rather than failing the request.
 	// Matches pulse.Options.AutoLabels.
 	autoLabels []*types.LabelBinding
+
+	// echoRequest causes ProcessChain to capture per-stage normalized
+	// requests into ChainResponse.NormalizedRequest so the CLI / MCP
+	// boundary can publish them on the envelope. Other execution paths
+	// (Process, Compose, Facet, Sample) keep the in-place defaults
+	// mutation behavior — the boundary clones for echo purposes itself.
+	// Matches pulse.Options.EchoRequest.
+	echoRequest bool
 }
 
 // New creates a new Service with the given filesystem configuration.
@@ -136,6 +144,19 @@ func (s *Service) SetAutoLabels(bindings []*types.LabelBinding) {
 // AutoLabels returns the configured default bindings. Exposed for tests.
 func (s *Service) AutoLabels() []*types.LabelBinding {
 	return s.autoLabels
+}
+
+// SetEchoRequest toggles per-stage normalized-request capture in
+// ProcessChain. When true, ChainResponse carries a NormalizedRequest
+// snapshot built during execution; when false, that field is nil.
+// Matches pulse.Options.EchoRequest.
+func (s *Service) SetEchoRequest(enabled bool) {
+	s.echoRequest = enabled
+}
+
+// EchoRequest reports the current echo setting.
+func (s *Service) EchoRequest() bool {
+	return s.echoRequest
 }
 
 // SetExtensionsSnapshot installs the descriptor-side projection of

--- a/skills/getting-started.md
+++ b/skills/getting-started.md
@@ -76,8 +76,8 @@ For pointing a human at the right chapter. The MCP tool list above is the LLM-fa
 
 | Leaf | One-line | mdBook chapter |
 |---|---|---|
-| `process` | Execute a Request from a JSON file. Flags: `--request`, `--json`, `--stream`, `--no-defaults`, `--strict` (promote request-validation warnings into hard errors, e.g. numeric aggregation on a categorical field). | https://frankbardon.github.io/pulse/cli/api-process.html |
-| `process-chain` | Execute a source-rooted linear chain of mergeable processing stages. Flags: `--request`, `--json`, `--no-defaults`. Mergeable-only — rejected stages return `PULSE_CHAIN_NOT_MERGEABLE` so callers can fall back to per-stage `process`. | https://frankbardon.github.io/pulse/cli/api-process-chain.html |
+| `process` | Execute a Request from a JSON file. Flags: `--request`, `--json`, `--stream`, `--no-defaults`, `--strict` (promote request-validation warnings into hard errors, e.g. numeric aggregation on a categorical field), `--echo-request` (include the normalized request on `envelope.request`; ignored under `--stream`). | https://frankbardon.github.io/pulse/cli/api-process.html |
+| `process-chain` | Execute a source-rooted linear chain of mergeable processing stages. Flags: `--request`, `--json`, `--no-defaults`, `--echo-request` (per-stage normalized echo on `envelope.request`). Mergeable-only — rejected stages return `PULSE_CHAIN_NOT_MERGEABLE` so callers can fall back to per-stage `process`. | https://frankbardon.github.io/pulse/cli/api-process-chain.html |
 | `compose` | Execute a ComposedRequest batch | https://frankbardon.github.io/pulse/cli/api-compose.html |
 | `predict` | Validate a request against the schema | https://frankbardon.github.io/pulse/cli/api-predict.html |
 | `cohort inspect` | Print schema and descriptions of a `.pulse` file | https://frankbardon.github.io/pulse/cli/cohort-inspect.html |

--- a/types/chain.go
+++ b/types/chain.go
@@ -47,4 +47,14 @@ type ChainResponse struct {
 
 	// Final aliases the last entry in Stages for ergonomic access.
 	Final *Response `json:"final"`
+
+	// NormalizedRequest is the chain request the engine actually
+	// executed — each stage's Request reflects smart-defaults
+	// resolution against its per-stage schema (the original cohort
+	// for stage 0, the synthesised stage-output schemas for stages
+	// 1+). Populated only when pulse.Options.EchoRequest is true at
+	// service-construction time; nil otherwise so the wire size is
+	// unchanged for callers that do not need it. Serialised under
+	// the omitempty rule.
+	NormalizedRequest *ChainRequest `json:"normalized_request,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds `descriptor.Envelope.Request` — an opt-in echo of the *normalized* request the engine ran — so automation callers (MCP clients, CLI pipelines, replay tools) can capture the full start-to-finish scope of an operation in a single response payload.

- **Envelope-level**: new `request` field, `omitempty`. Wire shape unchanged when the option is off.
- **Normalized**: smart defaults resolved (per-stage for `ProcessChain`).
- **Streaming-skipped**: `--stream` / `ProcessStream` emit raw NDJSON and never build an envelope, so the echo is implicitly absent there.

### Surface

- `pulse.Options.EchoRequest`
- `descriptor.PredictOptions.EchoRequest`
- `descriptor.NewEnvelopeWithRequest(data, request)` + `(*Envelope).WithRequest`
- `descriptor.NormalizeRequest(req, schema)` helper
- `service.Service.SetEchoRequest` / `EchoRequest()`
- `types.ChainResponse.NormalizedRequest *types.ChainRequest` — populated per-stage during execution (stage 0 against on-disk schema, stages 1+ against synthesized stage-output schemas)
- CLI `--echo-request` on `api process`, `api process-chain`, `api compose`, `api sample`, `api facet`, `api predict`

### Format contract

`format_version` stays at `"1.0"` — the `request` field is additive (omitempty) and does not bump the version. CLAUDE.md "Output Format Contract" updated.

### Tests

- `TestEnvelope_RequestOmittedByDefault` — wire shape unchanged when off
- `TestEnvelope_RequestPopulatedWhenSet` — JSON surfaces the echo
- `TestPredict_EchoRequest_Normalized` — envelope echoes post-defaults clone; `PredictResult.Request` stays raw
- `TestProcessChain_NormalizedRequest_PerStage` — per-stage capture; nil when option off

## Test plan

- [x] `go test ./...` — full suite green
- [x] `go vet ./...` / `go fmt ./...` — clean
- [x] New tests added + passing
- [x] Goldens unaffected (`Manifest` shape unchanged; envelope shape uses omitempty)
- [x] CLAUDE.md Update Demand row added

🤖 Generated with [Claude Code](https://claude.com/claude-code)