### PR TITLE
feat(grouper): add fiscal_offset to GROUP_DATE for fiscal year/quarter bucketing

### DIFF
--- a/descriptor/capabilities_groupers.go
+++ b/descriptor/capabilities_groupers.go
@@ -17,7 +17,7 @@ func grouperCapabilities() []Operator {
 		{
 			Name:        string(types.GROUP_DATE),
 			Category:    "grouper",
-			Description: "Partition date-typed records by a calendar component (year, quarter, month, week, day, day_of_week).",
+			Description: "Partition date-typed records by a calendar component (year, quarter, month, week, day, day_of_week). Optional fiscal_offset shifts year/quarter bucketing onto a fiscal calendar with end-year labels (FY-prefixed keys).",
 			Params: []Param{
 				{
 					Name:        "component",
@@ -27,9 +27,16 @@ func grouperCapabilities() []Operator {
 					Description: "Calendar component to bucket by.",
 					EnumValues:  []string{"day", "day_of_week", "month", "quarter", "week", "year"},
 				},
+				{
+					Name:        "fiscal_offset",
+					Type:        "int",
+					Required:    false,
+					Default:     0,
+					Description: "Months after January when the fiscal year starts; valid only with component=year or component=quarter. Range [-11, 11]; offsets normalise mod 12 (offset=-3 == offset=9 => October start). 0 (default) = calendar year. Non-zero offsets prefix keys with FY using the end-year convention (Apr 2024-Mar 2025 with offset=3 => FY2025).",
+				},
 			},
 			AcceptsTypes:   []string{"date"},
-			EmitsTypeNote:  "string group key per row (e.g. 2024-Q1, 2024-01)",
+			EmitsTypeNote:  "string group key per row (e.g. 2024-Q1, 2024-01, FY2025-Q1)",
 			Streamable:     false,
 			StreamableHint: "Use GROUP_CATEGORY on an ATTR_DATE_PART output column for a streaming-friendly substitute.",
 		},

--- a/descriptor/testdata/manifest.json
+++ b/descriptor/testdata/manifest.json
@@ -1188,7 +1188,7 @@
         {
           "name": "GROUP_DATE",
           "category": "grouper",
-          "description": "Partition date-typed records by a calendar component (year, quarter, month, week, day, day_of_week).",
+          "description": "Partition date-typed records by a calendar component (year, quarter, month, week, day, day_of_week). Optional fiscal_offset shifts year/quarter bucketing onto a fiscal calendar with end-year labels (FY-prefixed keys).",
           "params": [
             {
               "name": "component",
@@ -1204,12 +1204,19 @@
                 "week",
                 "year"
               ]
+            },
+            {
+              "name": "fiscal_offset",
+              "type": "int",
+              "required": false,
+              "default": 0,
+              "description": "Months after January when the fiscal year starts; valid only with component=year or component=quarter. Range [-11, 11]; offsets normalise mod 12 (offset=-3 == offset=9 =\u003e October start). 0 (default) = calendar year. Non-zero offsets prefix keys with FY using the end-year convention (Apr 2024-Mar 2025 with offset=3 =\u003e FY2025)."
             }
           ],
           "accepts_types": [
             "date"
           ],
-          "emits_type_note": "string group key per row (e.g. 2024-Q1, 2024-01)",
+          "emits_type_note": "string group key per row (e.g. 2024-Q1, 2024-01, FY2025-Q1)",
           "streamable": false,
           "streamable_hint": "Use GROUP_CATEGORY on an ATTR_DATE_PART output column for a streaming-friendly substitute."
         },
@@ -4368,4 +4375,4 @@
   "errors": [],
   "warnings": []
 }
-// golden-hash: 585bbb4ca68e533b179bae2afce28973364ae9b91b9264ab60535015be9dfd8b
+// golden-hash: 0624b3935266d69aaf825eb4001215dadd4ae6f704984149f6370fb1614f8ac6

