### PR TITLE
docs: drop stale E7-S15 facade-lift promise in Compose docs

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -843,11 +843,13 @@ func (s *Service) Compose(ctx context.Context, composed *types.ComposedRequest) 
 	// Empty / nil req.Overlays short-circuits with no allocation
 	// (byte-identical JSON vs pre-E7-S4 output).
 	//
-	// Facade rewire deferred to E7-S15: the layers + warnings are
-	// computed (so the hook surface is exercised end-to-end) but the
-	// facade still returns []*Response, so the values are discarded.
-	// E7-S15 lifts the return type to *ComposedResponse{Responses,
-	// Overlays} and persists both slots.
+	// Facade rewire still owed: the layers + warnings are computed (so
+	// the hook surface is exercised end-to-end) but the facade still
+	// returns []*Response, so the values are discarded here. The follow-up
+	// lifts the return type to *ComposedResponse{Responses, Overlays} and
+	// persists both slots — no story is currently scheduled. Originally
+	// promised to E7-S15 of result-overlay-system; that story shipped as a
+	// test-tier helper (composeOverlayCase) with zero production change.
 	if _, _, err := s.applyComposeOverlays(ctx, composed, requests, responses); err != nil {
 		return nil, err
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -1316,11 +1316,13 @@ type ComposedRequest struct {
 // ComposeOverlaySpec catalog has a typed response sibling to write
 // against during the E7 catalog rollout (E7-S4 through E7-S15 land the
 // per-kind handlers). The pulse.Pulse.Compose facade still returns
-// []*Response today — facade-level rewiring is intentionally deferred to
-// a downstream story so the type-layer contract (this file) can land
-// without rippling through service/, mcp/, and cli/api.go. Once the
-// facade lifts to *ComposedResponse the Overlays slot here is the slot
-// the runtime fills.
+// []*Response today — facade-level rewiring was intentionally deferred so
+// the type-layer contract (this file) could land without rippling through
+// service/, mcp/, and cli/api.go. Once the facade lifts to
+// *ComposedResponse the Overlays slot here is the slot the runtime fills.
+// No follow-up story is currently scheduled — the deferral was originally
+// pointed at E7-S15 of result-overlay-system, which shipped as a test-tier
+// helper only.
 //
 // Forward-compat: every ComposedResponse marshalled before any overlay
 // landed produces byte-identical JSON to the same shape with


### PR DESCRIPTION
## Summary

- Two comments in `service/service.go` and `types/types.go` promise that `Pulse.Compose` will be lifted to `*ComposedResponse` by `result-overlay-system/E7-S15`. That story actually shipped as a test-tier helper (`composeOverlayCase`) with zero production change — see commit `3e59f33`.
- The facade lift is still owed: today `service.applyComposeOverlays` computes the layers + warnings, then the values are discarded by the `Pulse.Compose` / `Pulse.ComposeParallel` / `pulse api compose` surface. No follow-up story is currently scheduled.
- Comment-only — no behavior change. `make lint`, `go vet ./...`, `go test ./service/ ./types/ ./descriptor/ ./examples/`, and the CLAUDE.md hygiene gates all clean on the worktree.

## Context

Caught while debugging why `examples/overlays/pairwise-z-matrix.json` returned no overlay layer end-to-end via `pulse api compose`. The example body is correct against the type-layer contract — but the layer never reaches the envelope because the facade still returns `[]*Response`.

Stale docs make it look like the lift is scheduled; it isn't. Truth-in-comments first; the actual facade lift is left for whichever effort picks it up.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` / `make lint`
- [x] `go test ./service/ ./types/ ./descriptor/ ./examples/`
- [x] Non-skippable gates: `TestClaudeMd*`, `TestUpdateDemand*`, `TestNoOrbit*`, `TestGoldensNot*`, `TestPredictNo*`, `TestDescriptorNo*`
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)