### PR TITLE
feat(filterers): FILTER_TRUE / FILTER_FALSE with opt-in JS coercion

### DIFF
--- a/descriptor/capabilities_filterers.go
+++ b/descriptor/capabilities_filterers.go
@@ -46,5 +46,21 @@ func filtererCapabilities() []Operator {
 			EmitsTypeNote: "record-level predicate",
 			Streamable:    true,
 		},
+		{
+			Name:          string(types.FILTER_TRUE),
+			Category:      "filterer",
+			Description:   "Keep records where Field is logically true. Strict mode (default, omit Values) requires packed_bool. Opt into JavaScript-style coercion across any field type with Values=[\"truthy\"].",
+			AcceptsTypes:  allCohortFieldTypes,
+			EmitsTypeNote: "record-level predicate",
+			Streamable:    true,
+		},
+		{
+			Name:          string(types.FILTER_FALSE),
+			Category:      "filterer",
+			Description:   "Keep records where Field is logically false. Strict mode (default, omit Values) requires packed_bool. Opt into JavaScript-style coercion across any field type with Values=[\"truthy\"].",
+			AcceptsTypes:  allCohortFieldTypes,
+			EmitsTypeNote: "record-level predicate",
+			Streamable:    true,
+		},
 	}
 }

--- a/descriptor/testdata/manifest.json
+++ b/descriptor/testdata/manifest.json
@@ -1028,6 +1028,33 @@
           "streamable": true
         },
         {
+          "name": "FILTER_FALSE",
+          "category": "filterer",
+          "description": "Keep records where Field is logically false. Strict mode (default, omit Values) requires packed_bool. Opt into JavaScript-style coercion across any field type with Values=[\"truthy\"].",
+          "params": null,
+          "accepts_types": [
+            "categorical_u16",
+            "categorical_u32",
+            "categorical_u8",
+            "date",
+            "decimal128",
+            "f32",
+            "f64",
+            "nullable_bool",
+            "nullable_decimal128",
+            "nullable_u16",
+            "nullable_u4",
+            "nullable_u8",
+            "packed_bool",
+            "u16",
+            "u32",
+            "u64",
+            "u8"
+          ],
+          "emits_type_note": "record-level predicate",
+          "streamable": true
+        },
+        {
           "name": "FILTER_INCLUDE",
           "category": "filterer",
           "description": "Keep records whose field value appears in the supplied Values list.",
@@ -1094,6 +1121,33 @@
             "nullable_u16",
             "nullable_u4",
             "nullable_u8",
+            "u16",
+            "u32",
+            "u64",
+            "u8"
+          ],
+          "emits_type_note": "record-level predicate",
+          "streamable": true
+        },
+        {
+          "name": "FILTER_TRUE",
+          "category": "filterer",
+          "description": "Keep records where Field is logically true. Strict mode (default, omit Values) requires packed_bool. Opt into JavaScript-style coercion across any field type with Values=[\"truthy\"].",
+          "params": null,
+          "accepts_types": [
+            "categorical_u16",
+            "categorical_u32",
+            "categorical_u8",
+            "date",
+            "decimal128",
+            "f32",
+            "f64",
+            "nullable_bool",
+            "nullable_decimal128",
+            "nullable_u16",
+            "nullable_u4",
+            "nullable_u8",
+            "packed_bool",
             "u16",
             "u32",
             "u64",
@@ -3334,9 +3388,11 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
           "FILTER_NULL",
-          "FILTER_RANGE"
+          "FILTER_RANGE",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY",
@@ -3404,9 +3460,11 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
           "FILTER_NULL",
-          "FILTER_RANGE"
+          "FILTER_RANGE",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY",
@@ -3474,9 +3532,11 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
           "FILTER_NULL",
-          "FILTER_RANGE"
+          "FILTER_RANGE",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY",
@@ -3544,9 +3604,11 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
           "FILTER_NULL",
-          "FILTER_RANGE"
+          "FILTER_RANGE",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY",
@@ -3614,9 +3676,11 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
           "FILTER_NULL",
-          "FILTER_RANGE"
+          "FILTER_RANGE",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY",
@@ -3684,9 +3748,11 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
           "FILTER_NULL",
-          "FILTER_RANGE"
+          "FILTER_RANGE",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY",
@@ -3760,9 +3826,11 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
           "FILTER_NULL",
-          "FILTER_RANGE"
+          "FILTER_RANGE",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY",
@@ -3825,8 +3893,10 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
-          "FILTER_NULL"
+          "FILTER_NULL",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY"
@@ -3858,8 +3928,10 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
-          "FILTER_NULL"
+          "FILTER_NULL",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY"
@@ -3894,8 +3966,10 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
-          "FILTER_NULL"
+          "FILTER_NULL",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY"
@@ -3930,8 +4004,10 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
-          "FILTER_NULL"
+          "FILTER_NULL",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY"
@@ -3966,8 +4042,10 @@
         "compatible_filterers": [
           "FILTER_EXCLUDE",
           "FILTER_EXPRESSION",
+          "FILTER_FALSE",
           "FILTER_INCLUDE",
-          "FILTER_NULL"
+          "FILTER_NULL",
+          "FILTER_TRUE"
         ],
         "compatible_groupers": [
           "GROUP_CATEGORY"
@@ -4290,4 +4368,4 @@
   "errors": [],
   "warnings": []
 }
-// golden-hash: b59a8336ad374023ad5b1775e7529720208f99ab91dcc2f450896686a7a99c02
+// golden-hash: 585bbb4ca68e533b179bae2afce28973364ae9b91b9264ab60535015be9dfd8b

--- a/processing/filterer.go
+++ b/processing/filterer.go
@@ -2,6 +2,7 @@ package processing
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/expr-lang/expr"
@@ -211,4 +212,113 @@ func (f *nullFilterer) Build(filter *types.Filterer, _ *encoding.Schema) (Filter
 		}
 		return present, nil
 	}, nil
+}
+
+// --- Boolean (FILTER_TRUE / FILTER_FALSE) ---
+
+// boolFilterer keeps records whose Field is logically true (want=true) or
+// logically false (want=false). Default (strict) mode requires Field to
+// be a packed_bool column; the predicate matches the raw 0/1 value. Opt
+// into JavaScript-style coercion with Values=["truthy"] — any field type
+// is then accepted and `Boolean(value)` semantics apply (0, NaN, "",
+// null → falsy; everything else → truthy).
+type boolFilterer struct {
+	want bool
+}
+
+func newTrueFilterer() FiltererBuilder  { return &boolFilterer{want: true} }
+func newFalseFilterer() FiltererBuilder { return &boolFilterer{want: false} }
+
+func (f *boolFilterer) typeName() types.FiltererType {
+	if f.want {
+		return types.FILTER_TRUE
+	}
+	return types.FILTER_FALSE
+}
+
+func (f *boolFilterer) Build(filter *types.Filterer, schema *encoding.Schema) (FilterFunc, error) {
+	tn := f.typeName()
+	if filter.Field == "" {
+		return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+			fmt.Sprintf("%s requires a Field", tn))
+	}
+
+	truthyMode := false
+	switch len(filter.Values) {
+	case 0:
+		// strict mode
+	case 1:
+		switch filter.Values[0] {
+		case "truthy":
+			truthyMode = true
+		case "strict":
+			truthyMode = false
+		default:
+			return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+				fmt.Sprintf("%s Values[0]=%q; must be \"truthy\" or \"strict\" (or omit Values for strict)", tn, filter.Values[0]))
+		}
+	default:
+		return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+			fmt.Sprintf("%s accepts at most one Values entry (\"truthy\" or \"strict\"); got %d", tn, len(filter.Values)))
+	}
+
+	field := schema.Field(filter.Field)
+	if field == nil {
+		return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+			fmt.Sprintf("%s field %q not found in schema", tn, filter.Field))
+	}
+	if !truthyMode && field.Type != encoding.FieldTypePackedBool {
+		return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+			fmt.Sprintf("%s strict mode requires packed_bool field; %q is %s. Pass Values=[\"truthy\"] to opt into JavaScript-style coercion.",
+				tn, filter.Field, field.Type.String()))
+	}
+
+	fieldName := filter.Field
+	want := f.want
+
+	if !truthyMode {
+		return func(record *Record) (bool, error) {
+			v, ok := record.NumericValue(fieldName)
+			if !ok {
+				return false, nil // null → drop in both directions
+			}
+			isTrue := v != 0
+			return isTrue == want, nil
+		}, nil
+	}
+
+	return func(record *Record) (bool, error) {
+		all := record.AllValues()
+		v, present := all[fieldName]
+		if !present {
+			// null / missing — JS coerces to false
+			return !want, nil
+		}
+		return jsTruthy(v) == want, nil
+	}, nil
+}
+
+// jsTruthy returns whether v would coerce to true under JavaScript's
+// Boolean(value) rules. Pulse record values are produced by AllValues,
+// so the concrete types in play are nil, bool, string (categorical
+// resolved), float64 (numeric/packed_bool/date), and encoding.Decimal128
+// (wide map). Anything else falls back to "non-nil → truthy" to mirror
+// JS object coercion.
+func jsTruthy(v any) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case bool:
+		return x
+	case string:
+		return x != ""
+	case float64:
+		return x != 0 && !math.IsNaN(x)
+	case float32:
+		return x != 0 && !math.IsNaN(float64(x))
+	case encoding.Decimal128:
+		return x.Sign() != 0
+	default:
+		return true
+	}
 }