--- a/processing/grouper.go
+++ b/processing/grouper.go
@@ -290,7 +290,8 @@ func (g *quantileGrouper) Group(records []*Record, field string) (map[string][]*
 // --- Date Grouper ---
 
 type dateGroupParams struct {
-	Component string `json:"component"`
+	Component    string `json:"component"`
+	FiscalOffset *int   `json:"fiscal_offset,omitempty"`
 }
 
 var validDateGroupComponents = map[string]bool{
@@ -298,12 +299,22 @@ var validDateGroupComponents = map[string]bool{
 	"week": true, "day": true, "day_of_week": true,
 }
 
+// fiscalComponents lists the only components that meaningfully accept a
+// fiscal_offset. Month/week/day/day_of_week buckets do not shift under a
+// fiscal calendar, so combining them with fiscal_offset is rejected at
+// construction time.
+var fiscalComponents = map[string]bool{
+	"year": true, "quarter": true,
+}
+
 type dateGrouper struct {
-	component string
+	component    string
+	fiscalOffset int // 0 = calendar; non-zero = FY starts at month (((offset%12)+12)%12)+1
 }
 
 func newDateGrouper(grp *types.Group, _ *encoding.Schema) (Grouper, error) {
 	component := "month"
+	fiscalOffset := 0
 	if len(grp.Params) > 0 {
 		var params dateGroupParams
 		if err := json.Unmarshal(grp.Params, &params); err != nil {
@@ -313,6 +324,9 @@ func newDateGrouper(grp *types.Group, _ *encoding.Schema) (Grouper, error) {
 		if params.Component != "" {
 			component = params.Component
 		}
+		if params.FiscalOffset != nil {
+			fiscalOffset = *params.FiscalOffset
+		}
 	}
 
 	if !validDateGroupComponents[component] {
@@ -320,7 +334,34 @@ func newDateGrouper(grp *types.Group, _ *encoding.Schema) (Grouper, error) {
 			fmt.Sprintf("invalid date group component %q: must be one of year, quarter, month, week, day, day_of_week", component))
 	}
 
-	return &dateGrouper{component: component}, nil
+	if fiscalOffset < -11 || fiscalOffset > 11 {
+		return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+			fmt.Sprintf("invalid GROUP_DATE fiscal_offset %d: must be in range [-11, 11]", fiscalOffset))
+	}
+	if fiscalOffset != 0 && !fiscalComponents[component] {
+		return nil, errors.NewCodedError(errors.PROCESSING_CONFIG,
+			fmt.Sprintf("GROUP_DATE fiscal_offset only applies to component=year or component=quarter, got %q", component))
+	}
+
+	return &dateGrouper{component: component, fiscalOffset: fiscalOffset}, nil
+}
+
+// fiscalYearQuarter returns the fiscal year (end-year convention) and the
+// 1-indexed fiscal quarter for a calendar date under a given fiscal offset.
+// Offset normalisation: start_month_1idx = ((offset%12)+12)%12 + 1, so
+// offset=3 and offset=-9 both yield start_month=April; offset=9 and
+// offset=-3 both yield start_month=October.
+func fiscalYearQuarter(t time.Time, offset int) (int, int) {
+	startMonth := ((offset%12)+12)%12 + 1
+	calYear := t.Year()
+	calMonth := int(t.Month())
+	fy := calYear
+	if startMonth != 1 && calMonth >= startMonth {
+		fy = calYear + 1
+	}
+	elapsed := (calMonth - startMonth + 12) % 12
+	fq := elapsed/3 + 1
+	return fy, fq
 }
 
 func (g *dateGrouper) Group(records []*Record, field string) (map[string][]*Record, error) {
@@ -339,9 +380,19 @@ func (g *dateGrouper) Group(records []*Record, field string) (map[string][]*Reco
 		var key string
 		switch g.component {
 		case "year":
-			key = fmt.Sprintf("%d", t.Year())
+			if g.fiscalOffset != 0 {
+				fy, _ := fiscalYearQuarter(t, g.fiscalOffset)
+				key = fmt.Sprintf("FY%d", fy)
+			} else {
+				key = fmt.Sprintf("%d", t.Year())
+			}
 		case "quarter":
-			key = fmt.Sprintf("%d-Q%d", t.Year(), (int(t.Month())-1)/3+1)
+			if g.fiscalOffset != 0 {
+				fy, fq := fiscalYearQuarter(t, g.fiscalOffset)
+				key = fmt.Sprintf("FY%d-Q%d", fy, fq)
+			} else {
+				key = fmt.Sprintf("%d-Q%d", t.Year(), (int(t.Month())-1)/3+1)
+			}
 		case "month":
 			key = t.Format("2006-01")
 		case "week":

--- a/processing/grouper_test.go
+++ b/processing/grouper_test.go
@@ -2,6 +2,7 @@ package processing
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -777,6 +778,162 @@ func TestGrouper_Date_NullHandling(t *testing.T) {
 	}
 	if len(groups["2024-01"]) != 2 {
 		t.Errorf("group 2024-01 count = %d, want 2", len(groups["2024-01"]))
+	}
+}
+
+// makeFiscalDateGrouper constructs a GROUP_DATE with the given component and
+// fiscal_offset; passing component="" defaults to month.
+func makeFiscalDateGrouper(t *testing.T, component string, fiscalOffset int, schema *encoding.Schema) Grouper {
+	t.Helper()
+	factory, ok := grouperRegistry[types.GROUP_DATE]
+	if !ok {
+		t.Fatalf("no grouper registered for GROUP_DATE")
+	}
+	if component == "" {
+		component = "month"
+	}
+	params := json.RawMessage(fmt.Sprintf(`{"component":%q,"fiscal_offset":%d}`, component, fiscalOffset))
+	g, err := factory(&types.Group{Type: types.GROUP_DATE, Field: "enrolled", Params: params}, schema)
+	if err != nil {
+		t.Fatalf("create grouper: %v", err)
+	}
+	return g
+}
+
+// TestGrouper_Date_FiscalQuarter_AprilStart pins the canonical UK-style
+// fiscal calendar (offset=3 => April-start FY) with end-year labels: a date
+// inside April-June 2024 lands in FY2025-Q1, March 2024 lands in the
+// preceding FY2024-Q4, and December 2024 (still inside FY2025) lands in
+// FY2025-Q3.
+func TestGrouper_Date_FiscalQuarter_AprilStart(t *testing.T) {
+	schema := dateSchema()
+	g := makeFiscalDateGrouper(t, "quarter", 3, schema)
+
+	records := makeRecords(schema, "enrolled", []float64{
+		epochDays(2024, 4, 1),   // FY2025-Q1 (Apr-Jun)
+		epochDays(2024, 6, 30),  // FY2025-Q1
+		epochDays(2024, 7, 1),   // FY2025-Q2 (Jul-Sep)
+		epochDays(2024, 12, 31), // FY2025-Q3 (Oct-Dec)
+		epochDays(2025, 3, 31),  // FY2025-Q4 (Jan-Mar)
+		epochDays(2024, 3, 31),  // FY2024-Q4 (preceding fiscal year)
+	})
+	groups, err := g.Group(records, "enrolled")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]int{
+		"FY2025-Q1": 2,
+		"FY2025-Q2": 1,
+		"FY2025-Q3": 1,
+		"FY2025-Q4": 1,
+		"FY2024-Q4": 1,
+	}
+	if len(groups) != len(want) {
+		t.Fatalf("group count = %d, want %d, groups: %v", len(groups), len(want), groupKeys(groups))
+	}
+	for k, n := range want {
+		if len(groups[k]) != n {
+			t.Errorf("group %s count = %d, want %d", k, len(groups[k]), n)
+		}
+	}
+}
+
+// TestGrouper_Date_FiscalYear_OctoberStart pins US-Federal-style FY: Oct 1
+// 2023 through Sep 30 2024 is FY2024, Oct 1 2024 flips to FY2025.
+func TestGrouper_Date_FiscalYear_OctoberStart(t *testing.T) {
+	schema := dateSchema()
+	g := makeFiscalDateGrouper(t, "year", 9, schema)
+
+	records := makeRecords(schema, "enrolled", []float64{
+		epochDays(2023, 10, 1), // FY2024
+		epochDays(2024, 9, 30), // FY2024
+		epochDays(2024, 10, 1), // FY2025
+	})
+	groups, err := g.Group(records, "enrolled")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(groups["FY2024"]) != 2 {
+		t.Errorf("FY2024 count = %d, want 2", len(groups["FY2024"]))
+	}
+	if len(groups["FY2025"]) != 1 {
+		t.Errorf("FY2025 count = %d, want 1", len(groups["FY2025"]))
+	}
+}
+
+// TestGrouper_Date_FiscalOffset_NegativeEquivalence asserts that offset=-3
+// (3 months earlier) and offset=9 (October start) produce identical
+// fiscal-year bucketing. Both should land Oct 1 2024 in FY2025.
+func TestGrouper_Date_FiscalOffset_NegativeEquivalence(t *testing.T) {
+	schema := dateSchema()
+	records := makeRecords(schema, "enrolled", []float64{
+		epochDays(2023, 10, 1),
+		epochDays(2024, 9, 30),
+		epochDays(2024, 10, 1),
+	})
+
+	gNeg := makeFiscalDateGrouper(t, "year", -3, schema)
+	gPos := makeFiscalDateGrouper(t, "year", 9, schema)
+
+	groupsNeg, err := gNeg.Group(records, "enrolled")
+	if err != nil {
+		t.Fatalf("neg group: %v", err)
+	}
+	groupsPos, err := gPos.Group(records, "enrolled")
+	if err != nil {
+		t.Fatalf("pos group: %v", err)
+	}
+	for _, k := range []string{"FY2024", "FY2025"} {
+		if len(groupsNeg[k]) != len(groupsPos[k]) {
+			t.Errorf("key %s: neg=%d pos=%d (should match)", k, len(groupsNeg[k]), len(groupsPos[k]))
+		}
+	}
+}
+
+// TestGrouper_Date_FiscalOffset_ZeroIsCalendar asserts that fiscal_offset=0
+// is byte-identical to the no-fiscal_offset path: keys must be bare years
+// (no FY prefix) so existing behaviour is preserved.
+func TestGrouper_Date_FiscalOffset_ZeroIsCalendar(t *testing.T) {
+	schema := dateSchema()
+	g := makeFiscalDateGrouper(t, "year", 0, schema)
+
+	records := makeRecords(schema, "enrolled", []float64{
+		epochDays(2024, 1, 15),
+		epochDays(2025, 6, 1),
+	})
+	groups, err := g.Group(records, "enrolled")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := groups["2024"]; !ok {
+		t.Errorf("offset=0 year key should be %q (no FY prefix), got %v", "2024", groupKeys(groups))
+	}
+	if _, ok := groups["FY2024"]; ok {
+		t.Errorf("offset=0 must not emit FY-prefixed key")
+	}
+}
+
+func TestGrouper_Date_FiscalOffset_OutOfRange(t *testing.T) {
+	schema := dateSchema()
+	factory := grouperRegistry[types.GROUP_DATE]
+	for _, off := range []int{-12, 12, 50, -50} {
+		params := json.RawMessage(fmt.Sprintf(`{"component":"year","fiscal_offset":%d}`, off))
+		_, err := factory(&types.Group{Type: types.GROUP_DATE, Field: "enrolled", Params: params}, schema)
+		if err == nil {
+			t.Errorf("expected error for fiscal_offset=%d, got nil", off)
+		}
+	}
+}
+
+func TestGrouper_Date_FiscalOffset_InvalidComponent(t *testing.T) {
+	schema := dateSchema()
+	factory := grouperRegistry[types.GROUP_DATE]
+	for _, comp := range []string{"month", "week", "day", "day_of_week"} {
+		params := json.RawMessage(fmt.Sprintf(`{"component":%q,"fiscal_offset":3}`, comp))
+		_, err := factory(&types.Group{Type: types.GROUP_DATE, Field: "enrolled", Params: params}, schema)
+		if err == nil {
+			t.Errorf("expected error for fiscal_offset with component=%s, got nil", comp)
+		}
 	}
 }
 

--- a/skills/grouper-design.md
+++ b/skills/grouper-design.md
@@ -73,16 +73,20 @@ Bin ages into 10-year ranges.
 Groups records by a date component extracted from a `date` type field. The field value is interpreted as epoch days since Unix epoch (1970-01-01) and converted to a UTC timestamp for component extraction.
 
 - **Fields**: Requires a `date` type field.
-- **Config**: `params` is a JSON object `{"component": "<component>"}` where component is one of: `year`, `quarter`, `month`, `week`, `day`, `day_of_week`. Defaults to `month` if `params` is omitted.
-- **Key format**:
+- **Config**: `params` is a JSON object `{"component": "<component>", "fiscal_offset": <int>}`. `component` is one of `year`, `quarter`, `month`, `week`, `day`, `day_of_week` and defaults to `month`. `fiscal_offset` is optional and defaults to `0`.
+- **Key format (calendar)**:
   - `year` → `"2024"`
   - `quarter` → `"2024-Q1"`
   - `month` → `"2024-01"`
   - `week` → `"2024-W03"` (ISO week)
   - `day` → `"2024-01-15"`
   - `day_of_week` → `"Monday"`
+- **Fiscal offset**: `fiscal_offset` is the number of months after January that the fiscal year starts; valid range `[-11, 11]`. Only meaningful with `component=year` or `component=quarter` — combining `fiscal_offset != 0` with any other component is rejected with `PROCESSING_CONFIG`. Offsets normalise modulo 12, so `fiscal_offset=-3` and `fiscal_offset=9` both pin an October-start fiscal year. `fiscal_offset=0` is byte-identical to the no-offset path (calendar year, no `FY` prefix).
+- **Key format (fiscal, end-year convention)**: a fiscal year is labelled by the calendar year in which it ENDS. The April-start fiscal year running Apr 2024 → Mar 2025 emits `FY2025`; an October-start fiscal year running Oct 2023 → Sep 2024 emits `FY2024`.
+  - `year` + fiscal → `"FY2025"`
+  - `quarter` + fiscal → `"FY2025-Q1"` (Q1 is the first three months of the fiscal year, NOT the first three calendar months)
 - **Null handling**: Records with null values are skipped (not grouped).
-- **Use when**: You want to segment time-series data by calendar periods (e.g., monthly enrollment counts, quarterly revenue, day-of-week patterns).
+- **Use when**: You want to segment time-series data by calendar periods (e.g., monthly enrollment counts, quarterly revenue, day-of-week patterns), or by fiscal periods that do not align with the calendar year (UK April-start `fiscal_offset=3`, US Federal October-start `fiscal_offset=9` or equivalently `-3`).
 </reference>
 
 <example name="group-date">
@@ -95,6 +99,38 @@ Group enrollments by month.
   ],
   "aggregations": [
     {"type": "AGG_COUNT", "field": "id"}
+  ]
+}
+```
+</example>
+
+<example name="group-date-fiscal-quarter">
+Group revenue by fiscal quarter under a UK-style April-start fiscal year.
+Keys emit as `FY2025-Q1` (Apr-Jun 2024), `FY2025-Q2` (Jul-Sep 2024), etc.
+
+```json
+{
+  "groups": [
+    {"type": "GROUP_DATE", "field": "booked_on", "params": {"component": "quarter", "fiscal_offset": 3}}
+  ],
+  "aggregations": [
+    {"type": "AGG_SUM", "field": "revenue"}
+  ]
+}
+```
+</example>
+
+<example name="group-date-fiscal-year-us-federal">
+Group obligations by US Federal fiscal year (October start). `fiscal_offset=9`
+and `fiscal_offset=-3` are equivalent. Keys emit as `FY2024`, `FY2025`, ...
+
+```json
+{
+  "groups": [
+    {"type": "GROUP_DATE", "field": "obligated_on", "params": {"component": "year", "fiscal_offset": 9}}
+  ],
+  "aggregations": [
+    {"type": "AGG_SUM", "field": "amount"}
   ]
 }
 ```


### PR DESCRIPTION
## Summary

- `GROUP_DATE` gains optional `fiscal_offset` param (range `[-11, 11]`, default `0`). Shifts year/quarter bucketing onto a fiscal calendar; offsets normalise modulo 12 (so `-3` ≡ `9`, both yielding an October-start FY).
- Non-zero offsets prefix keys with `FY` using the **end-year** convention: Apr 2024 - Mar 2025 with `offset=3` emits `FY2025`; Oct 2023 - Sep 2024 with `offset=9` emits `FY2024`. `offset=0` is byte-identical to the prior calendar path (no `FY` prefix).
- `fiscal_offset` is rejected with `PROCESSING_CONFIG` when combined with `component=month/week/day/day_of_week`, since only year/quarter shift meaningfully under a fiscal calendar.

## Files

- `processing/grouper.go` — param plumbing + `fiscalYearQuarter` helper + year/quarter switch arms.
- `processing/grouper_test.go` — 6 new tests: UK April-start quarter (including year-boundary roll), US Federal October-start year, `-3`/`+9` equivalence, `offset=0` ≡ calendar, out-of-range rejection, non-fiscal-component rejection.
- `descriptor/capabilities_groupers.go` — `fiscal_offset` documented in capability metadata; updated `EmitsTypeNote`.
- `descriptor/testdata/manifest.json` — golden regenerated.
- `skills/grouper-design.md` — reference section + 2 new examples (UK April-start quarter, US Federal year).

## Test plan

- [x] `go test ./processing/ -run TestGrouper_Date`
- [x] `go test ./...` (all packages green; manifest golden regenerated)
- [x] `go vet ./...`
- [x] `gofmt -l processing/ descriptor/ skills/` clean
- [x] Reviewer sanity-check: try `{"type":"GROUP_DATE","field":"<date>","params":{"component":"quarter","fiscal_offset":3}}` against a sample cohort and confirm `FY2025-Q1` covers Apr-Jun 2024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)