### PR TITLE
perf(filter): project per-record decode to predicate-referenced fields

### DIFF
--- a/service/filter_to_file.go
+++ b/service/filter_to_file.go
@@ -204,11 +204,12 @@ func (s *Service) filterSingleFileBytesToFile(ctx context.Context, fsys afero.Fs
 	if err != nil {
 		return 0, err
 	}
+	keep := s.fieldFilterForPlan(schema, plan)
 
 	out := bytes.NewBuffer(make([]byte, 0, len(data)))
 	out.Write(data[:headerSchemaEnd])
 
-	written, err := s.streamFilterRecords(ctx, data, br, schema, filterFn, out)
+	written, err := s.streamFilterRecords(ctx, data, br, schema, filterFn, keep, out)
 	if err != nil {
 		return 0, err
 	}
@@ -241,6 +242,7 @@ func (s *Service) filterShardArchiveToFile(ctx context.Context, fsys afero.Fs, d
 	if err != nil {
 		return 0, err
 	}
+	keep := s.fieldFilterForPlan(canonicalSchema, plan)
 
 	// Per-shard filter + accumulate output payloads.
 	type filteredShard struct {
@@ -279,7 +281,7 @@ func (s *Service) filterShardArchiveToFile(ctx context.Context, fsys afero.Fs, d
 
 		buf := bytes.NewBuffer(make([]byte, 0, len(shardBytes)))
 		buf.Write(shardBytes[:localHeaderSchemaEnd])
-		written, ferr := s.streamFilterRecords(ctx, shardBytes, br, canonicalSchema, filterFn, buf)
+		written, ferr := s.streamFilterRecords(ctx, shardBytes, br, canonicalSchema, filterFn, keep, buf)
 		if ferr != nil {
 			return 0, ferr
 		}
@@ -319,10 +321,27 @@ func (s *Service) filterShardArchiveToFile(ctx context.Context, fsys afero.Fs, d
 // header+schema), applies filterFn against records decoded with schema,
 // and writes raw record-byte ranges from data into out for kept rows.
 // Returns the number of records written.
-func (s *Service) streamFilterRecords(ctx context.Context, data []byte, br *bytes.Reader, schema *encoding.Schema, filterFn processing.FilterFunc, out *bytes.Buffer) (int64, error) {
-	values := make(map[string]float64, len(schema.Fields))
-	nulls := make(map[string]bool, len(schema.Fields))
-	wide := make(map[string]any, len(schema.Fields))
+//
+// keep narrows per-record map population to the fields the predicate
+// actually reads (built once via fieldFilterForPlan). A nil keep falls
+// through to the full-decode path — used when the predicate's field set
+// can't be proven (malformed expression, unknown extension hook).
+func (s *Service) streamFilterRecords(ctx context.Context, data []byte, br *bytes.Reader, schema *encoding.Schema, filterFn processing.FilterFunc, keep encoding.FieldFilter, out *bytes.Buffer) (int64, error) {
+	mapSize := len(schema.Fields)
+	if keep != nil {
+		mapSize = 0
+		for _, f := range schema.Fields {
+			if keep(f.Name) {
+				mapSize++
+			}
+		}
+		if mapSize == 0 {
+			mapSize = 1
+		}
+	}
+	values := make(map[string]float64, mapSize)
+	nulls := make(map[string]bool, mapSize)
+	wide := make(map[string]any, mapSize)
 	rr := encoding.NewRecordReader(br, schema)
 
 	var written int64
@@ -331,7 +350,7 @@ func (s *Service) streamFilterRecords(ctx context.Context, data []byte, br *byte
 			return 0, err
 		}
 		posStart := int64(len(data)) - int64(br.Len())
-		err := rr.ReadRecordWithWide(values, nulls, wide)
+		err := rr.ReadRecordWithWideProjected(values, nulls, wide, keep)
 		if err == io.EOF {
 			break
 		}
@@ -352,6 +371,41 @@ func (s *Service) streamFilterRecords(ctx context.Context, data []byte, br *byte
 		written++
 	}
 	return written, nil
+}
+
+// fieldFilterForPlan returns a per-field projection filter narrowing
+// per-record map population to the fields the plan's predicates actually
+// read. Returns nil when the field set can't be narrowed safely
+// (malformed expression, extension hook without introspection) — the
+// caller then falls through to the full-decode path via
+// ReadRecordWithWideProjected's nil-filter contract.
+//
+// The set is built by feeding a synthetic types.Request through
+// processing.NeededFields (the same machinery the buffered Process path
+// uses since v0.12.3) and then unioning the MemberSet include field.
+// Saves map allocations + float64 conversions for unreferenced columns;
+// byte reads still happen so file offsets stay aligned.
+func (s *Service) fieldFilterForPlan(schema *encoding.Schema, plan filterPlan) encoding.FieldFilter {
+	if schema == nil {
+		return nil
+	}
+	req := &types.Request{}
+	if plan.filterExpr != "" {
+		req.Filterers = []*types.Filterer{
+			{Type: types.FILTER_EXPRESSION, Expression: plan.filterExpr},
+		}
+	}
+	set := processing.NeededFields(req, schema, s.extensions)
+	if set.IsWide() {
+		return nil
+	}
+	if plan.set != nil && plan.includeField != "" {
+		set.Add(plan.includeField)
+	}
+	if set.Len() == 0 {
+		return nil
+	}
+	return func(name string) bool { return set.Has(name) }
 }
 
 // buildSingleFilter resolves filterExpr into a single FilterFunc bound

--- a/service/filter_to_file_projection_test.go
+++ b/service/filter_to_file_projection_test.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/frankbardon/pulse/encoding"
+	"github.com/frankbardon/pulse/fs"
+	"github.com/spf13/afero"
+)
+
+// stubMemberSet satisfies processing.MemberSet for tests that need only
+// the metadata surface (the hot-path predicate is not exercised here —
+// fieldFilterForPlan inspects the plan, not the set contents).
+type stubMemberSet struct{}
+
+func (stubMemberSet) Len() int     { return 1 }
+func (stubMemberSet) Kind() string { return "stub" }
+
+// TestFieldFilterForPlan_NarrowsToExprIdents asserts the projection
+// filter built from a FILTER_EXPRESSION predicate keeps only identifiers
+// the expression references.
+func TestFieldFilterForPlan_NarrowsToExprIdents(t *testing.T) {
+	schema := testSchema() // fields: id, score
+	cfg := setupTestFS(t, "src.pulse", schema, testRecords())
+	svc := New(cfg)
+
+	keep := svc.fieldFilterForPlan(schema, filterPlan{filterExpr: "score > 25.0"})
+	if keep == nil {
+		t.Fatal("keep filter nil; expected narrow set")
+	}
+	if !keep("score") {
+		t.Error("keep(score) = false, want true")
+	}
+	if keep("id") {
+		t.Error("keep(id) = true, want false (not referenced by predicate)")
+	}
+}
+
+// TestFieldFilterForPlan_MalformedExpressionFallsBack asserts a syntax
+// error in the predicate widens the field set so the caller falls back
+// to the full-decode path (signalled by a nil FieldFilter).
+func TestFieldFilterForPlan_MalformedExpressionFallsBack(t *testing.T) {
+	schema := testSchema()
+	cfg := setupTestFS(t, "src.pulse", schema, testRecords())
+	svc := New(cfg)
+
+	keep := svc.fieldFilterForPlan(schema, filterPlan{filterExpr: "not (valid expr"})
+	if keep != nil {
+		t.Fatal("keep filter non-nil; malformed expression should widen + return nil")
+	}
+}
+
+// TestFieldFilterForPlan_IncludesMemberSetField asserts plan.includeField
+// (the field tested for membership in a MemberSet predicate) joins the
+// projected set even though it isn't referenced in filterExpr.
+func TestFieldFilterForPlan_IncludesMemberSetField(t *testing.T) {
+	schema := testSchema()
+	cfg := setupTestFS(t, "src.pulse", schema, testRecords())
+	svc := New(cfg)
+
+	keep := svc.fieldFilterForPlan(schema, filterPlan{
+		set:          stubMemberSet{},
+		includeField: "id",
+		filterExpr:   "score > 25.0",
+	})
+	if keep == nil {
+		t.Fatal("keep filter nil; expected narrow set")
+	}
+	if !keep("id") {
+		t.Error("keep(id) = false, want true (member-set include field)")
+	}
+	if !keep("score") {
+		t.Error("keep(score) = false, want true (predicate ident)")
+	}
+}
+
+// TestFilterToFile_ProjectionPreservesOutput verifies that projecting
+// per-record decode to predicate-referenced fields does not change the
+// bytes written for surviving records. Same input + predicate must
+// yield byte-identical output regardless of projection — projection is
+// a decode-time optimisation, not a semantic change.
+func TestFilterToFile_ProjectionPreservesOutput(t *testing.T) {
+	schema := testSchema()
+	cfg := setupTestFS(t, "src.pulse", schema, testRecords())
+	svc := New(cfg)
+
+	// Run twice: once with the natural narrow predicate (projection
+	// kicks in), once with a synthetic predicate that the projection
+	// extractor must widen (referencing every field) — the surviving
+	// rows are the same so the outputs must match.
+	if _, err := svc.FilterToFile(context.Background(), "src.pulse", "narrow.pulse", "score > 25.0"); err != nil {
+		t.Fatalf("FilterToFile narrow: %v", err)
+	}
+	if _, err := svc.FilterToFile(context.Background(), "src.pulse", "wide.pulse", "score > 25.0 && id > 0"); err != nil {
+		t.Fatalf("FilterToFile wide: %v", err)
+	}
+
+	narrowBytes, err := afero.ReadFile(cfg.Fs(), "narrow.pulse")
+	if err != nil {
+		t.Fatalf("ReadFile narrow: %v", err)
+	}
+	wideBytes, err := afero.ReadFile(cfg.Fs(), "wide.pulse")
+	if err != nil {
+		t.Fatalf("ReadFile wide: %v", err)
+	}
+	if len(narrowBytes) != len(wideBytes) {
+		t.Fatalf("output sizes differ: narrow=%d wide=%d", len(narrowBytes), len(wideBytes))
+	}
+	for i := range narrowBytes {
+		if narrowBytes[i] != wideBytes[i] {
+			t.Fatalf("output diverges at byte %d: narrow=%#x wide=%#x", i, narrowBytes[i], wideBytes[i])
+		}
+	}
+}
+
+// TestFieldFilterForPlan_EmptyPlanReturnsNil guards the degenerate case
+// where no predicate is supplied. fieldFilterForPlan is only invoked
+// from paths that have already validated a predicate exists, but the
+// helper itself should not produce an empty-set FieldFilter that would
+// reject every field at decode.
+func TestFieldFilterForPlan_EmptyPlanReturnsNil(t *testing.T) {
+	schema := testSchema()
+	cfg := setupTestFS(t, "src.pulse", schema, testRecords())
+	svc := New(cfg)
+
+	if keep := svc.fieldFilterForPlan(schema, filterPlan{}); keep != nil {
+		t.Fatal("empty plan should return nil keep filter (fall through to full decode)")
+	}
+}
+
+// TestFieldFilterForPlan_PassesThroughEncodingFieldFilter ensures the
+// returned filter satisfies the encoding.FieldFilter type so it slots
+// into ReadRecordWithWideProjected without a wrapper.
+func TestFieldFilterForPlan_PassesThroughEncodingFieldFilter(t *testing.T) {
+	schema := testSchema()
+	cfg := setupTestFS(t, "src.pulse", schema, testRecords())
+	svc := New(cfg)
+
+	var keep encoding.FieldFilter = svc.fieldFilterForPlan(schema, filterPlan{filterExpr: "score > 0"})
+	if keep == nil {
+		t.Fatal("keep nil; expected non-nil for valid predicate")
+	}
+}
+
+// BenchmarkFilterToFileWideCohort mirrors BenchmarkCrosstabWideCohort —
+// 200-field schema (3 referenced + 197 padding), 10K rows, single-field
+// predicate. Quantifies the per-record map-write + float-conversion
+// savings on the streaming filter path.
+//
+// Measured on darwin/arm64 (M1 Max), 200 fields × 10K rows, predicate
+// `value > 5000`:
+//   - baseline (ReadRecordWithWide):           744 ms/op, 554 MB/op, 8.59M allocs/op
+//   - projected (ReadRecordWithWideProjected): 149 ms/op, 152 MB/op, 2.58M allocs/op
+//   ≈ 5× wall time, 3.6× memory, 3.3× allocations.
+//
+// Savings scale with the unreferenced-field count — at 628 fields (the
+// BERA visa_custom shape that motivated this PR) the unprojected path
+// was the difference between an interactive filter and a five-minute
+// CPU burn on a single-column predicate.
+//
+// To re-derive the baseline number, swap the
+// ReadRecordWithWideProjected call in streamFilterRecords back to
+// ReadRecordWithWide and rerun.
+//
+// Run with: go test ./service/ -bench BenchmarkFilterToFileWideCohort -benchmem -run=^$
+func BenchmarkFilterToFileWideCohort(b *testing.B) {
+	const pad = 197
+	const rows = 10000
+
+	schema := buildBenchWideSchema(pad)
+	recs := buildBenchWideRecords(rows, pad)
+
+	var buf bytes.Buffer
+	if err := encoding.WriteHeader(&buf); err != nil {
+		b.Fatalf("WriteHeader: %v", err)
+	}
+	if err := encoding.WriteSchema(&buf, schema); err != nil {
+		b.Fatalf("WriteSchema: %v", err)
+	}
+	for ri, rec := range recs {
+		for fi, field := range schema.Fields {
+			if err := encoding.WriteFieldValue(&buf, field.Type, rec[fi]); err != nil {
+				b.Fatalf("WriteFieldValue record[%d] field[%d]: %v", ri, fi, err)
+			}
+		}
+	}
+	cfg := fs.NewMemMap()
+	if err := afero.WriteFile(cfg.Fs(), "src.pulse", buf.Bytes(), 0644); err != nil {
+		b.Fatalf("WriteFile: %v", err)
+	}
+	svc := New(cfg)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := svc.FilterToFile(ctx, "src.pulse", "dst.pulse", "value > 5000"); err != nil {
+			b.Fatalf("FilterToFile: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `streamFilterRecords` now uses `ReadRecordWithWideProjected` with a `FieldFilter` built once per call from `processing.NeededFields`, so per-record map population is limited to the fields the predicate actually reads.
- Bytes for unreferenced fields are still consumed (file offsets stay aligned); the savings are map writes + float64 / decimal128 conversions, not raw I/O.
- Malformed expressions or extension hooks without introspection widen the set → nil `FieldFilter` → existing full-decode path. Behavior is byte-identical to the prior implementation in both branches.
- Single-file and shard-archive paths receive the same projection filter (computed once against the canonical schema, reused per shard).

## Why

A user filtering a 782 MB single-file `.pulse` (628-field BERA `visa_custom` cohort) with a one-column predicate (`male == 1`) saw the process burn 5+ minutes of CPU on warm-cache input. Profiling showed full-row decode dominating per-record cost: 627 of 628 columns were being decoded into maps and immediately discarded because the predicate touched only one column.

The pieces for projection (`NeededFields`, `FieldSet`, `ReadRecordWithWideProjected`) all shipped in v0.12.3 for the crosstab buffered path; this PR wires the same machinery into the streaming filter path.

## Benchmark

`BenchmarkFilterToFileWideCohort` — 200-field schema (3 referenced + 197 padding), 10K rows, predicate `value > 5000`. darwin/arm64 (M1 Max):

| Path | ns/op | B/op | allocs/op |
|---|---|---|---|
| Baseline (`ReadRecordWithWide`) | 743,868,812 | 553,991,016 | 8,591,874 |
| Projected (`ReadRecordWithWideProjected`) | 148,573,724 | 151,640,768 | 2,581,862 |
| **Speedup** | **5.0×** | **3.6×** | **3.3×** |

Savings scale with the unreferenced-field count. At 628 fields (visa_custom) a one-column predicate sees the dominant per-row cost drop into the projected portion.

## Test plan

- [x] `go test ./...` — full suite green.
- [x] `TestFieldFilterForPlan_NarrowsToExprIdents` — predicate expression idents land in the projected set.
- [x] `TestFieldFilterForPlan_MalformedExpressionFallsBack` — syntax error widens → nil filter (full-decode fallback).
- [x] `TestFieldFilterForPlan_IncludesMemberSetField` — `plan.includeField` joins the projected set.
- [x] `TestFieldFilterForPlan_EmptyPlanReturnsNil` — empty plan returns nil so the caller can branch cleanly.
- [x] `TestFilterToFile_ProjectionPreservesOutput` — narrow vs wide predicate over the same surviving rows produces byte-identical output.
- [x] All 27 existing `TestFilterToFile_*` cases (single-file, anchor, shard archive, member-set) — pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)