--- a/processing/filterer_bool_test.go
+++ b/processing/filterer_bool_test.go
@@ -1,0 +1,285 @@
+package processing
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/types"
+)
+
+func boolSchema() *encoding.Schema {
+	return &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "flag", Type: encoding.FieldTypePackedBool, Nullable: true},
+			{Name: "score", Type: encoding.FieldTypeF64, Nullable: true},
+		},
+	}
+}
+
+func mixedSchema() *encoding.Schema {
+	dict := encoding.NewDictionary()
+	dict.Add("") // first slot intentionally empty so id=0 resolves to ""
+	dict.Add("hello")
+	return &encoding.Schema{
+		Fields: []encoding.Field{
+			{Name: "flag", Type: encoding.FieldTypePackedBool, Nullable: true},
+			{Name: "score", Type: encoding.FieldTypeF64, Nullable: true},
+			{Name: "notes", Type: encoding.FieldTypeCategoricalU8, Dictionary: dict, Nullable: true},
+		},
+	}
+}
+
+func buildFilter(t *testing.T, ft types.FiltererType, field string, values []string, schema *encoding.Schema) (FilterFunc, error) {
+	t.Helper()
+	builder := filtererRegistry[ft]()
+	return builder.Build(&types.Filterer{Type: ft, Field: field, Values: values}, schema)
+}
+
+// --- Strict mode ---
+
+func TestFilterer_True_Strict_PackedBool(t *testing.T) {
+	schema := boolSchema()
+	fn, err := buildFilter(t, types.FILTER_TRUE, "flag", nil, schema)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cases := []struct {
+		name string
+		val  float64
+		null bool
+		want bool
+	}{
+		{"true", 1, false, true},
+		{"false", 0, false, false},
+		{"null", 0, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := NewRecordWithNulls(schema, map[string]float64{"flag": c.val}, map[string]bool{"flag": c.null})
+			got, err := fn(rec)
+			if err != nil {
+				t.Fatalf("filter: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("FILTER_TRUE strict flag=%v null=%v: got %v want %v", c.val, c.null, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFilterer_False_Strict_PackedBool(t *testing.T) {
+	schema := boolSchema()
+	fn, err := buildFilter(t, types.FILTER_FALSE, "flag", nil, schema)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cases := []struct {
+		name string
+		val  float64
+		null bool
+		want bool
+	}{
+		{"true", 1, false, false},
+		{"false", 0, false, true},
+		{"null", 0, true, false}, // strict drops null in both directions
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := NewRecordWithNulls(schema, map[string]float64{"flag": c.val}, map[string]bool{"flag": c.null})
+			got, err := fn(rec)
+			if err != nil {
+				t.Fatalf("filter: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("FILTER_FALSE strict flag=%v null=%v: got %v want %v", c.val, c.null, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFilterer_True_Strict_RejectsNonBool(t *testing.T) {
+	schema := boolSchema()
+	_, err := buildFilter(t, types.FILTER_TRUE, "score", nil, schema)
+	if err == nil {
+		t.Fatal("expected strict mode to reject non-packed_bool field")
+	}
+	if !strings.Contains(err.Error(), "packed_bool") {
+		t.Errorf("error should mention packed_bool, got %q", err.Error())
+	}
+}
+
+func TestFilterer_True_RequiresField(t *testing.T) {
+	schema := boolSchema()
+	_, err := buildFilter(t, types.FILTER_TRUE, "", nil, schema)
+	if err == nil {
+		t.Fatal("expected error when Field is empty")
+	}
+}
+
+func TestFilterer_True_MissingFieldInSchema(t *testing.T) {
+	schema := boolSchema()
+	_, err := buildFilter(t, types.FILTER_TRUE, "ghost", nil, schema)
+	if err == nil {
+		t.Fatal("expected error when field not in schema")
+	}
+}
+
+func TestFilterer_True_RejectsUnknownValuesToken(t *testing.T) {
+	schema := boolSchema()
+	_, err := buildFilter(t, types.FILTER_TRUE, "flag", []string{"loose"}, schema)
+	if err == nil {
+		t.Fatal("expected error for unknown values token")
+	}
+}
+
+func TestFilterer_True_RejectsTooManyValues(t *testing.T) {
+	schema := boolSchema()
+	_, err := buildFilter(t, types.FILTER_TRUE, "flag", []string{"truthy", "extra"}, schema)
+	if err == nil {
+		t.Fatal("expected error for >1 values entry")
+	}
+}
+
+func TestFilterer_True_StrictExplicit(t *testing.T) {
+	schema := boolSchema()
+	if _, err := buildFilter(t, types.FILTER_TRUE, "flag", []string{"strict"}, schema); err != nil {
+		t.Fatalf("explicit strict should build: %v", err)
+	}
+}
+
+// --- Truthy (opt-in JS coercion) ---
+
+func TestFilterer_True_Truthy_Numeric(t *testing.T) {
+	schema := boolSchema()
+	fn, err := buildFilter(t, types.FILTER_TRUE, "score", []string{"truthy"}, schema)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cases := []struct {
+		name string
+		val  float64
+		null bool
+		want bool // FILTER_TRUE keeps truthy
+	}{
+		{"positive", 3.5, false, true},
+		{"negative", -1, false, true},
+		{"zero", 0, false, false},
+		{"null", 0, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := NewRecordWithNulls(schema, map[string]float64{"score": c.val}, map[string]bool{"score": c.null})
+			got, err := fn(rec)
+			if err != nil {
+				t.Fatalf("filter: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("FILTER_TRUE truthy score=%v null=%v: got %v want %v", c.val, c.null, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFilterer_False_Truthy_Numeric_KeepsNullAndZero(t *testing.T) {
+	schema := boolSchema()
+	fn, err := buildFilter(t, types.FILTER_FALSE, "score", []string{"truthy"}, schema)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cases := []struct {
+		name string
+		val  float64
+		null bool
+		want bool
+	}{
+		{"zero-kept", 0, false, true},
+		{"null-kept", 0, true, true},
+		{"positive-dropped", 5, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := NewRecordWithNulls(schema, map[string]float64{"score": c.val}, map[string]bool{"score": c.null})
+			got, err := fn(rec)
+			if err != nil {
+				t.Fatalf("filter: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("FILTER_FALSE truthy score=%v null=%v: got %v want %v", c.val, c.null, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFilterer_True_Truthy_Categorical(t *testing.T) {
+	schema := mixedSchema()
+	fn, err := buildFilter(t, types.FILTER_TRUE, "notes", []string{"truthy"}, schema)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	// id 0 resolves to "" (falsy); id 1 resolves to "hello" (truthy).
+	recEmpty := NewRecordWithNulls(schema, map[string]float64{"notes": 0}, map[string]bool{"notes": false})
+	recText := NewRecordWithNulls(schema, map[string]float64{"notes": 1}, map[string]bool{"notes": false})
+	recNull := NewRecordWithNulls(schema, map[string]float64{"notes": 0}, map[string]bool{"notes": true})
+
+	for _, c := range []struct {
+		name string
+		rec  *Record
+		want bool
+	}{
+		{"empty-string-dropped", recEmpty, false},
+		{"non-empty-kept", recText, true},
+		{"null-dropped", recNull, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := fn(c.rec)
+			if err != nil {
+				t.Fatalf("filter: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("FILTER_TRUE truthy notes: got %v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestJSTruthy_TableMatchesJS(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want bool
+	}{
+		{"nil", nil, false},
+		{"bool-true", true, true},
+		{"bool-false", false, false},
+		{"empty-string", "", false},
+		{"non-empty-string", "x", true},
+		{"zero-f64", 0.0, false},
+		{"neg-zero-f64", negZeroF64(), false},
+		{"positive-f64", 1.5, true},
+		{"negative-f64", -1.5, true},
+		{"nan-f64", nanF64(), false},
+		{"zero-f32", float32(0), false},
+		{"positive-f32", float32(2.5), true},
+		{"decimal-zero", encoding.ZeroDecimal128(), false},
+		{"decimal-non-zero", encoding.NewDecimal128FromInt(5), true},
+		{"other-type-non-nil", struct{}{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := jsTruthy(c.in); got != c.want {
+				t.Errorf("jsTruthy(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func nanF64() float64 {
+	zero := 0.0
+	return zero / zero
+}
+
+func negZeroF64() float64 {
+	one := 1.0
+	return -1 / (one / 0)
+}

--- a/processing/registry.go
+++ b/processing/registry.go
@@ -49,6 +49,8 @@ var filtererRegistry = map[types.FiltererType]FiltererFactory{
 	types.FILTER_RANGE:      newRangeFilterer,
 	types.FILTER_EXPRESSION: newExpressionFilterer,
 	types.FILTER_NULL:       newNullFilterer,
+	types.FILTER_TRUE:       newTrueFilterer,
+	types.FILTER_FALSE:      newFalseFilterer,
 }
 
 // grouperRegistry maps group types to their factory functions.

--- a/skills/aggregation-guide.md
+++ b/skills/aggregation-guide.md
@@ -1,6 +1,6 @@
 ---
 name: aggregation-guide
-description: Choose between the 16 AGG_* operators (SUM, AVG, MEDIAN, PERCENTILE, ZSCORE, FREQUENCY, MODE, KURTOSIS, ...) and 5 FILTER_* operators. Use when assembling a Process request, interpreting percentile/frequency output, or picking a row-filter.
+description: Choose between the 16 AGG_* operators (SUM, AVG, MEDIAN, PERCENTILE, ZSCORE, FREQUENCY, MODE, KURTOSIS, ...) and 7 FILTER_* operators. Use when assembling a Process request, interpreting percentile/frequency output, or picking a row-filter.
 type: guide
 applies_to: process, compose, predict
 ---
@@ -8,7 +8,7 @@ applies_to: process, compose, predict
 # Aggregation Guide
 
 <skill_overview>
-Pulse exposes 18 aggregators and 6 filterers that run during `process` and `compose`. Invoke this skill when choosing aggregators for a request, validating numeric-vs-categorical compatibility, or shaping filterers before grouping.
+Pulse exposes 21 aggregators and 7 filterers that run during `process` and `compose`. Invoke this skill when choosing aggregators for a request, validating numeric-vs-categorical compatibility, or shaping filterers before grouping.
 </skill_overview>
 
 <reference>
@@ -116,7 +116,7 @@ For "give me the per-value count of one or more fields" without aggregating acro
 </reference>
 
 <reference>
-## Filterers (6)
+## Filterers (7)
 
 Filterers run before grouping and aggregation. The `types.Filterer` JSON shape is `{"type", "field", "values", "expression"}`; only the keys relevant to each filterer type are used.
 
@@ -126,6 +126,8 @@ Filterers run before grouping and aggregation. The `types.Filterer` JSON shape i
 | FILTER_EXCLUDE | `field`, `values` (string list) | Drop records whose field value is in `values`. Nulls pass through. |
 | FILTER_RANGE | `field`, `values` (exactly `[min, max]`) | Keep records where `min <= value <= max` (both bounds inclusive). Nulls are dropped. |
 | FILTER_NULL | `field`, `values` (exactly `["is_null"]` or `["is_not_null"]`) | Keep records based on null state of the field. Use `is_null` to keep records where the field is null; `is_not_null` to drop them. |
+| FILTER_TRUE | `field`, optional `values=["truthy"]` | Keep records where `field` is logically true. Strict mode (default, omit `values`) requires `field` to be `packed_bool` and matches rows whose value is 1; null rows are dropped. Opt-in `values=["truthy"]` accepts any field type and applies JavaScript `Boolean(value)` semantics — `0`, `NaN`, `""`, and null coerce to falsy and are dropped. |
+| FILTER_FALSE | `field`, optional `values=["truthy"]` | Mirror of FILTER_TRUE. Strict mode keeps `packed_bool` rows whose value is 0; null rows are dropped. With `values=["truthy"]`, JS-falsy rows (including null / missing) are kept — same coercion table as FILTER_TRUE. |
 | FILTER_EXPRESSION | `expression` (expr-lang string returning bool) | Evaluate `expression` against the record's field map; keep records where it returns `true`. No `field` key. |
 </reference>
 
@@ -174,6 +176,37 @@ To count nulls and non-nulls in a single request, combine `AGG_COUNT` (non-null)
   {"type": "AGG_NULL_COUNT", "field": "email", "label": "n_missing"}
 ]}
 ```
+</example>
+
+<example name="filter-true-false">
+Keep records where `is_active` (a `packed_bool` field) is true. Strict mode — no `values` key.
+
+```json
+{"type": "FILTER_TRUE", "field": "is_active"}
+```
+
+Drop records where `is_active` is true (i.e. keep the explicit `false` rows; nulls are dropped).
+
+```json
+{"type": "FILTER_FALSE", "field": "is_active"}
+```
+
+Opt into JavaScript-style coercion to filter a non-boolean column. The block below keeps any row whose `notes` text is non-empty (empty string and null are dropped):
+
+```json
+{"type": "FILTER_TRUE", "field": "notes", "values": ["truthy"]}
+```
+
+`values=["truthy"]` is the only opt-in token; without it, `FILTER_TRUE` / `FILTER_FALSE` reject non-`packed_bool` fields with `PROCESSING_CONFIG` so a coercion is never silent. Coercion table mirrors JavaScript `Boolean(value)`:
+
+| Field shape | Falsy values | Everything else |
+|---|---|---|
+| numeric (u*, f*, date, packed_bool) | `0`, `NaN` | truthy |
+| categorical_* (resolved string) | `""` | truthy |
+| decimal128 | mantissa == 0 | truthy |
+| null / missing | always falsy | — |
+
+Use strict mode whenever the field actually is `packed_bool` — it avoids a per-row map allocation that the coercion path needs.
 </example>
 
 <example name="filter-expression">

--- a/types/streamability.go
+++ b/types/streamability.go
@@ -173,7 +173,8 @@ func (t FiltererType) Streamable() bool {
 	switch t {
 	case FILTER_INCLUDE, FILTER_EXCLUDE, FILTER_RANGE,
 		FILTER_EXPRESSION,
-		FILTER_NULL:
+		FILTER_NULL,
+		FILTER_TRUE, FILTER_FALSE:
 		return true
 	}
 	return false

--- a/types/streamability_test.go
+++ b/types/streamability_test.go
@@ -76,6 +76,8 @@ func TestStreamability_FilterersKnown(t *testing.T) {
 		FILTER_RANGE:      true,
 		FILTER_EXPRESSION: true,
 		FILTER_NULL:       true,
+		FILTER_TRUE:       true,
+		FILTER_FALSE:      true,
 	}
 	for _, f := range AllFiltererTypes() {
 		want, ok := expected[f]

--- a/types/types.go
+++ b/types/types.go
@@ -85,6 +85,24 @@ const (
 	// Mode is "is_null" (keep null-valued records) or "is_not_null" (keep
 	// non-null records). Row-local; streamable.
 	FILTER_NULL FiltererType = "FILTER_NULL"
+
+	// FILTER_TRUE keeps records where Field is logically true. Default
+	// (strict) mode requires Field to be packed_bool and keeps records
+	// whose value is 1. Opt-in JavaScript-style truthiness coercion is
+	// enabled with Values=["truthy"]; in that mode any field type is
+	// accepted and the same rules JS uses for `Boolean(value)` apply
+	// (0, NaN, empty string, null → falsy; everything else → truthy).
+	// Row-local; streamable.
+	FILTER_TRUE FiltererType = "FILTER_TRUE"
+
+	// FILTER_FALSE keeps records where Field is logically false. Default
+	// (strict) mode requires Field to be packed_bool and keeps records
+	// whose value is 0. Opt-in JavaScript-style falsiness coercion is
+	// enabled with Values=["truthy"]; in that mode any field type is
+	// accepted and records whose value would coerce to falsy under
+	// `Boolean(value)` are kept (0, NaN, empty string, null → kept).
+	// Row-local; streamable.
+	FILTER_FALSE FiltererType = "FILTER_FALSE"
 )
 
 // AllFiltererTypes returns all defined filterer types.
@@ -92,9 +110,11 @@ func AllFiltererTypes() []FiltererType {
 	return []FiltererType{
 		FILTER_EXCLUDE,
 		FILTER_EXPRESSION,
+		FILTER_FALSE,
 		FILTER_INCLUDE,
 		FILTER_NULL,
 		FILTER_RANGE,
+		FILTER_TRUE,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `FILTER_TRUE` / `FILTER_FALSE` filterers. Default (strict) mode requires a `packed_bool` field and matches the raw 0/1 value.
- Opt-in JavaScript-style coercion: pass `Values=["truthy"]` to accept any field type and apply `Boolean(value)` rules (`0`, `NaN`, `""`, null → falsy). Strict mode rejects non-`packed_bool` fields up front so coercion is never silent.
- Updates `types`, `streamability`, `processing/registry`, `descriptor/capabilities_filterers`, the `aggregation-guide` skill, and regenerates the manifest golden.

## Coercion table (truthy mode)
| Field shape | Falsy | Everything else |
|---|---|---|
| numeric (u*, f*, date, packed_bool) | `0`, `NaN` | truthy |
| categorical_* (resolved string) | `""` | truthy |
| decimal128 | mantissa == 0 | truthy |
| null / missing | always falsy | — |

## Test plan
- [x] `go test ./...` — full suite green (including `TestStreamability_FilterersKnown`, `TestRootManifestGolden`, `TestGoldensNotHandEdited`).
- [x] New unit suite in `processing/filterer_bool_test.go` covers strict packed_bool, non-bool rejection, missing-field error, unknown-token rejection, truthy numeric / categorical, FILTER_FALSE keeping null + zero, and a JS coercion table including negative zero / NaN / Decimal128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)