### PR TITLE
feat: OVERLAY_PAIRWISE_* — intra-matrix axis-pairwise significance overlays

### DIFF
--- a/descriptor/capabilities_overlay.go
+++ b/descriptor/capabilities_overlay.go
@@ -145,6 +145,24 @@ func OverlayCapabilities() []OverlayCapability {
 // rather than silently dropped — types.AllOverlayKinds() is the
 // authoritative iteration surface, and the per-kind switch below is
 // expected to grow in lock-step.
+// pairwiseDescription composes the shared OVERLAY_PAIRWISE_* manifest
+// blurb around the per-kind test sentence so the four entries stay
+// consistent on the catalog surface.
+func pairwiseDescription(test string) string {
+	return "Intra-matrix axis-pairwise " + test + ". " +
+		"ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row — " +
+		"the per-Request counterpart to the Compose-host OVERLAY_PROP_Z_PANEL (pairs across the host's own " +
+		"axis indices, not across slots). MATRIX payload: the PAIR axis carries one entry per evaluated (i, j) " +
+		"index pair (key = the 2-tuple of the compared legs' labels), the OPPOSITE axis echoes the host's other " +
+		"axis, and each cell holds the pair's two-sided p-value (absent when a leg is unreadable or the test " +
+		"degenerate). The Ref union is left empty (intra-matrix). Params (all optional): pair_along_dim restricts " +
+		"pairs to same-bucket comparisons; n_source selects the sample-size leg (cell n / margins / n_within / " +
+		"weight sum); n_within_depth pins the within-group denominator; p_source picks percentage vs proportion " +
+		"cell values. Reads Response.Components.Crosstab — a components-disabled host fires " +
+		"PULSE_OVERLAY_COMPONENTS_REQUIRED. Emits RAW p-values only; direction, thresholds, and min-n flags are " +
+		"the embedder's presentation concern. Buffered (inferential)."
+}
+
 func overlayCapabilityFor(kind types.OverlayKind) OverlayCapability {
 	switch kind {
 	case types.OverlayKindChiSqCol:
@@ -489,6 +507,38 @@ func overlayCapabilityFor(kind types.OverlayKind) OverlayCapability {
 				"emits PULSE_OVERLAY_EXPECTED_LOW per cell when the Cochran rule fires on the 2×2 (any " +
 				"expected < 1 OR ≥ 20% of expected counts < 5), flagging cells where the cheaper χ² " +
 				"approximation would be unreliable and Fisher's exact is structurally required.",
+		}
+	case types.OverlayKindPairwiseProbitT:
+		return OverlayCapability{
+			Kind:        types.OverlayKindPairwiseProbitT,
+			Shapes:      []types.OverlayShape{types.OverlayShapeMatrix},
+			Scopes:      []types.OverlayScope{types.OverlayScopeRow, types.OverlayScopeColumn},
+			RefKinds:    []string{},
+			Description: pairwiseDescription("probit t-test (Φ⁻¹ transform of each leg's proportion, Student-t tail on df = n_i + n_j - 2; reuses the Student-t survival helper backing TEST_T)"),
+		}
+	case types.OverlayKindPairwisePropZ:
+		return OverlayCapability{
+			Kind:        types.OverlayKindPairwisePropZ,
+			Shapes:      []types.OverlayShape{types.OverlayShapeMatrix},
+			Scopes:      []types.OverlayScope{types.OverlayScopeRow, types.OverlayScopeColumn},
+			RefKinds:    []string{},
+			Description: pairwiseDescription("pooled-SE two-proportion z-test (reuses the twoProportionZ helper backing OVERLAY_PROP_Z_CELL / TEST_PROP_Z, so p-values match byte-for-byte)"),
+		}
+	case types.OverlayKindPairwiseTwoMeansZ:
+		return OverlayCapability{
+			Kind:        types.OverlayKindPairwiseTwoMeansZ,
+			Shapes:      []types.OverlayShape{types.OverlayShapeMatrix},
+			Scopes:      []types.OverlayScope{types.OverlayScopeRow, types.OverlayScopeColumn},
+			RefKinds:    []string{},
+			Description: pairwiseDescription("two-means z-test on AGG_WELFORD cells (normal-CDF tail, no df adjustment; reads the {mean, variance, n} Welford triple from CellComponents). A non-Welford host fires PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE"),
+		}
+	case types.OverlayKindPairwiseWelchT:
+		return OverlayCapability{
+			Kind:        types.OverlayKindPairwiseWelchT,
+			Shapes:      []types.OverlayShape{types.OverlayShapeMatrix},
+			Scopes:      []types.OverlayScope{types.OverlayScopeRow, types.OverlayScopeColumn},
+			RefKinds:    []string{},
+			Description: pairwiseDescription("Welch–Satterthwaite t-test on AGG_WELFORD cells (Welch SE + Satterthwaite df, Student-t tail; reads the {mean, variance, n} Welford triple from CellComponents). A non-Welford host fires PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE"),
 		}
 	case types.OverlayKindFormula:
 		return OverlayCapability{

--- a/descriptor/overlay.go
+++ b/descriptor/overlay.go
@@ -44,6 +44,86 @@ var chiSqRowSupportedScopes = map[types.OverlayScope]bool{
 	types.OverlayScopeRow: true,
 }
 
+// pairwiseSupportedScopes are the axis-pairing scopes the OVERLAY_PAIRWISE_*
+// family accepts: ROW pairs row indices for each column, COLUMN pairs
+// column indices for each row.
+var pairwiseSupportedScopes = map[types.OverlayScope]bool{
+	types.OverlayScopeRow:    true,
+	types.OverlayScopeColumn: true,
+}
+
+// validateOverlayPairwise validates the shared contract for every
+// OVERLAY_PAIRWISE_* kind: implicit-margin (empty Ref), MATRIX host,
+// ROW / COLUMN scope, and well-formed Params (decodable, known n_source /
+// p_source modes, non-negative pair_along_dim / n_within_depth). The
+// per-cell components requirement (PULSE_OVERLAY_COMPONENTS_REQUIRED) and
+// the Welford-shape requirement are runtime conditions — they depend on
+// the materialised host, not the request shape, so the handler raises
+// them, not predict.
+func validateOverlayPairwise(env *Envelope, req *types.Request, spec *types.OverlaySpec, index int) {
+	// Ref must be empty — the pairwise test compares two slots of the
+	// host matrix inline; no external reference family applies.
+	if spec.Ref.Margin != nil ||
+		spec.Ref.Sibling != nil ||
+		spec.Ref.BaselineIndex != nil ||
+		spec.Ref.Population != nil ||
+		spec.Ref.Stage != nil ||
+		spec.Ref.Slot != nil {
+		env.AddError(string(errors.PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE),
+			"overlay "+string(spec.Kind)+" must leave Ref empty (intra-matrix pairwise: the test compares two slots of the host matrix along the scope axis)",
+			map[string]any{"index": index, "kind": string(spec.Kind)})
+		return
+	}
+
+	// Host must be MATRIX-shaped — the pair axis is a host crosstab axis.
+	if req == nil || req.Crosstab == nil {
+		env.AddError(string(errors.PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE),
+			"overlay "+string(spec.Kind)+" requires a MATRIX host (Request.Crosstab); none present",
+			map[string]any{"index": index, "kind": string(spec.Kind)})
+		return
+	}
+
+	// Scope must be ROW or COLUMN — it names the pair axis.
+	if !pairwiseSupportedScopes[spec.Scope] {
+		env.AddError(string(errors.PULSE_OVERLAY_SCOPE_UNSUPPORTED),
+			"overlay "+string(spec.Kind)+" does not support scope "+string(spec.Scope)+" (supports: row, column)",
+			map[string]any{"index": index, "kind": string(spec.Kind), "scope": string(spec.Scope)})
+		return
+	}
+
+	// Params must decode and name known modes / non-negative depths.
+	params, err := types.DecodePairwiseParams(spec.Params)
+	if err != nil {
+		env.AddError(string(errors.PULSE_OVERLAY_PARAM_MISSING),
+			"overlay "+string(spec.Kind)+" has malformed Params: "+err.Error(),
+			map[string]any{"index": index, "kind": string(spec.Kind)})
+		return
+	}
+	if !types.ValidPairwiseNSource(params.NSource) {
+		env.AddError(string(errors.PULSE_OVERLAY_PARAM_MISSING),
+			"overlay "+string(spec.Kind)+" has unknown n_source: "+params.NSource,
+			map[string]any{"index": index, "kind": string(spec.Kind), "n_source": params.NSource})
+		return
+	}
+	if !types.ValidPairwisePSource(params.PSource) {
+		env.AddError(string(errors.PULSE_OVERLAY_PARAM_MISSING),
+			"overlay "+string(spec.Kind)+" has unknown p_source: "+params.PSource,
+			map[string]any{"index": index, "kind": string(spec.Kind), "p_source": params.PSource})
+		return
+	}
+	if params.PairAlongDim != nil && *params.PairAlongDim < 0 {
+		env.AddError(string(errors.PULSE_OVERLAY_PARAM_MISSING),
+			"overlay "+string(spec.Kind)+" pair_along_dim must be >= 0",
+			map[string]any{"index": index, "kind": string(spec.Kind), "pair_along_dim": *params.PairAlongDim})
+		return
+	}
+	if params.NWithinDepth < 0 {
+		env.AddError(string(errors.PULSE_OVERLAY_PARAM_MISSING),
+			"overlay "+string(spec.Kind)+" n_within_depth must be >= 0",
+			map[string]any{"index": index, "kind": string(spec.Kind), "n_within_depth": params.NWithinDepth})
+	}
+}
+
 // chiSqColSupportedScopes is the supported scope set for
 // OVERLAY_CHISQ_COL. The per-column χ² goodness-of-fit test is a COLUMN-
 // scoped inferential overlay (mechanical column-axis twin of
@@ -835,6 +915,11 @@ func validateOverlaySpec(env *Envelope, req *types.Request, spec *types.OverlayS
 		validateOverlayDeltaVsSibling(env, req, spec, index)
 	case types.OverlayKindFisherExactCell:
 		validateOverlayFisherExactCell(env, req, spec, index)
+	case types.OverlayKindPairwiseProbitT,
+		types.OverlayKindPairwisePropZ,
+		types.OverlayKindPairwiseTwoMeansZ,
+		types.OverlayKindPairwiseWelchT:
+		validateOverlayPairwise(env, req, spec, index)
 	case types.OverlayKindFormula:
 		validateFormulaOverlay(env, req, spec, opts, index)
 	case types.OverlayKindIndexVsBaseline:

--- a/descriptor/predict_overlay_test.go
+++ b/descriptor/predict_overlay_test.go
@@ -86,6 +86,10 @@ func TestPredict_OverlaysApplied_AllE2Kinds(t *testing.T) {
 				Margin: &types.OverlayMarginRef{Axis: types.MarginAxisRow},
 			},
 		},
+		{Name: "pairwise_probit_t", Kind: types.OverlayKindPairwiseProbitT, Scope: types.OverlayScopeRow},
+		{Name: "pairwise_prop_z", Kind: types.OverlayKindPairwisePropZ, Scope: types.OverlayScopeRow},
+		{Name: "pairwise_two_means_z", Kind: types.OverlayKindPairwiseTwoMeansZ, Scope: types.OverlayScopeRow},
+		{Name: "pairwise_welch_t", Kind: types.OverlayKindPairwiseWelchT, Scope: types.OverlayScopeRow},
 	}
 
 	matrixHostKinds := map[types.OverlayKind]bool{}
@@ -504,6 +508,26 @@ func TestPredict_OverlayCost_E2KindsBufferedDefault(t *testing.T) {
 			Kind:  types.OverlayKindFisherExactCell,
 			Scope: types.OverlayScopeCell,
 		},
+		types.OverlayKindPairwiseProbitT: {
+			Name:  "pairwise_probit_t",
+			Kind:  types.OverlayKindPairwiseProbitT,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwisePropZ: {
+			Name:  "pairwise_prop_z",
+			Kind:  types.OverlayKindPairwisePropZ,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwiseTwoMeansZ: {
+			Name:  "pairwise_two_means_z",
+			Kind:  types.OverlayKindPairwiseTwoMeansZ,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwiseWelchT: {
+			Name:  "pairwise_welch_t",
+			Kind:  types.OverlayKindPairwiseWelchT,
+			Scope: types.OverlayScopeRow,
+		},
 		types.OverlayKindFormula: {
 			Name:   "formula",
 			Kind:   types.OverlayKindFormula,
@@ -698,6 +722,26 @@ func TestPredict_OverlaysApplied_AllKinds_DescriptorCoverage(t *testing.T) {
 			Name:  "fisher_exact_cell",
 			Kind:  types.OverlayKindFisherExactCell,
 			Scope: types.OverlayScopeCell,
+		},
+		types.OverlayKindPairwiseProbitT: {
+			Name:  "pairwise_probit_t",
+			Kind:  types.OverlayKindPairwiseProbitT,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwisePropZ: {
+			Name:  "pairwise_prop_z",
+			Kind:  types.OverlayKindPairwisePropZ,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwiseTwoMeansZ: {
+			Name:  "pairwise_two_means_z",
+			Kind:  types.OverlayKindPairwiseTwoMeansZ,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwiseWelchT: {
+			Name:  "pairwise_welch_t",
+			Kind:  types.OverlayKindPairwiseWelchT,
+			Scope: types.OverlayScopeRow,
 		},
 		// MATRIX-host descriptive — no Ref family (formula sources its
 		// per-shape namespace from the host payload).
@@ -1127,6 +1171,26 @@ func TestPredict_OverlayCost_AllKindsHaveMultiplier(t *testing.T) {
 			Name:  "fisher_exact_cell",
 			Kind:  types.OverlayKindFisherExactCell,
 			Scope: types.OverlayScopeCell,
+		},
+		types.OverlayKindPairwiseProbitT: {
+			Name:  "pairwise_probit_t",
+			Kind:  types.OverlayKindPairwiseProbitT,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwisePropZ: {
+			Name:  "pairwise_prop_z",
+			Kind:  types.OverlayKindPairwisePropZ,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwiseTwoMeansZ: {
+			Name:  "pairwise_two_means_z",
+			Kind:  types.OverlayKindPairwiseTwoMeansZ,
+			Scope: types.OverlayScopeRow,
+		},
+		types.OverlayKindPairwiseWelchT: {
+			Name:  "pairwise_welch_t",
+			Kind:  types.OverlayKindPairwiseWelchT,
+			Scope: types.OverlayScopeRow,
 		},
 		types.OverlayKindFormula: {
 			Name:   "formula",

--- a/descriptor/testdata/manifest.json
+++ b/descriptor/testdata/manifest.json
@@ -4807,7 +4807,7 @@
         ]
       }
     ],
-    "error_codes_count": 145,
+    "error_codes_count": 146,
     "error_domains": [
       "CLI",
       "DATA",
@@ -4905,6 +4905,7 @@
       "PULSE_LOOKUP_MISS",
       "PULSE_LOOKUP_TABLE_UNKNOWN",
       "PULSE_OVERLAY_CHAIN_STAGE_SHAPE_DIVERGENT",
+      "PULSE_OVERLAY_COMPONENTS_REQUIRED",
       "PULSE_OVERLAY_DICT_PREFIX_DRIFT",
       "PULSE_OVERLAY_EXPECTED_LOW",
       "PULSE_OVERLAY_EXPORT_CSV_UNSUPPORTED",
@@ -6354,6 +6355,22 @@
         "description": "Kolmogorov-Smirnov distance + p-value comparing host Facet NUMERIC distribution against the resolved population."
       },
       {
+        "name": "op-overlay-pairwise-probit-t",
+        "description": "Intra-matrix axis-pairwise probit t-test (Φ⁻¹ transform of each leg's proportion, Student-t tail)."
+      },
+      {
+        "name": "op-overlay-pairwise-prop-z",
+        "description": "Intra-matrix axis-pairwise pooled-SE two-proportion z-test (row-vs-row or col-vs-col within one crosstab)."
+      },
+      {
+        "name": "op-overlay-pairwise-two-means-z",
+        "description": "Intra-matrix axis-pairwise two-means z-test on AGG_WELFORD cells (normal-CDF tail, no df)."
+      },
+      {
+        "name": "op-overlay-pairwise-welch-t",
+        "description": "Intra-matrix axis-pairwise Welch–Satterthwaite t-test on AGG_WELFORD cells."
+      },
+      {
         "name": "op-overlay-panel-index-vs-ref",
         "description": "Compose-host multi-reference index — indexes every target slot against a shared reference; emits one layer per target."
       },
@@ -6794,7 +6811,7 @@
         "description": "Window slot semantics — partition / order / frame, what WIN_* operators share conceptually, streamability per window. Topical design; per-WIN detail lives in atomic op-win-* skills."
       }
     ],
-    "examples_count": 160,
+    "examples_count": 162,
     "example_categories": [
       "aggregations",
       "attributes",
@@ -7412,6 +7429,58 @@
         ],
         "buffered": true,
         "description": "Single scalar Kolmogorov-Smirnov distance D = sup_x |F_subset(x) - F_pop(x)| plus an asymptotic p-value comparing the host Facet subset NUMERIC distribution against the resolved population NUMERIC distribution. GROUP scope over a FACET (FacetSchema) host with SCALAR payload — the layer carries the KS statistic plus the asymptotic p-value via OverlaySummary{Statistic, PValue, Parameters{\"n_subset\", \"n_pop\"}}. Fourth and final FACET-host overlay in the catalog (siblings: OVERLAY_INDEX_VS_POP descriptive, OVERLAY_ZSCORE_VS_POP descriptive, OVERLAY_CHISQ_VS_POP inferential discrete-arm only). KS is the canonical NUMERIC-arm distributional-shift indicator — it pairs with CHISQ_VS_POP as the two inferential FACET-host kinds, partitioning the inferential FACET surface by host arm (CHISQ for categorical, KS for numeric). The viz developer renders the SCALAR statistic as a distributional-shift indicator near the facet header. Math: D = sup_x |F_subset(x) - F_pop(x)|; en = sqrt(n_subset * n_pop / (n_subset + n_pop)); p_value = kolmogorovSurvival((en + 0.12 + 0.11/en) * D) — the same Kolmogorov-survival helper backing TEST_KS (processing/test_stat.go), so the overlay and the row-test surface produce identical p-values for the same D + N. NUMERIC ARM ONLY: KS is undefined on categorical distributions (no continuous CDF to compare). A categorical host (no numeric payload) fires PULSE_OVERLAY_SCOPE_UNSUPPORTED at runtime; the per-kind validator rejects categorical hosts at predict time so the runtime arm is belt-and-braces. Distinct from CHISQ_VS_POP which is DISCRETE-arm only and rejects numeric hosts with PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE. Population-sample availability: the resolver exposes only summary state for numeric fields (Welford mean/stdev/count, optional percentile map, optional histogram) — raw population values were folded into Welford state and discarded. The handler picks the highest-precision reconstruction available: (1) HISTOGRAM PATH (preferred) when host AND population each surface a histogram with matching Min/Max/bucket count — aligns bucket edges and computes sup-CDF-difference over the bucket-fraction CDF on both sides; (2) PERCENTILE FALLBACK when both arms surface a percentile map but histograms are absent or mismatched — turns each percentile entry into a CDF sample point and computes sup-CDF-difference over the common percentile labels (lower precision than histograms but well-defined); (3) WELFORD-ONLY DEGENERATE when neither histograms nor percentiles are available — emits NaN + NaN with one PULSE_OVERLAY_REF_ZERO warning whose Details document which knobs were missing on the FacetRequest. KS precision is bounded by histogram bucket width (path 1) or percentile-label resolution (path 2) because the population view does not retain raw values; future work may lift the resolver to retain raw sorted population values when a KS overlay is requested, at which point the handler can call ksTwoSampleD on raw arms directly (additive change). INHERENTLY BUFFERED per PRD §2 Non-Goals (\"Streaming overlay path for inferential kinds\") — the empirical-CDF construction requires sorted values on both sides; an online folded shape would widen the streaming carrier beyond v1's single-state lag accumulator. Degenerate inputs: empty host (n_subset == 0) OR empty population (n_pop == 0) emits NaN + NaN with PULSE_OVERLAY_REF_ZERO; histogram arms with mismatched edges (different Min/Max/bucket count) fall through to the percentile fallback if available, else emit PULSE_OVERLAY_REF_ZERO carrying the mismatching shape Details. Ref.Population MUST be populated (the cohort name lives on Ref.Population.Cohort); any other ref-family pointer (Margin / Sibling / BaselineIndex / Prior / RollingMean / YoY / Stage / Slot) fires PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE at predict time. Level / Within MUST be zero (population comparison is a single-statistic lookup, not an axis prefix); non-zero values fire PULSE_OVERLAY_LEVEL_OUT_OF_RANGE mirroring the implicit-ref family. Scope must be GROUP. Renderer-facing shape: viz developer reads OverlayPayload.Scalar for the KS distance D and OverlaySummary for the (statistic, p-value) pair — large D and small p-value flag \"the subset distribution shape diverges from the population\". The layer-level Baseline stays unset (inferential overlays do not surface a ratio centerpoint; mirrors CHISQ_VS_POP)."
+      },
+      {
+        "kind": "OVERLAY_PAIRWISE_PROBIT_T",
+        "shapes": [
+          "matrix"
+        ],
+        "scopes": [
+          "column",
+          "row"
+        ],
+        "ref_kinds": [],
+        "buffered": true,
+        "description": "Intra-matrix axis-pairwise probit t-test (Φ⁻¹ transform of each leg's proportion, Student-t tail on df = n_i + n_j - 2; reuses the Student-t survival helper backing TEST_T). ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row — the per-Request counterpart to the Compose-host OVERLAY_PROP_Z_PANEL (pairs across the host's own axis indices, not across slots). MATRIX payload: the PAIR axis carries one entry per evaluated (i, j) index pair (key = the 2-tuple of the compared legs' labels), the OPPOSITE axis echoes the host's other axis, and each cell holds the pair's two-sided p-value (absent when a leg is unreadable or the test degenerate). The Ref union is left empty (intra-matrix). Params (all optional): pair_along_dim restricts pairs to same-bucket comparisons; n_source selects the sample-size leg (cell n / margins / n_within / weight sum); n_within_depth pins the within-group denominator; p_source picks percentage vs proportion cell values. Reads Response.Components.Crosstab — a components-disabled host fires PULSE_OVERLAY_COMPONENTS_REQUIRED. Emits RAW p-values only; direction, thresholds, and min-n flags are the embedder's presentation concern. Buffered (inferential)."
+      },
+      {
+        "kind": "OVERLAY_PAIRWISE_PROP_Z",
+        "shapes": [
+          "matrix"
+        ],
+        "scopes": [
+          "column",
+          "row"
+        ],
+        "ref_kinds": [],
+        "buffered": true,
+        "description": "Intra-matrix axis-pairwise pooled-SE two-proportion z-test (reuses the twoProportionZ helper backing OVERLAY_PROP_Z_CELL / TEST_PROP_Z, so p-values match byte-for-byte). ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row — the per-Request counterpart to the Compose-host OVERLAY_PROP_Z_PANEL (pairs across the host's own axis indices, not across slots). MATRIX payload: the PAIR axis carries one entry per evaluated (i, j) index pair (key = the 2-tuple of the compared legs' labels), the OPPOSITE axis echoes the host's other axis, and each cell holds the pair's two-sided p-value (absent when a leg is unreadable or the test degenerate). The Ref union is left empty (intra-matrix). Params (all optional): pair_along_dim restricts pairs to same-bucket comparisons; n_source selects the sample-size leg (cell n / margins / n_within / weight sum); n_within_depth pins the within-group denominator; p_source picks percentage vs proportion cell values. Reads Response.Components.Crosstab — a components-disabled host fires PULSE_OVERLAY_COMPONENTS_REQUIRED. Emits RAW p-values only; direction, thresholds, and min-n flags are the embedder's presentation concern. Buffered (inferential)."
+      },
+      {
+        "kind": "OVERLAY_PAIRWISE_TWO_MEANS_Z",
+        "shapes": [
+          "matrix"
+        ],
+        "scopes": [
+          "column",
+          "row"
+        ],
+        "ref_kinds": [],
+        "buffered": true,
+        "description": "Intra-matrix axis-pairwise two-means z-test on AGG_WELFORD cells (normal-CDF tail, no df adjustment; reads the {mean, variance, n} Welford triple from CellComponents). A non-Welford host fires PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE. ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row — the per-Request counterpart to the Compose-host OVERLAY_PROP_Z_PANEL (pairs across the host's own axis indices, not across slots). MATRIX payload: the PAIR axis carries one entry per evaluated (i, j) index pair (key = the 2-tuple of the compared legs' labels), the OPPOSITE axis echoes the host's other axis, and each cell holds the pair's two-sided p-value (absent when a leg is unreadable or the test degenerate). The Ref union is left empty (intra-matrix). Params (all optional): pair_along_dim restricts pairs to same-bucket comparisons; n_source selects the sample-size leg (cell n / margins / n_within / weight sum); n_within_depth pins the within-group denominator; p_source picks percentage vs proportion cell values. Reads Response.Components.Crosstab — a components-disabled host fires PULSE_OVERLAY_COMPONENTS_REQUIRED. Emits RAW p-values only; direction, thresholds, and min-n flags are the embedder's presentation concern. Buffered (inferential)."
+      },
+      {
+        "kind": "OVERLAY_PAIRWISE_WELCH_T",
+        "shapes": [
+          "matrix"
+        ],
+        "scopes": [
+          "column",
+          "row"
+        ],
+        "ref_kinds": [],
+        "buffered": true,
+        "description": "Intra-matrix axis-pairwise Welch–Satterthwaite t-test on AGG_WELFORD cells (Welch SE + Satterthwaite df, Student-t tail; reads the {mean, variance, n} Welford triple from CellComponents). A non-Welford host fires PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE. ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row — the per-Request counterpart to the Compose-host OVERLAY_PROP_Z_PANEL (pairs across the host's own axis indices, not across slots). MATRIX payload: the PAIR axis carries one entry per evaluated (i, j) index pair (key = the 2-tuple of the compared legs' labels), the OPPOSITE axis echoes the host's other axis, and each cell holds the pair's two-sided p-value (absent when a leg is unreadable or the test degenerate). The Ref union is left empty (intra-matrix). Params (all optional): pair_along_dim restricts pairs to same-bucket comparisons; n_source selects the sample-size leg (cell n / margins / n_within / weight sum); n_within_depth pins the within-group denominator; p_source picks percentage vs proportion cell values. Reads Response.Components.Crosstab — a components-disabled host fires PULSE_OVERLAY_COMPONENTS_REQUIRED. Emits RAW p-values only; direction, thresholds, and min-n flags are the embedder's presentation concern. Buffered (inferential)."
       },
       {
         "kind": "OVERLAY_PANEL_INDEX_VS_REF",
@@ -8917,4 +8986,4 @@
   "errors": [],
   "warnings": []
 }
-// golden-hash: d5012369448e3115b09ffae99aaadc24fadeb84b0129b2cd486bc17f205e7ab5
+// golden-hash: bbb0c2ebe3dfcdbc1008a2acc6c7febe9c0b217ff13bbf21ddc49505de1a5d8c

--- a/descriptor/testdata/payload-schema.json
+++ b/descriptor/testdata/payload-schema.json
@@ -1337,6 +1337,10 @@
         "OVERLAY_INDEX_VS_STAGE",
         "OVERLAY_INDEX_VS_TOTAL",
         "OVERLAY_KS_VS_POP",
+        "OVERLAY_PAIRWISE_PROBIT_T",
+        "OVERLAY_PAIRWISE_PROP_Z",
+        "OVERLAY_PAIRWISE_TWO_MEANS_Z",
+        "OVERLAY_PAIRWISE_WELCH_T",
         "OVERLAY_PANEL_INDEX_VS_REF",
         "OVERLAY_PROP_Z_CELL",
         "OVERLAY_PROP_Z_PANEL",
@@ -2471,4 +2475,4 @@
   ],
   "title": "Pulse payload contract"
 }
-// golden-hash: 68cb49b2bad697d46046ffe22bec016e5748e52ff490fcdabec562b57c6a22ed
+// golden-hash: d19c448d71bebb613474a0a068359491ad8aa3889a9c59f00c4427c0a60b2a36

--- a/errors/codes.go
+++ b/errors/codes.go
@@ -697,6 +697,16 @@ const (
 	// non-MATRIX host (Request.Crosstab is nil).
 	PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE Code = "PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE"
 
+	// PULSE_OVERLAY_COMPONENTS_REQUIRED indicates an overlay kind that
+	// reads Response.Components.Crosstab (per-cell n / weight sums /
+	// Welford triples / margin counts) ran against a host built with
+	// components disabled. The OVERLAY_PAIRWISE_* family raises this at
+	// handler entry: without the components block there is no sample-size
+	// leg to divide by. Re-run with components enabled (clear
+	// DisableComponents / the per-request override) so the host carries
+	// the counters the pairwise test needs.
+	PULSE_OVERLAY_COMPONENTS_REQUIRED Code = "PULSE_OVERLAY_COMPONENTS_REQUIRED"
+
 	// PULSE_OVERLAY_SCOPE_UNSUPPORTED indicates an OverlaySpec named a
 	// scope that is not yet supported for the chosen Kind.
 	// OVERLAY_INDEX_VS_MARGIN currently supports Scope=CELL only.
@@ -1152,6 +1162,7 @@ var allCodes = []Code{
 	PULSE_REQUEST_UNKNOWN_FIELD,
 	PULSE_OVERLAY_KIND_UNKNOWN,
 	PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE,
+	PULSE_OVERLAY_COMPONENTS_REQUIRED,
 	PULSE_OVERLAY_SCOPE_UNSUPPORTED,
 	PULSE_OVERLAY_REF_ZERO,
 	PULSE_OVERLAY_EXPECTED_LOW,

--- a/errors/fixup_metadata.go
+++ b/errors/fixup_metadata.go
@@ -1228,6 +1228,17 @@ var codeMetadata = map[Code]Metadata{
 			},
 		},
 	},
+	PULSE_OVERLAY_COMPONENTS_REQUIRED: {
+		Message: "An overlay kind that reads per-cell components (n / weight sums / Welford triples / margin counts) ran against a host built with components disabled. The OVERLAY_PAIRWISE_* family needs the components block to resolve each pair leg's sample size.",
+		Fixups: []Fixup{
+			{
+				Action:   FixupReplaceField,
+				Path:     []string{"DisableComponents"},
+				Hint:     "Re-run with components enabled: clear Options.DisableComponents (and any per-request disable_components override) so Response.Components.Crosstab carries the cell n / Welford triples the pairwise overlay divides by.",
+				Examples: []any{false},
+			},
+		},
+	},
 	PULSE_OVERLAY_SCOPE_UNSUPPORTED: {
 		Message: "An OverlaySpec named a Scope that is not supported for the chosen Kind. OVERLAY_INDEX_VS_MARGIN currently supports Scope=cell only; row / column / total / matrix / group land in later releases alongside the matching payload shapes.",
 		Fixups: []Fixup{

--- a/examples/overlays/40_crosstab_pairwise_prop_z.json
+++ b/examples/overlays/40_crosstab_pairwise_prop_z.json
@@ -1,0 +1,67 @@
+{
+  "_meta": {
+    "category": "overlays",
+    "description": "Crosstab count of region x segment decorated with the intra-matrix axis-pairwise proportion overlays OVERLAY_PAIRWISE_PROP_Z and OVERLAY_PAIRWISE_PROBIT_T at ROW scope: each tests one region against another within each segment column (brand-vs-brand-style pairing along the host's own row axis, not across Compose slots). The PAIR axis of the emitted MATRIX payload carries one entry per evaluated (i, j) row pair keyed by the two region labels; each cell holds the pair's two-sided p-value at that segment. p_source picks how the cell value becomes a proportion and n_source selects the sample-size leg (here the row margin count). The family emits RAW p-values only; direction, significance thresholds, and min-n flags are the embedder's presentation concern. Reads Response.Components.Crosstab for the per-leg n.",
+    "name": "crosstab-pairwise-prop-z",
+    "operators": [
+      "AGG_COUNT",
+      "GROUP_CATEGORY"
+    ],
+    "tags": [
+      "cross-tabulation",
+      "cohort-analysis",
+      "overlay",
+      "hypothesis-test",
+      "proportion-analysis",
+      "two-sample"
+    ]
+  },
+  "cohort": {
+    "filename": "experiment.pulse",
+    "data_dir": ".data"
+  },
+  "crosstab": {
+    "rows": [
+      {
+        "type": "GROUP_CATEGORY",
+        "field": "region"
+      }
+    ],
+    "columns": [
+      {
+        "type": "GROUP_CATEGORY",
+        "field": "segment"
+      }
+    ],
+    "cell": {
+      "type": "AGG_COUNT",
+      "field": "id",
+      "label": "n"
+    },
+    "margins": {
+      "rows": true,
+      "columns": true,
+      "grand": true
+    }
+  },
+  "overlays": [
+    {
+      "name": "region_prop_z",
+      "kind": "OVERLAY_PAIRWISE_PROP_Z",
+      "scope": "row",
+      "params": {
+        "p_source": "cell_value",
+        "n_source": "row_margin_n"
+      }
+    },
+    {
+      "name": "region_probit_t",
+      "kind": "OVERLAY_PAIRWISE_PROBIT_T",
+      "scope": "row",
+      "params": {
+        "p_source": "cell_value",
+        "n_source": "row_margin_n"
+      }
+    }
+  ]
+}

--- a/examples/overlays/41_crosstab_pairwise_means.json
+++ b/examples/overlays/41_crosstab_pairwise_means.json
@@ -1,0 +1,56 @@
+{
+  "_meta": {
+    "category": "overlays",
+    "description": "Crosstab of region x segment with an AGG_WELFORD cell (the streaming {mean, variance, n} triple on revenue) decorated with the intra-matrix axis-pairwise mean overlays OVERLAY_PAIRWISE_WELCH_T and OVERLAY_PAIRWISE_TWO_MEANS_Z at ROW scope: each tests one region's mean revenue against another within each segment column, reading the Welford triple from Response.Components.Crosstab.CellComponents. WELCH_T uses the Welch standard error plus Satterthwaite degrees of freedom and a Student-t tail (reuses studentTTwoSidedP backing TEST_T / TEST_WELCH); TWO_MEANS_Z uses the same standard error with a normal-CDF tail and no df adjustment. The PAIR axis of the emitted MATRIX payload carries one entry per region pair keyed by the two region labels; each cell holds the pair's two-sided p-value at that segment. A non-Welford host fires PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE. The family emits RAW p-values only; direction and thresholds are the embedder's presentation concern.",
+    "name": "crosstab-pairwise-means",
+    "operators": [
+      "AGG_WELFORD",
+      "GROUP_CATEGORY"
+    ],
+    "tags": [
+      "cross-tabulation",
+      "cohort-analysis",
+      "overlay",
+      "hypothesis-test",
+      "two-sample",
+      "parametric",
+      "welch",
+      "welford-triple"
+    ]
+  },
+  "cohort": {
+    "filename": "experiment.pulse",
+    "data_dir": ".data"
+  },
+  "crosstab": {
+    "rows": [
+      {
+        "type": "GROUP_CATEGORY",
+        "field": "region"
+      }
+    ],
+    "columns": [
+      {
+        "type": "GROUP_CATEGORY",
+        "field": "segment"
+      }
+    ],
+    "cell": {
+      "type": "AGG_WELFORD",
+      "field": "revenue",
+      "label": "revenue_triple"
+    }
+  },
+  "overlays": [
+    {
+      "name": "region_welch_t",
+      "kind": "OVERLAY_PAIRWISE_WELCH_T",
+      "scope": "row"
+    },
+    {
+      "name": "region_two_means_z",
+      "kind": "OVERLAY_PAIRWISE_TWO_MEANS_Z",
+      "scope": "row"
+    }
+  ]
+}

--- a/processing/crosstab.go
+++ b/processing/crosstab.go
@@ -900,7 +900,17 @@ func applyOverlaysToResponse(req *types.Request, resp *types.Response, exts *Ext
 		// quietly skip so we never panic on a nil host view.
 		return nil
 	}
-	host := NewCrosstabHostView(resp.Crosstab.Matrix)
+	// Thread the per-cell components block (universal-floor counters,
+	// Welford triples, margin counts) into the host view so component-
+	// reading overlays (the OVERLAY_PAIRWISE_* family) can resolve sample
+	// sizes and Welford moments. Nil when components were disabled — those
+	// handlers surface PULSE_OVERLAY_COMPONENTS_REQUIRED rather than
+	// silently dividing by a zero n. Payload-only overlays ignore it.
+	var crosstabComps *types.CrosstabComponents
+	if resp.Components != nil {
+		crosstabComps = resp.Components.Crosstab
+	}
+	host := NewCrosstabHostViewWithComponents(resp.Crosstab.Matrix, crosstabComps)
 	// When the Processor carries a live ExtensionRegistry the
 	// FORMULA dispatch arm of ApplyOverlaysWithExtensions threads the
 	// registry's ExprFunctions into the compile-time `[]expr.Option`

--- a/processing/overlay.go
+++ b/processing/overlay.go
@@ -65,13 +65,34 @@ import (
 type CrosstabHostView struct {
 	// payload is the underlying matrix the host produced. Read-only.
 	payload *types.MatrixPayload
+
+	// components is the matching Response.Components.Crosstab block, when
+	// the host produced one. Nil when components were disabled
+	// (Options.DisableComponents / per-request override) or the host path
+	// did not emit them. Overlays that need universal-floor counters
+	// (cell n, weight sums), Welford triples, or margin counts read them
+	// through the CrosstabComponents accessors; payload-only overlays
+	// (share, index, χ², Fisher) ignore this field. Read-only.
+	components *types.CrosstabComponents
 }
 
 // NewCrosstabHostView wraps a MatrixPayload as a host view. payload
 // must be non-nil; the view does not copy the payload, callers must
-// not mutate it during overlay execution.
+// not mutate it during overlay execution. The components block is left
+// nil — use NewCrosstabHostViewWithComponents for overlays that read
+// per-cell counters / Welford triples.
 func NewCrosstabHostView(payload *types.MatrixPayload) *CrosstabHostView {
 	return &CrosstabHostView{payload: payload}
+}
+
+// NewCrosstabHostViewWithComponents wraps a MatrixPayload together with
+// its Response.Components.Crosstab block. comps may be nil (components
+// disabled); component-reading handlers surface
+// PULSE_OVERLAY_COMPONENTS_REQUIRED in that case rather than dividing by
+// a zero sample size. The view does not copy either pointer; callers
+// must not mutate them during overlay execution.
+func NewCrosstabHostViewWithComponents(payload *types.MatrixPayload, comps *types.CrosstabComponents) *CrosstabHostView {
+	return &CrosstabHostView{payload: payload, components: comps}
 }
 
 // Payload returns the underlying MatrixPayload pointer so handlers
@@ -254,17 +275,21 @@ type overlayHandler func(spec *types.OverlaySpec, host *CrosstabHostView) (types
 // (types/overlay.go + types/overlay_streamability.go), add the runtime
 // handler in this package, and add the dispatch entry here.
 var overlayHandlers = map[types.OverlayKind]overlayHandler{
-	types.OverlayKindChiSqCol:        applyChiSqCol,
-	types.OverlayKindChiSqMatrix:     applyChiSqMatrix,
-	types.OverlayKindChiSqRow:        applyChiSqRow,
-	types.OverlayKindDeltaVsMargin:   applyDeltaVsMargin,
-	types.OverlayKindFisherExactCell: applyFisherExactCell,
-	types.OverlayKindFormula:         applyFormula,
-	types.OverlayKindIndexVsMargin:   applyIndexVsMargin,
-	types.OverlayKindShareOfCol:      applyShareOfCol,
-	types.OverlayKindShareOfRow:      applyShareOfRow,
-	types.OverlayKindShareOfTotal:    applyShareOfTotal,
-	types.OverlayKindZScoreVsMargin:  applyZScoreVsMargin,
+	types.OverlayKindChiSqCol:          applyChiSqCol,
+	types.OverlayKindChiSqMatrix:       applyChiSqMatrix,
+	types.OverlayKindChiSqRow:          applyChiSqRow,
+	types.OverlayKindDeltaVsMargin:     applyDeltaVsMargin,
+	types.OverlayKindFisherExactCell:   applyFisherExactCell,
+	types.OverlayKindFormula:           applyFormula,
+	types.OverlayKindIndexVsMargin:     applyIndexVsMargin,
+	types.OverlayKindPairwiseProbitT:   applyPairwiseProbitT,
+	types.OverlayKindPairwisePropZ:     applyPairwisePropZ,
+	types.OverlayKindPairwiseTwoMeansZ: applyPairwiseTwoMeansZ,
+	types.OverlayKindPairwiseWelchT:    applyPairwiseWelchT,
+	types.OverlayKindShareOfCol:        applyShareOfCol,
+	types.OverlayKindShareOfRow:        applyShareOfRow,
+	types.OverlayKindShareOfTotal:      applyShareOfTotal,
+	types.OverlayKindZScoreVsMargin:    applyZScoreVsMargin,
 }
 
 // ApplyOverlays executes every spec in specs against the host view

--- a/processing/overlay_pairwise.go
+++ b/processing/overlay_pairwise.go
@@ -1,0 +1,601 @@
+package processing
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/frankbardon/pulse/errors"
+	"github.com/frankbardon/pulse/types"
+)
+
+// This file implements the OVERLAY_PAIRWISE_* family: intra-matrix
+// axis-pairwise significance overlays that test one host-matrix slot
+// against another ALONG a single axis of the same materialised crosstab
+// (row-vs-row for each column under ROW scope; column-vs-column for each
+// row under COLUMN scope). It is the per-Request counterpart to the
+// Compose-host OVERLAY_PROP_Z_PANEL — where the panel pairs across slots,
+// this family pairs across the host's own axis indices.
+//
+// Output: a MATRIX payload whose PAIR axis carries one entry per evaluated
+// (i, j) index pair (key = the 2-tuple of the compared legs' display
+// labels) and whose OPPOSITE axis echoes the host's other axis. Each cell
+// holds the pair's two-sided p-value at that opposite-axis position, or is
+// absent when a leg was unreadable or the test degenerate. The family
+// emits RAW p-values only; direction, thresholds, and min-n flags are the
+// embedder's presentation concern.
+//
+// All four kinds reuse the shared harness below; only the per-pair Compute
+// kernel and the input shape (proportion + n vs Welford triple) differ.
+
+// applyPairwisePropZ / ...ProbitT / ...WelchT / ...TwoMeansZ are the
+// dispatch entry points registered in overlayHandlers. Each pins the kind
+// and delegates to the shared runner.
+func applyPairwisePropZ(spec *types.OverlaySpec, host *CrosstabHostView) (types.OverlayLayer, []types.OverlayWarning, error) {
+	return runPairwiseOverlay(spec, host, pairwisePropZKernel, false)
+}
+
+func applyPairwiseProbitT(spec *types.OverlaySpec, host *CrosstabHostView) (types.OverlayLayer, []types.OverlayWarning, error) {
+	return runPairwiseOverlay(spec, host, pairwiseProbitTKernel, false)
+}
+
+func applyPairwiseWelchT(spec *types.OverlaySpec, host *CrosstabHostView) (types.OverlayLayer, []types.OverlayWarning, error) {
+	return runPairwiseOverlay(spec, host, pairwiseWelchTKernel, true)
+}
+
+func applyPairwiseTwoMeansZ(spec *types.OverlaySpec, host *CrosstabHostView) (types.OverlayLayer, []types.OverlayWarning, error) {
+	return runPairwiseOverlay(spec, host, pairwiseTwoMeansZKernel, true)
+}
+
+// pwInputs carries one pair's two legs. Proportion kinds populate p1/p2 +
+// n1/n2 (m/v are NaN); Welford kinds populate m/v/n (p is NaN).
+type pwInputs struct {
+	p1, p2 float64
+	m1, m2 float64
+	v1, v2 float64
+	n1, n2 int
+}
+
+// pwKernel computes one pair's two-sided p-value. ok=false with a reason
+// string signals a degenerate / unreadable pair that stays absent on the
+// payload and folds into one aggregated warning per reason.
+type pwKernel func(in pwInputs) (pValue float64, reason string, ok bool)
+
+// pairwisePair is one evaluated (i, j) index pair along the pair axis,
+// carrying each leg's display label for the output key.
+type pairwisePair struct {
+	i, j           int
+	labelI, labelJ string
+}
+
+func runPairwiseOverlay(spec *types.OverlaySpec, host *CrosstabHostView, kernel pwKernel, welford bool) (types.OverlayLayer, []types.OverlayWarning, error) {
+	params, err := types.DecodePairwiseParams(spec.Params)
+	if err != nil {
+		return types.OverlayLayer{}, nil, errors.NewCodedErrorWithDetails(
+			errors.PROCESSING_INTERNAL,
+			"overlay "+string(spec.Kind)+" has malformed Params: "+err.Error(),
+			map[string]any{"code": string(errors.PULSE_OVERLAY_PARAM_MISSING), "kind": string(spec.Kind)})
+	}
+
+	// Components gate — every kind reads per-cell counters / Welford
+	// triples / margin counts. Without them there is no sample-size leg.
+	if !host.HasComponents() {
+		return types.OverlayLayer{}, nil, errors.NewCodedErrorWithDetails(
+			errors.PROCESSING_INTERNAL,
+			"overlay "+string(spec.Kind)+" requires Response.Components.Crosstab; the host was built with components disabled",
+			map[string]any{"code": string(errors.PULSE_OVERLAY_COMPONENTS_REQUIRED), "kind": string(spec.Kind)})
+	}
+	// Welford-input kinds need {mean, variance, n} on at least one cell.
+	if welford && !host.HasWelfordCells() {
+		return types.OverlayLayer{}, nil, errors.NewCodedErrorWithDetails(
+			errors.PROCESSING_INTERNAL,
+			"overlay "+string(spec.Kind)+" requires AGG_WELFORD cells (Welford triple on CellComponents); host matrix has none",
+			map[string]any{"code": string(errors.PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE), "kind": string(spec.Kind)})
+	}
+
+	rowScope := spec.Scope == types.OverlayScopeRow
+
+	pairs, perr := buildPairwisePairs(spec, host, params, rowScope)
+	if perr != nil {
+		return types.OverlayLayer{}, nil, perr
+	}
+
+	// Opposite-axis extent: ROW scope pairs rows, so the opposite axis is
+	// columns; COLUMN scope pairs columns, opposite axis is rows.
+	oppCount := host.ColumnCount()
+	if !rowScope {
+		oppCount = host.RowCount()
+	}
+
+	tally := newPairwiseTally()
+
+	// pvals[pairPos][opp] — laid out pair-major; transposed into the
+	// output MatrixPayload below per scope.
+	pvals := make([][]types.MatrixCell, len(pairs))
+	for p := range pairs {
+		pvals[p] = make([]types.MatrixCell, oppCount)
+		for o := 0; o < oppCount; o++ {
+			r1, c1 := pairwiseLegCoord(rowScope, pairs[p].i, o)
+			r2, c2 := pairwiseLegCoord(rowScope, pairs[p].j, o)
+			in, ok := extractPairInputs(host, params, welford, rowScope, r1, c1, r2, c2)
+			if !ok {
+				tally.add("ORBIT_STATS_SKIP_EXTRACT_FAILED", o)
+				continue
+			}
+			pv, reason, ok := kernel(in)
+			if !ok {
+				tally.add(reason, o)
+				continue
+			}
+			pvals[p][o] = types.MatrixCell{Value: pv, Present: true}
+		}
+	}
+
+	layer := buildPairwiseLayer(spec, host, pairs, pvals, rowScope)
+	// Attach the per-reason skip diagnostics to the layer's own carrier
+	// (in addition to the returned slice the orchestrator promotes to
+	// Response.Warnings) so a per-Request consumer that reads layers
+	// directly — e.g. Orbit's stat-test marker pass — can associate each
+	// skip with its originating spec.
+	warns := tally.warnings(spec)
+	layer.Warnings = warns
+	return layer, warns, nil
+}
+
+// buildPairwisePairs enumerates (i, j) index pairs along the pair axis.
+// PairAlongDim=nil yields the full upper triangular; a non-nil value
+// buckets indexes by their axis-key tuple minus that dim and pairs only
+// within each bucket. Out-of-range pair_along_dim / n_within_depth against
+// the actual axis depth fail with PULSE_OVERLAY_PARAM_MISSING.
+func buildPairwisePairs(spec *types.OverlaySpec, host *CrosstabHostView, params types.PairwiseOverlayParams, rowScope bool) ([]pairwisePair, error) {
+	count := host.ColumnCount()
+	depth := host.ColumnAxisDepth()
+	keyAt := host.columnKey
+	labelAt := func(i int) string { return stringifyOverlayAxisKey(host.columnKey(i)) }
+	if rowScope {
+		count = host.RowCount()
+		depth = host.RowAxisDepth()
+		keyAt = host.rowKey
+		labelAt = func(i int) string { return stringifyOverlayAxisKey(host.rowKey(i)) }
+	}
+
+	if params.NSource == types.PairwiseNSourceNWithin && params.NWithinDepth >= depth {
+		return nil, errors.NewCodedErrorWithDetails(errors.PROCESSING_INTERNAL,
+			"overlay "+string(spec.Kind)+" n_within_depth exceeds pair-axis dim count",
+			map[string]any{"code": string(errors.PULSE_OVERLAY_PARAM_MISSING), "kind": string(spec.Kind),
+				"n_within_depth": params.NWithinDepth, "dim_count": depth})
+	}
+
+	indexes := make([]int, count)
+	for i := range indexes {
+		indexes[i] = i
+	}
+
+	if params.PairAlongDim == nil {
+		out := make([]pairwisePair, 0, count*(count-1)/2)
+		for a := 0; a < len(indexes); a++ {
+			for b := a + 1; b < len(indexes); b++ {
+				i, j := indexes[a], indexes[b]
+				out = append(out, pairwisePair{i: i, j: j, labelI: labelAt(i), labelJ: labelAt(j)})
+			}
+		}
+		return out, nil
+	}
+
+	dim := *params.PairAlongDim
+	if dim >= depth {
+		return nil, errors.NewCodedErrorWithDetails(errors.PROCESSING_INTERNAL,
+			"overlay "+string(spec.Kind)+" pair_along_dim out of range for pair-axis dim count",
+			map[string]any{"code": string(errors.PULSE_OVERLAY_PARAM_MISSING), "kind": string(spec.Kind),
+				"pair_along_dim": dim, "dim_count": depth})
+	}
+
+	// Bucket by tuple-minus-dim, preserving insertion order so pairs come
+	// out in axis-natural order (mirrors the nil-PairAlongDim double loop).
+	type bucket struct {
+		key     types.AxisKey
+		indexes []int
+	}
+	buckets := make([]*bucket, 0, count)
+	for _, i := range indexes {
+		ki := keyAt(i)
+		if ki == nil || dim >= len(ki) {
+			continue
+		}
+		matched := false
+		for _, b := range buckets {
+			if axisKeyEqualExceptDim(b.key, ki, dim) {
+				b.indexes = append(b.indexes, i)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			buckets = append(buckets, &bucket{key: ki, indexes: []int{i}})
+		}
+	}
+
+	out := make([]pairwisePair, 0)
+	for _, b := range buckets {
+		for a := 0; a < len(b.indexes); a++ {
+			for c := a + 1; c < len(b.indexes); c++ {
+				i, j := b.indexes[a], b.indexes[c]
+				out = append(out, pairwisePair{i: i, j: j, labelI: labelAt(i), labelJ: labelAt(j)})
+			}
+		}
+	}
+	return out, nil
+}
+
+// pairwiseLegCoord maps a (pairIndex, oppositeIndex) into (row, col). For
+// ROW scope the pair axis is rows (pairIndex = row, opp = column); for
+// COLUMN scope it is columns (pairIndex = column, opp = row).
+func pairwiseLegCoord(rowScope bool, pairIdx, oppIdx int) (row, col int) {
+	if rowScope {
+		return pairIdx, oppIdx
+	}
+	return oppIdx, pairIdx
+}
+
+// extractPairInputs reads both legs' inputs for a pair at a fixed
+// opposite-axis coordinate. Returns ok=false when either leg is
+// unreadable (missing cell / components).
+func extractPairInputs(host *CrosstabHostView, params types.PairwiseOverlayParams, welford, rowScope bool, r1, c1, r2, c2 int) (pwInputs, bool) {
+	if welford {
+		m1, v1, n1, ok1 := host.WelfordTriple(r1, c1)
+		m2, v2, n2, ok2 := host.WelfordTriple(r2, c2)
+		if !ok1 || !ok2 {
+			return pwInputs{}, false
+		}
+		return pwInputs{m1: m1, m2: m2, v1: v1, v2: v2, n1: n1, n2: n2,
+			p1: math.NaN(), p2: math.NaN()}, true
+	}
+	p1, ok1 := pairwiseProportion(host, params, r1, c1)
+	p2, ok2 := pairwiseProportion(host, params, r2, c2)
+	n1, nok1 := pairwiseSampleSize(host, params, rowScope, r1, c1)
+	n2, nok2 := pairwiseSampleSize(host, params, rowScope, r2, c2)
+	if !ok1 || !ok2 || !nok1 || !nok2 {
+		return pwInputs{}, false
+	}
+	return pwInputs{p1: p1, p2: p2, n1: n1, n2: n2,
+		m1: math.NaN(), m2: math.NaN(), v1: math.NaN(), v2: math.NaN()}, true
+}
+
+func pairwiseProportion(host *CrosstabHostView, params types.PairwiseOverlayParams, r, c int) (float64, bool) {
+	v, ok := host.CellAt(r, c)
+	if !ok {
+		return 0, false
+	}
+	if params.PSource == types.PairwisePSourceCellValue {
+		return v, true
+	}
+	return v / 100.0, true
+}
+
+// pairwiseSampleSize reads the n leg per the n_source mode. rowScope names
+// the pair axis so n_within sums CellCounts along it.
+func pairwiseSampleSize(host *CrosstabHostView, params types.PairwiseOverlayParams, rowScope bool, r, c int) (int, bool) {
+	switch params.NSource {
+	case types.PairwiseNSourceCellValueWeight:
+		v, ok := host.CellAt(r, c)
+		if !ok {
+			return 0, false
+		}
+		return int(v), true
+	case types.PairwiseNSourceRowMarginN:
+		return host.RowMarginN(r)
+	case types.PairwiseNSourceColumnMarginN:
+		return host.ColumnMarginN(c)
+	case types.PairwiseNSourceCellWeightSum:
+		f, ok := host.CellWeightSum(r, c)
+		if !ok {
+			return 0, false
+		}
+		return int(f), true
+	case types.PairwiseNSourceNWithin:
+		prefix := params.NWithinDepth + 1
+		if rowScope {
+			return host.RowSlabN(r, c, prefix)
+		}
+		return host.ColumnSlabN(r, c, prefix)
+	default:
+		return host.CellN(r, c)
+	}
+}
+
+// buildPairwiseLayer assembles the MATRIX-payload OverlayLayer. ROW scope
+// emits rows = pairs, columns = host columns; COLUMN scope transposes.
+func buildPairwiseLayer(spec *types.OverlaySpec, host *CrosstabHostView, pairs []pairwisePair, pvals [][]types.MatrixCell, rowScope bool) types.OverlayLayer {
+	pairHeader := types.AxisHeader{Fields: []string{"pair_a", "pair_b"}, Types: []string{"PAIR", "PAIR"}}
+	pairKeys := make([]types.AxisKey, len(pairs))
+	for p, pr := range pairs {
+		pairKeys[p] = types.AxisKey{pr.labelI, pr.labelJ}
+	}
+
+	var mx types.MatrixPayload
+	mx.CellLabel = "p_value"
+	present := 0
+
+	if rowScope {
+		mx.RowHeader = pairHeader
+		mx.RowKeys = pairKeys
+		mx.ColumnHeader = host.Payload().ColumnHeader
+		mx.ColumnKeys = copyAxisKeys(host.Payload().ColumnKeys)
+		mx.Cells = pvals // already [pair][col]
+		for _, row := range pvals {
+			for _, cell := range row {
+				if cell.Present {
+					present++
+				}
+			}
+		}
+	} else {
+		mx.RowHeader = host.Payload().RowHeader
+		mx.RowKeys = copyAxisKeys(host.Payload().RowKeys)
+		mx.ColumnHeader = pairHeader
+		mx.ColumnKeys = pairKeys
+		// Transpose pvals ([pair][row]) into Cells ([row][pair]).
+		rowCount := host.RowCount()
+		cells := make([][]types.MatrixCell, rowCount)
+		for r := 0; r < rowCount; r++ {
+			cells[r] = make([]types.MatrixCell, len(pairs))
+			for p := range pairs {
+				cell := pvals[p][r]
+				cells[r][p] = cell
+				if cell.Present {
+					present++
+				}
+			}
+		}
+		mx.Cells = cells
+	}
+
+	count := present
+	return types.OverlayLayer{
+		Name:  overlayLayerName(spec),
+		Kind:  spec.Kind,
+		Scope: spec.Scope,
+		Ref:   spec.Ref,
+		Payload: types.OverlayPayload{
+			Shape:  types.OverlayShapeMatrix,
+			Matrix: &mx,
+		},
+		Summary: &types.OverlaySummary{Count: &count},
+	}
+}
+
+func copyAxisKeys(in []types.AxisKey) []types.AxisKey {
+	if in == nil {
+		return nil
+	}
+	out := make([]types.AxisKey, len(in))
+	for i, k := range in {
+		out[i] = append(types.AxisKey(nil), k...)
+	}
+	return out
+}
+
+// stringifyOverlayAxisKey collapses an AxisKey into a deterministic label
+// for the pair-key 2-tuple. Single-element keys produce the bare value;
+// multi-element keys join with "|".
+func stringifyOverlayAxisKey(k types.AxisKey) string {
+	switch len(k) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("%v", k[0])
+	default:
+		parts := make([]string, len(k))
+		for i, v := range k {
+			parts[i] = fmt.Sprintf("%v", v)
+		}
+		return joinPipe(parts)
+	}
+}
+
+func joinPipe(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += "|"
+		}
+		out += p
+	}
+	return out
+}
+
+// ----- per-pair Compute kernels (ported from Orbit service/stats) -----
+
+// pairwisePropZKernel is the pooled-SE two-proportion z-test. Reuses the
+// shared twoProportionZ helper so p-values match OVERLAY_PROP_Z_CELL.
+func pairwisePropZKernel(in pwInputs) (float64, string, bool) {
+	if in.n1 == 0 || in.n2 == 0 {
+		return 0, "ORBIT_STATS_SKIP_N_ZERO", false
+	}
+	n1f, n2f := float64(in.n1), float64(in.n2)
+	p, ok := twoProportionZ(in.p1*n1f, n1f, in.p2*n2f, n2f)
+	if !ok {
+		return 0, "ORBIT_STATS_SKIP_POOLED_SE_INVALID", false
+	}
+	return p, "", true
+}
+
+// pairwiseProbitTKernel is the probit t-test: Φ⁻¹ transform of each leg's
+// proportion, Student-t tail on df = n1 + n2 - 2.
+func pairwiseProbitTKernel(in pwInputs) (float64, string, bool) {
+	if in.n1 == 0 || in.n2 == 0 {
+		return 0, "ORBIT_STATS_SKIP_N_ZERO", false
+	}
+	dof := float64(in.n1 + in.n2 - 2)
+	if dof <= 0 {
+		return 0, "ORBIT_STATS_SKIP_DOF_INVALID", false
+	}
+	const eps = 1e-10
+	p1c := clipUnit(in.p1, eps, 1-eps)
+	p2c := clipUnit(in.p2, eps, 1-eps)
+	denom := math.Sqrt(1.0/float64(in.n1) + 1.0/float64(in.n2))
+	if denom == 0 {
+		return 0, "ORBIT_STATS_SKIP_DENOM_INVALID", false
+	}
+	t := (standardNormalPPF(p1c) - standardNormalPPF(p2c)) / denom
+	if math.IsNaN(t) || math.IsInf(t, 0) {
+		return 0, "ORBIT_STATS_SKIP_T_INVALID", false
+	}
+	pv := studentTTwoSidedP(t, dof)
+	if math.IsNaN(pv) {
+		return 0, "ORBIT_STATS_SKIP_PVALUE_NAN", false
+	}
+	return pv, "", true
+}
+
+// pairwiseWelchTKernel is the Welch–Satterthwaite t-test on Welford
+// triples.
+func pairwiseWelchTKernel(in pwInputs) (float64, string, bool) {
+	if in.n1 <= 1 || in.n2 <= 1 {
+		return 0, "ORBIT_STATS_SKIP_N_TOO_SMALL", false
+	}
+	n1f, n2f := float64(in.n1), float64(in.n2)
+	a := in.v1 / n1f
+	b := in.v2 / n2f
+	if a+b <= 0 {
+		return 0, "ORBIT_STATS_SKIP_VARIANCE_INVALID", false
+	}
+	se := math.Sqrt(a + b)
+	if se == 0 {
+		return 0, "ORBIT_STATS_SKIP_SE_ZERO", false
+	}
+	t := (in.m1 - in.m2) / se
+	dofDenom := (a*a)/(n1f-1) + (b*b)/(n2f-1)
+	if dofDenom <= 0 {
+		return 0, "ORBIT_STATS_SKIP_DOF_INVALID", false
+	}
+	dof := (a + b) * (a + b) / dofDenom
+	if dof <= 0 || math.IsNaN(dof) || math.IsInf(dof, 0) {
+		return 0, "ORBIT_STATS_SKIP_DOF_INVALID", false
+	}
+	pv := studentTTwoSidedP(t, dof)
+	if math.IsNaN(pv) {
+		return 0, "ORBIT_STATS_SKIP_PVALUE_NAN", false
+	}
+	return pv, "", true
+}
+
+// pairwiseTwoMeansZKernel is the two-means z-test on Welford triples
+// (normal CDF tail, no df adjustment).
+func pairwiseTwoMeansZKernel(in pwInputs) (float64, string, bool) {
+	if in.n1 <= 1 || in.n2 <= 1 {
+		return 0, "ORBIT_STATS_SKIP_N_TOO_SMALL", false
+	}
+	a := in.v1 / float64(in.n1)
+	b := in.v2 / float64(in.n2)
+	if a+b <= 0 {
+		return 0, "ORBIT_STATS_SKIP_VARIANCE_INVALID", false
+	}
+	se := math.Sqrt(a + b)
+	if se == 0 {
+		return 0, "ORBIT_STATS_SKIP_SE_ZERO", false
+	}
+	z := (in.m1 - in.m2) / se
+	pv := 2 * standardNormalCDF(-math.Abs(z))
+	return pv, "", true
+}
+
+func clipUnit(x, lo, hi float64) float64 {
+	if x < lo {
+		return lo
+	}
+	if x > hi {
+		return hi
+	}
+	return x
+}
+
+// standardNormalPPF returns Φ⁻¹(p) via the Beasley-Springer-Moro rational
+// approximation (~1e-9 across the support). Ported from Orbit's stats
+// package so the probit kernel matches byte-for-byte. ±Inf at p∈{0,1};
+// the probit kernel clips p before calling.
+func standardNormalPPF(p float64) float64 {
+	a := [...]float64{
+		-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02,
+		1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00,
+	}
+	b := [...]float64{
+		-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02,
+		6.680131188771972e+01, -1.328068155288572e+01,
+	}
+	c := [...]float64{
+		-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00,
+		-2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00,
+	}
+	d := [...]float64{
+		7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00,
+		3.754408661907416e+00,
+	}
+	const pLow = 0.02425
+	const pHigh = 1 - pLow
+	switch {
+	case p <= 0:
+		return math.Inf(-1)
+	case p >= 1:
+		return math.Inf(1)
+	case p < pLow:
+		q := math.Sqrt(-2 * math.Log(p))
+		return (((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q + c[5]) /
+			((((d[0]*q+d[1])*q+d[2])*q+d[3])*q + 1)
+	case p <= pHigh:
+		q := p - 0.5
+		r := q * q
+		return (((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r + a[5]) * q /
+			(((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r + 1)
+	default:
+		q := math.Sqrt(-2 * math.Log(1-p))
+		return -(((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q + c[5]) /
+			((((d[0]*q+d[1])*q+d[2])*q+d[3])*q + 1)
+	}
+}
+
+// ----- skip aggregation -----
+
+// pairwiseTally aggregates per-(pair, opposite) skips by reason code into
+// one warning per code carrying the count and a sample opposite-axis
+// index, mirroring Orbit's skipTally — avoids one warning per degenerate
+// cell on a wide matrix.
+type pairwiseTally struct {
+	order  []string
+	counts map[string]int
+	sample map[string]int
+}
+
+func newPairwiseTally() *pairwiseTally {
+	return &pairwiseTally{counts: map[string]int{}, sample: map[string]int{}}
+}
+
+func (t *pairwiseTally) add(reason string, oppIdx int) {
+	if reason == "" {
+		reason = "ORBIT_STATS_SKIP_EXTRACT_FAILED"
+	}
+	if _, seen := t.counts[reason]; !seen {
+		t.order = append(t.order, reason)
+		t.sample[reason] = oppIdx
+	}
+	t.counts[reason]++
+}
+
+func (t *pairwiseTally) warnings(spec *types.OverlaySpec) []types.OverlayWarning {
+	if len(t.order) == 0 {
+		return nil
+	}
+	out := make([]types.OverlayWarning, 0, len(t.order))
+	for _, reason := range t.order {
+		out = append(out, types.OverlayWarning{
+			Code:    string(errors.PULSE_OVERLAY_REF_ZERO),
+			Message: "overlay " + string(spec.Kind) + " skipped " + fmt.Sprint(t.counts[reason]) + " pair-cell(s): " + reason,
+			Details: map[string]any{
+				"kind":                string(spec.Kind),
+				"reason":              reason,
+				"skipped":             t.counts[reason],
+				"sample_opposite_idx": t.sample[reason],
+			},
+		})
+	}
+	return out
+}

--- a/processing/overlay_pairwise_host.go
+++ b/processing/overlay_pairwise_host.go
@@ -1,0 +1,262 @@
+package processing
+
+import (
+	"fmt"
+
+	"github.com/frankbardon/pulse/types"
+)
+
+// This file extends CrosstabHostView with the component-reading
+// accessors the OVERLAY_PAIRWISE_* family needs: per-cell universal-floor
+// counters (n, weight sums), Welford triples ({mean, variance, n}), margin
+// record counts, and within-group slab sums for the n_within denominator
+// mode. Payload-only overlays (share / index / χ² / Fisher) never call
+// these — they read cells + margins straight off the MatrixPayload.
+//
+// Every accessor is nil-safe and returns ok=false when components were
+// disabled or the requested slot/key is absent, so handlers can surface
+// PULSE_OVERLAY_COMPONENTS_REQUIRED / per-cell skip warnings instead of
+// dividing by a zero sample size.
+
+// HasComponents reports whether the host carries a components block.
+// Component-reading handlers gate on this once up front and bail with
+// PULSE_OVERLAY_COMPONENTS_REQUIRED when false.
+func (h *CrosstabHostView) HasComponents() bool {
+	return h != nil && h.components != nil
+}
+
+// Components returns the underlying CrosstabComponents pointer (nil when
+// components were disabled). Read-only.
+func (h *CrosstabHostView) Components() *types.CrosstabComponents {
+	if h == nil {
+		return nil
+	}
+	return h.components
+}
+
+// CellComponentFloat reads a numeric key from CellComponents[rowIdx][colIdx].
+// Returns (0, false) when components are absent or the slot/key is missing
+// or non-numeric.
+func (h *CrosstabHostView) CellComponentFloat(rowIdx, colIdx int, key string) (float64, bool) {
+	if h == nil || h.components == nil || len(h.components.CellComponents) == 0 {
+		return 0, false
+	}
+	if rowIdx < 0 || rowIdx >= len(h.components.CellComponents) {
+		return 0, false
+	}
+	row := h.components.CellComponents[rowIdx]
+	if colIdx < 0 || colIdx >= len(row) || row[colIdx] == nil {
+		return 0, false
+	}
+	v, ok := row[colIdx][key]
+	if !ok {
+		return 0, false
+	}
+	return componentToFloat(v)
+}
+
+// CellN reads the universal-floor "n" counter from CellComponents[r][c].
+func (h *CrosstabHostView) CellN(rowIdx, colIdx int) (int, bool) {
+	f, ok := h.CellComponentFloat(rowIdx, colIdx, "n")
+	if !ok {
+		return 0, false
+	}
+	return int(f), true
+}
+
+// CellWeightSum reads the "sum_weights" key from CellComponents[r][c]
+// (emitted by AGG_WEIGHTED_MEAN). Used as the prop-Z sample-size leg when
+// the cell aggregator is weighted so n matches the weighted denominator.
+func (h *CrosstabHostView) CellWeightSum(rowIdx, colIdx int) (float64, bool) {
+	return h.CellComponentFloat(rowIdx, colIdx, "sum_weights")
+}
+
+// WelfordTriple reads {mean, variance, n} from CellComponents[r][c].
+// Used by OVERLAY_PAIRWISE_WELCH_T and OVERLAY_PAIRWISE_TWO_MEANS_Z.
+// Returns ok=false unless all three keys are present and numeric.
+func (h *CrosstabHostView) WelfordTriple(rowIdx, colIdx int) (mean, variance float64, n int, ok bool) {
+	m, mok := h.CellComponentFloat(rowIdx, colIdx, "mean")
+	v, vok := h.CellComponentFloat(rowIdx, colIdx, "variance")
+	nf, nok := h.CellComponentFloat(rowIdx, colIdx, "n")
+	if !mok || !vok || !nok {
+		return 0, 0, 0, false
+	}
+	return m, v, int(nf), true
+}
+
+// HasWelfordCells reports whether at least one present cell carries a full
+// {mean, variance, n} triple. The Welford-input handlers gate on this so a
+// matrix whose cell aggregator is not AGG_WELFORD fails fast with a shape
+// error instead of skipping every pair.
+func (h *CrosstabHostView) HasWelfordCells() bool {
+	if h == nil || h.components == nil {
+		return false
+	}
+	for _, row := range h.components.CellComponents {
+		for _, cell := range row {
+			if cell == nil {
+				continue
+			}
+			_, hasM := cell["mean"]
+			_, hasV := cell["variance"]
+			_, hasN := cell["n"]
+			if hasM && hasV && hasN {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// RowMarginN reads the per-row margin record count from
+// CrosstabComponents.RowMarginCounts.
+func (h *CrosstabHostView) RowMarginN(rowIdx int) (int, bool) {
+	if h == nil || h.components == nil ||
+		rowIdx < 0 || rowIdx >= len(h.components.RowMarginCounts) {
+		return 0, false
+	}
+	return h.components.RowMarginCounts[rowIdx], true
+}
+
+// ColumnMarginN reads the per-column margin record count from
+// CrosstabComponents.ColumnMarginCounts.
+func (h *CrosstabHostView) ColumnMarginN(colIdx int) (int, bool) {
+	if h == nil || h.components == nil ||
+		colIdx < 0 || colIdx >= len(h.components.ColumnMarginCounts) {
+		return 0, false
+	}
+	return h.components.ColumnMarginCounts[colIdx], true
+}
+
+// ColumnSlabN sums CellCounts at (rowIdx, c') over every column c' whose
+// ColumnKey agrees with colIdx on the first `prefix` dim positions — the
+// fixed-prefix subgroup that is the denominator under normalize=row when
+// NormalizeWithin = prefix-1 (Pulse-W convention). Returns (0, false) when
+// components/CellCounts are absent; (sum, true) otherwise (sum may be 0).
+func (h *CrosstabHostView) ColumnSlabN(rowIdx, colIdx, prefix int) (int, bool) {
+	if h == nil || h.components == nil || len(h.components.CellCounts) == 0 {
+		return 0, false
+	}
+	if rowIdx < 0 || rowIdx >= len(h.components.CellCounts) {
+		return 0, false
+	}
+	anchor := h.columnKey(colIdx)
+	if anchor == nil || prefix <= 0 || prefix > len(anchor) {
+		return 0, false
+	}
+	row := h.components.CellCounts[rowIdx]
+	total := 0
+	for c := 0; c < len(row); c++ {
+		k := h.columnKey(c)
+		if k == nil || len(k) < prefix {
+			continue
+		}
+		if axisKeyPrefixEqual(anchor, k, prefix) {
+			total += row[c]
+		}
+	}
+	return total, true
+}
+
+// RowSlabN is the row-axis analog of ColumnSlabN: sums CellCounts at
+// (r', colIdx) over rows r' whose RowKey matches rowIdx's on the first
+// `prefix` dim positions. Used by row-axis pairwise specs with n_within.
+func (h *CrosstabHostView) RowSlabN(rowIdx, colIdx, prefix int) (int, bool) {
+	if h == nil || h.components == nil || len(h.components.CellCounts) == 0 {
+		return 0, false
+	}
+	anchor := h.rowKey(rowIdx)
+	if anchor == nil || prefix <= 0 || prefix > len(anchor) {
+		return 0, false
+	}
+	total := 0
+	for rIdx := 0; rIdx < len(h.components.CellCounts); rIdx++ {
+		k := h.rowKey(rIdx)
+		if k == nil || len(k) < prefix {
+			continue
+		}
+		if !axisKeyPrefixEqual(anchor, k, prefix) {
+			continue
+		}
+		row := h.components.CellCounts[rIdx]
+		if colIdx < 0 || colIdx >= len(row) {
+			continue
+		}
+		total += row[colIdx]
+	}
+	return total, true
+}
+
+// rowKey / columnKey return the raw axis-key tuple at an index, or nil
+// when out of range / payload absent. PairAlongDim bucketing and the
+// n_within slab sums need positional dim access, not the joined label.
+func (h *CrosstabHostView) rowKey(rowIdx int) types.AxisKey {
+	if h == nil || h.payload == nil || rowIdx < 0 || rowIdx >= len(h.payload.RowKeys) {
+		return nil
+	}
+	return h.payload.RowKeys[rowIdx]
+}
+
+func (h *CrosstabHostView) columnKey(colIdx int) types.AxisKey {
+	if h == nil || h.payload == nil || colIdx < 0 || colIdx >= len(h.payload.ColumnKeys) {
+		return nil
+	}
+	return h.payload.ColumnKeys[colIdx]
+}
+
+// axisKeyPrefixEqual reports whether a and b agree on the first `prefix`
+// positions. Values compare via fmt.Sprintf so int / int64 / string
+// round-trip variants collapse to the same string.
+func axisKeyPrefixEqual(a, b types.AxisKey, prefix int) bool {
+	if len(a) < prefix || len(b) < prefix {
+		return false
+	}
+	for i := 0; i < prefix; i++ {
+		if fmt.Sprintf("%v", a[i]) != fmt.Sprintf("%v", b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// axisKeyEqualExceptDim reports whether a and b agree on every position
+// EXCEPT the given dim index. PairAlongDim bucketing groups pair-axis
+// indexes whose tuples differ only at one specified position.
+func axisKeyEqualExceptDim(a, b types.AxisKey, dim int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if i == dim {
+			continue
+		}
+		if fmt.Sprintf("%v", a[i]) != fmt.Sprintf("%v", b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// componentToFloat coerces a generic CellComponents map value into
+// float64. Components ride as int / int64 / float64 from the aggregator
+// side and may arrive as float64 after a JSON round-trip; both collapse
+// here. Returns ok=false for non-numeric values.
+func componentToFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case float32:
+		return float64(x), true
+	case int:
+		return float64(x), true
+	case int32:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case uint32:
+		return float64(x), true
+	case uint64:
+		return float64(x), true
+	}
+	return 0, false
+}

--- a/processing/overlay_pairwise_test.go
+++ b/processing/overlay_pairwise_test.go
@@ -1,0 +1,246 @@
+package processing
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/frankbardon/pulse/errors"
+	"github.com/frankbardon/pulse/types"
+)
+
+// pairwisePropHost builds a 3-row × 2-col crosstab whose cells are
+// percentages (0..100) plus a components block carrying per-cell n. Row
+// keys are single-dim category labels.
+func pairwisePropHost() *CrosstabHostView {
+	mx := &types.MatrixPayload{
+		RowHeader:    types.AxisHeader{Fields: []string{"brand"}, Types: []string{"GROUP_CATEGORY"}},
+		ColumnHeader: types.AxisHeader{Fields: []string{"aud"}, Types: []string{"GROUP_CATEGORY"}},
+		RowKeys:      []types.AxisKey{{"A"}, {"B"}, {"C"}},
+		ColumnKeys:   []types.AxisKey{{"x"}, {"y"}},
+		Cells: [][]types.MatrixCell{
+			{{Value: 50.0, Present: true}, {Value: 20.0, Present: true}},
+			{{Value: 30.0, Present: true}, {Value: 20.0, Present: true}},
+			{{Value: 10.0, Present: true}, {Value: 20.0, Present: true}},
+		},
+	}
+	comps := &types.CrosstabComponents{
+		CellComponents: [][]map[string]any{
+			{{"n": 100}, {"n": 100}},
+			{{"n": 100}, {"n": 100}},
+			{{"n": 100}, {"n": 100}},
+		},
+	}
+	return NewCrosstabHostViewWithComponents(mx, comps)
+}
+
+func TestOverlayPairwise_PropZ_RowScope(t *testing.T) {
+	host := pairwisePropHost()
+	specs := []types.OverlaySpec{{
+		Name:  "pz",
+		Kind:  types.OverlayKindPairwisePropZ,
+		Scope: types.OverlayScopeRow,
+	}}
+	layers, _, err := ApplyOverlays(specs, host)
+	if err != nil {
+		t.Fatalf("ApplyOverlays: %v", err)
+	}
+	if len(layers) != 1 {
+		t.Fatalf("expected 1 layer, got %d", len(layers))
+	}
+	mx := layers[0].Payload.Matrix
+	if mx == nil {
+		t.Fatalf("nil matrix payload")
+	}
+	// 3 rows -> 3 pairs (A,B),(A,C),(B,C); 2 opposite columns.
+	if len(mx.RowKeys) != 3 {
+		t.Fatalf("expected 3 pair rows, got %d", len(mx.RowKeys))
+	}
+	if got := mx.RowKeys[0]; got[0] != "A" || got[1] != "B" {
+		t.Fatalf("pair[0] key = %v, want [A B]", got)
+	}
+	if len(mx.ColumnKeys) != 2 {
+		t.Fatalf("expected 2 opposite columns, got %d", len(mx.ColumnKeys))
+	}
+	// Pair (A,B) at column x: p1=0.50 n1=100, p2=0.30 n2=100. Parity:
+	// the cell p-value must equal the shared twoProportionZ helper.
+	wantP, ok := twoProportionZ(0.50*100, 100, 0.30*100, 100)
+	if !ok {
+		t.Fatalf("twoProportionZ unexpectedly undefined")
+	}
+	got := mx.Cells[0][0]
+	if !got.Present {
+		t.Fatalf("pair (A,B) col x cell absent")
+	}
+	gv, _ := got.Value.(float64)
+	if math.Abs(gv-wantP) > 1e-12 {
+		t.Fatalf("pair (A,B) col x p = %v, want %v", gv, wantP)
+	}
+}
+
+func TestOverlayPairwise_ColumnScope(t *testing.T) {
+	host := pairwisePropHost()
+	specs := []types.OverlaySpec{{
+		Kind:  types.OverlayKindPairwisePropZ,
+		Scope: types.OverlayScopeColumn,
+	}}
+	layers, _, err := ApplyOverlays(specs, host)
+	if err != nil {
+		t.Fatalf("ApplyOverlays: %v", err)
+	}
+	mx := layers[0].Payload.Matrix
+	// 2 columns -> 1 pair (x,y); rows echo the 3 host rows.
+	if len(mx.ColumnKeys) != 1 {
+		t.Fatalf("expected 1 pair column, got %d", len(mx.ColumnKeys))
+	}
+	if len(mx.RowKeys) != 3 {
+		t.Fatalf("expected 3 host rows, got %d", len(mx.RowKeys))
+	}
+}
+
+func TestOverlayPairwise_PairAlongDim(t *testing.T) {
+	// Two-dim column axis: (wave, aud). pair_along_dim=1 pairs auds within
+	// each wave bucket only — never across waves.
+	mx := &types.MatrixPayload{
+		RowHeader:    types.AxisHeader{Fields: []string{"brand"}, Types: []string{"GROUP_CATEGORY"}},
+		ColumnHeader: types.AxisHeader{Fields: []string{"wave", "aud"}, Types: []string{"GROUP_CATEGORY", "GROUP_CATEGORY"}},
+		RowKeys:      []types.AxisKey{{"A"}},
+		ColumnKeys:   []types.AxisKey{{"2021", "all"}, {"2021", "owner"}, {"2022", "all"}, {"2022", "owner"}},
+		Cells: [][]types.MatrixCell{
+			{{Value: 50.0, Present: true}, {Value: 30.0, Present: true}, {Value: 40.0, Present: true}, {Value: 20.0, Present: true}},
+		},
+	}
+	comps := &types.CrosstabComponents{
+		CellComponents: [][]map[string]any{
+			{{"n": 100}, {"n": 100}, {"n": 100}, {"n": 100}},
+		},
+	}
+	host := NewCrosstabHostViewWithComponents(mx, comps)
+	dim := 1
+	specs := []types.OverlaySpec{{
+		Kind:   types.OverlayKindPairwisePropZ,
+		Scope:  types.OverlayScopeColumn,
+		Params: mustParams(t, types.PairwiseOverlayParams{PairAlongDim: &dim}),
+	}}
+	layers, _, err := ApplyOverlays(specs, host)
+	if err != nil {
+		t.Fatalf("ApplyOverlays: %v", err)
+	}
+	out := layers[0].Payload.Matrix
+	// Expect exactly 2 pairs: (2021/all,2021/owner) and (2022/all,2022/owner).
+	if len(out.ColumnKeys) != 2 {
+		t.Fatalf("expected 2 within-wave pairs, got %d: %v", len(out.ColumnKeys), out.ColumnKeys)
+	}
+	for _, k := range out.ColumnKeys {
+		if k[0] == k[1] {
+			t.Fatalf("degenerate self-pair %v", k)
+		}
+	}
+}
+
+func TestOverlayPairwise_WelchT_Welford(t *testing.T) {
+	mx := &types.MatrixPayload{
+		RowHeader:    types.AxisHeader{Fields: []string{"brand"}, Types: []string{"GROUP_CATEGORY"}},
+		ColumnHeader: types.AxisHeader{Fields: []string{"aud"}, Types: []string{"GROUP_CATEGORY"}},
+		RowKeys:      []types.AxisKey{{"A"}, {"B"}},
+		ColumnKeys:   []types.AxisKey{{"x"}},
+		Cells: [][]types.MatrixCell{
+			{{Value: 10.0, Present: true}},
+			{{Value: 12.0, Present: true}},
+		},
+	}
+	comps := &types.CrosstabComponents{
+		CellComponents: [][]map[string]any{
+			{{"mean": 10.0, "variance": 4.0, "n": 50}},
+			{{"mean": 12.0, "variance": 9.0, "n": 60}},
+		},
+	}
+	host := NewCrosstabHostViewWithComponents(mx, comps)
+	specs := []types.OverlaySpec{{Kind: types.OverlayKindPairwiseWelchT, Scope: types.OverlayScopeRow}}
+	layers, _, err := ApplyOverlays(specs, host)
+	if err != nil {
+		t.Fatalf("ApplyOverlays: %v", err)
+	}
+	cell := layers[0].Payload.Matrix.Cells[0][0]
+	if !cell.Present {
+		t.Fatalf("welch pair cell absent")
+	}
+	// Closed-form Welch: a=4/50, b=9/60; se=sqrt(a+b); t=(10-12)/se;
+	// df via Satterthwaite; p = studentTTwoSidedP(t, df).
+	a, b := 4.0/50, 9.0/60
+	se := math.Sqrt(a + b)
+	tStat := (10.0 - 12.0) / se
+	df := (a + b) * (a + b) / ((a*a)/49 + (b*b)/59)
+	want := studentTTwoSidedP(tStat, df)
+	gv, _ := cell.Value.(float64)
+	if math.Abs(gv-want) > 1e-12 {
+		t.Fatalf("welch p = %v, want %v", gv, want)
+	}
+}
+
+func TestOverlayPairwise_ComponentsRequired(t *testing.T) {
+	mx := &types.MatrixPayload{
+		RowHeader:    types.AxisHeader{Fields: []string{"brand"}, Types: []string{"GROUP_CATEGORY"}},
+		ColumnHeader: types.AxisHeader{Fields: []string{"aud"}, Types: []string{"GROUP_CATEGORY"}},
+		RowKeys:      []types.AxisKey{{"A"}, {"B"}},
+		ColumnKeys:   []types.AxisKey{{"x"}},
+		Cells:        [][]types.MatrixCell{{{Value: 50.0, Present: true}}, {{Value: 30.0, Present: true}}},
+	}
+	// No components.
+	host := NewCrosstabHostView(mx)
+	specs := []types.OverlaySpec{{Kind: types.OverlayKindPairwisePropZ, Scope: types.OverlayScopeRow}}
+	_, _, err := ApplyOverlays(specs, host)
+	if err == nil {
+		t.Fatalf("expected COMPONENTS_REQUIRED error, got nil")
+	}
+	if !pairwiseErrHasCode(err, errors.PULSE_OVERLAY_COMPONENTS_REQUIRED) {
+		t.Fatalf("error %v does not carry PULSE_OVERLAY_COMPONENTS_REQUIRED", err)
+	}
+}
+
+func TestOverlayPairwise_NonWelfordShapeMismatch(t *testing.T) {
+	// Welch kind against a host with only "n" (no mean/variance) — must
+	// fail the Welford-shape gate.
+	host := pairwisePropHost()
+	specs := []types.OverlaySpec{{Kind: types.OverlayKindPairwiseWelchT, Scope: types.OverlayScopeRow}}
+	_, _, err := ApplyOverlays(specs, host)
+	if err == nil {
+		t.Fatalf("expected shape-mismatch error, got nil")
+	}
+	if !pairwiseErrHasCode(err, errors.PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE) {
+		t.Fatalf("error %v does not carry PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE", err)
+	}
+}
+
+func TestStandardNormalPPF_RoundTrip(t *testing.T) {
+	for _, p := range []float64{0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.975, 0.99} {
+		z := standardNormalPPF(p)
+		back := standardNormalCDF(z)
+		if math.Abs(back-p) > 1e-6 {
+			t.Fatalf("ppf/cdf round-trip for p=%v: got %v", p, back)
+		}
+	}
+	if z := standardNormalPPF(0.5); math.Abs(z) > 1e-9 {
+		t.Fatalf("ppf(0.5) = %v, want ~0", z)
+	}
+}
+
+func mustParams(t *testing.T, p types.PairwiseOverlayParams) []byte {
+	t.Helper()
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	return raw
+}
+
+// containsCode reports whether err is a *CodedError carrying code in its
+// Details["code"] key (the canonical overlay-code carrier).
+func pairwiseErrHasCode(err error, code errors.Code) bool {
+	coded, ok := err.(*errors.CodedError)
+	if !ok {
+		return false
+	}
+	c, _ := coded.Details["code"].(string)
+	return c == string(code)
+}

--- a/skills/op-overlay-pairwise-probit-t.md
+++ b/skills/op-overlay-pairwise-probit-t.md
@@ -1,0 +1,47 @@
+---
+name: op-overlay-pairwise-probit-t
+kind: operator
+category: OVERLAY
+operator: OVERLAY_PAIRWISE_PROBIT_T
+description: Intra-matrix axis-pairwise probit t-test (Φ⁻¹ transform of each leg's proportion, Student-t tail).
+type: reference
+applies_to: process, compose
+examples_tags: [overlay, cross-tabulation, hypothesis-test, pairwise]
+---
+
+Overlays decorate the host result; they do not emit `Response.Components` (but this family READS them).
+
+Intra-matrix pairwise: tests one host-matrix slot against another ALONG one axis of the SAME crosstab. ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row. Sibling of `OVERLAY_PAIRWISE_PROP_Z` — same proportion + n inputs, different test (probit transform).
+
+## Params
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `Scope` | enum | (required) | `row` or `column`. |
+| `Ref` | object | (empty) | Intra-matrix — leave empty. |
+| `params.pair_along_dim` | int | (unset) | Restrict pairs to same-bucket comparisons on the pair axis. |
+| `params.n_source` | enum | `cell_n_unweighted` | Sample-size leg (see `op-overlay-pairwise-prop-z`). |
+| `params.n_within_depth` | int | `0` | Within-group denominator depth for `n_source=n_within`. |
+| `params.p_source` | enum | `cell_value_pct` | `cell_value_pct` or `cell_value`. |
+
+## Host shape
+
+MATRIX crosstab + `Response.Components.Crosstab`. Components-disabled host → `PULSE_OVERLAY_COMPONENTS_REQUIRED`.
+
+## Output
+
+MATRIX — pair × opposite-axis grid of two-sided p-values. Identical layout to `op-overlay-pairwise-prop-z`.
+
+## Math
+
+Per pair: `t = (Φ⁻¹(p_i) - Φ⁻¹(p_j)) / sqrt(1/n_i + 1/n_j)` against Student-t with `df = n_i + n_j - 2`, two-sided. Proportions are clipped to `[1e-10, 1-1e-10]` before the Φ⁻¹ transform. Reuses the Student-t survival helper backing `TEST_T`.
+
+## Gotchas
+
+- `df <= 0` (n_i + n_j <= 2) or a non-finite t skips the pair (aggregated `PULSE_OVERLAY_REF_ZERO` warning).
+- Emits RAW p-values only — direction / thresholds / min-n are the embedder's job.
+- Buffered (inferential).
+
+## See
+
+- Skills: `overlay-system`, `crosstab-guide`, `op-overlay-pairwise-prop-z`, `op-test-t`.

--- a/skills/op-overlay-pairwise-prop-z.md
+++ b/skills/op-overlay-pairwise-prop-z.md
@@ -1,0 +1,44 @@
+---
+name: op-overlay-pairwise-prop-z
+kind: operator
+category: OVERLAY
+operator: OVERLAY_PAIRWISE_PROP_Z
+description: Intra-matrix axis-pairwise pooled-SE two-proportion z-test (row-vs-row or col-vs-col within one crosstab).
+type: reference
+applies_to: process, compose
+examples_tags: [overlay, cross-tabulation, hypothesis-test, pairwise]
+---
+
+Overlays decorate the host result; they do not emit `Response.Components` (but this family READS them).
+
+Intra-matrix pairwise: tests one host-matrix slot against another ALONG one axis of the SAME crosstab — the per-Request counterpart to the Compose-host `OVERLAY_PROP_Z_PANEL` (which pairs across slots). ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row.
+
+## Params
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `Scope` | enum | (required) | `row` (pair rows per column) or `column` (pair columns per row). |
+| `Ref` | object | (empty) | Intra-matrix — leave empty. Any populated arm → `PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE`. |
+| `params.pair_along_dim` | int | (unset) | Restrict pairs to "all pair-axis dims agree except this one" buckets. Unset = every pair. |
+| `params.n_source` | enum | `cell_n_unweighted` | Sample-size leg: `cell_n_unweighted` / `cell_value_weighted` / `row_margin_n` / `column_margin_n` / `n_within` / `cell_weight_sum`. |
+| `params.n_within_depth` | int | `0` | With `n_source=n_within`, fixes the first depth+1 pair-axis dims in the denominator (mirrors `CrosstabSpec.NormalizeWithin`). |
+| `params.p_source` | enum | `cell_value_pct` | `cell_value_pct` (cell is a 0..100 percentage, ÷100) or `cell_value` (already 0..1). |
+
+## Host shape
+
+MATRIX crosstab (`Response.Crosstab.Matrix`) + `Response.Components.Crosstab`. A components-disabled host fires `PULSE_OVERLAY_COMPONENTS_REQUIRED`.
+
+## Output
+
+MATRIX — `OverlayLayer.Payload.Shape = "matrix"`. The PAIR axis carries one entry per evaluated `(i, j)` index pair (key = the 2-tuple of the compared legs' labels); the OPPOSITE axis echoes the host's other axis. Cell `(pair, opp)` = the pair's two-sided p-value, absent when a leg is unreadable or the test degenerate. ROW scope → rows = pairs, cols = host columns; COLUMN scope transposes.
+
+## Gotchas
+
+- Reuses `twoProportionZ` — p-values match `OVERLAY_PROP_Z_CELL` / `TEST_PROP_Z` byte-for-byte for the same (success, n) inputs.
+- Emits RAW p-values only. Direction (which leg is greater), thresholds, and min-n flags are the embedder's job — every input for them is already on the response (host cells, per-cell n).
+- Degenerate pairs (n=0, pooled ∈ {0,1}, zero SE) fold into one aggregated `PULSE_OVERLAY_REF_ZERO` warning per reason.
+- Buffered (inferential).
+
+## See
+
+- Skills: `overlay-system`, `crosstab-guide`, `op-overlay-pairwise-probit-t`, `op-overlay-prop-z-cell`, `op-test-prop-z`.

--- a/skills/op-overlay-pairwise-two-means-z.md
+++ b/skills/op-overlay-pairwise-two-means-z.md
@@ -1,0 +1,47 @@
+---
+name: op-overlay-pairwise-two-means-z
+kind: operator
+category: OVERLAY
+operator: OVERLAY_PAIRWISE_TWO_MEANS_Z
+description: Intra-matrix axis-pairwise two-means z-test on AGG_WELFORD cells (normal-CDF tail, no df).
+type: reference
+applies_to: process, compose
+examples_tags: [overlay, cross-tabulation, hypothesis-test, pairwise, welford-triple]
+---
+
+Overlays decorate the host result; they do not emit `Response.Components` (but this family READS them).
+
+Intra-matrix pairwise on MEANS: tests one host-matrix cell's mean against another ALONG one axis of the SAME crosstab, reading the `{mean, variance, n}` Welford triple from `Response.Components.Crosstab.CellComponents`. ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row. Normal-CDF sibling of `OVERLAY_PAIRWISE_WELCH_T` — same standard error, no Satterthwaite df adjustment.
+
+## Params
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `Scope` | enum | (required) | `row` or `column`. |
+| `Ref` | object | (empty) | Intra-matrix — leave empty. |
+| `params.pair_along_dim` | int | (unset) | Restrict pairs to same-bucket comparisons on the pair axis. |
+
+`n_source` / `p_source` are ignored — n and the moments come from the Welford triple.
+
+## Host shape
+
+MATRIX crosstab whose **cell aggregator is `AGG_WELFORD`** + `Response.Components.Crosstab`. A non-Welford host fires `PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE`; a components-disabled host fires `PULSE_OVERLAY_COMPONENTS_REQUIRED`.
+
+## Output
+
+MATRIX — pair × opposite-axis grid of two-sided p-values (same layout as `op-overlay-pairwise-prop-z`).
+
+## Math
+
+Per pair: `a = v_i/n_i`, `b = v_j/n_j`; `se = sqrt(a + b)`; `z = (m_i - m_j) / se`; `p = 2 * (1 - Φ(|z|))` via the `standardNormalCDF` helper backing `TEST_Z_TWO_SAMPLE`.
+
+## Gotchas
+
+- Either leg with `n <= 1` skips the pair (aggregated `PULSE_OVERLAY_REF_ZERO` warning).
+- Use `OVERLAY_PAIRWISE_WELCH_T` when small-sample df correction matters; this kind assumes the normal approximation.
+- Emits RAW p-values only — direction / thresholds are the embedder's job.
+- Buffered (inferential).
+
+## See
+
+- Skills: `overlay-system`, `crosstab-guide`, `op-overlay-pairwise-welch-t`, `op-agg-welford`, `op-test-z-two-sample`.

--- a/skills/op-overlay-pairwise-welch-t.md
+++ b/skills/op-overlay-pairwise-welch-t.md
@@ -1,0 +1,47 @@
+---
+name: op-overlay-pairwise-welch-t
+kind: operator
+category: OVERLAY
+operator: OVERLAY_PAIRWISE_WELCH_T
+description: Intra-matrix axis-pairwise Welch–Satterthwaite t-test on AGG_WELFORD cells.
+type: reference
+applies_to: process, compose
+examples_tags: [overlay, cross-tabulation, hypothesis-test, pairwise, welford-triple]
+---
+
+Overlays decorate the host result; they do not emit `Response.Components` (but this family READS them).
+
+Intra-matrix pairwise on MEANS: tests one host-matrix cell's mean against another ALONG one axis of the SAME crosstab, reading the `{mean, variance, n}` Welford triple from `Response.Components.Crosstab.CellComponents`. ROW scope pairs row indices for each column; COLUMN scope pairs column indices for each row.
+
+## Params
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `Scope` | enum | (required) | `row` or `column`. |
+| `Ref` | object | (empty) | Intra-matrix — leave empty. |
+| `params.pair_along_dim` | int | (unset) | Restrict pairs to same-bucket comparisons on the pair axis. |
+
+`n_source` / `p_source` are ignored — n and the moments come from the Welford triple.
+
+## Host shape
+
+MATRIX crosstab whose **cell aggregator is `AGG_WELFORD`** + `Response.Components.Crosstab`. A non-Welford host fires `PULSE_OVERLAY_REF_INCOMPATIBLE_WITH_SHAPE`; a components-disabled host fires `PULSE_OVERLAY_COMPONENTS_REQUIRED`.
+
+## Output
+
+MATRIX — pair × opposite-axis grid of two-sided p-values (same layout as `op-overlay-pairwise-prop-z`).
+
+## Math
+
+Per pair: `a = v_i/n_i`, `b = v_j/n_j`; `se = sqrt(a + b)`; `t = (m_i - m_j) / se`; `df = (a+b)² / (a²/(n_i-1) + b²/(n_j-1))` (Welch–Satterthwaite); two-sided via the `studentTTwoSidedP` helper backing `TEST_T` / `TEST_WELCH`.
+
+## Gotchas
+
+- Either leg with `n <= 1` skips the pair (aggregated `PULSE_OVERLAY_REF_ZERO` warning).
+- Normal-CDF sibling is `OVERLAY_PAIRWISE_TWO_MEANS_Z` (same SE, no df adjustment).
+- Emits RAW p-values only — direction / thresholds are the embedder's job.
+- Buffered (inferential).
+
+## See
+
+- Skills: `overlay-system`, `crosstab-guide`, `op-overlay-pairwise-two-means-z`, `op-agg-welford`, `op-test-welch`.

--- a/types/overlay.go
+++ b/types/overlay.go
@@ -1955,6 +1955,93 @@ const (
 	// streamable-test path is plumbed (PRD §2 Non-Goals).
 	OverlayKindPropZPanel OverlayKind = "OVERLAY_PROP_Z_PANEL"
 
+	// The OVERLAY_PAIRWISE_* family is the intra-matrix axis-pairwise
+	// significance catalog: per-Request (NOT Compose-host) overlays that
+	// test one host-matrix slot against another ALONG a single axis of the
+	// SAME materialised crosstab. Where OVERLAY_PROP_Z_PANEL pairs across
+	// Compose SLOTS, this family pairs across the host's own row (or
+	// column) indices — "test brand A vs brand B within each audience
+	// column" against one Process result. ROW scope pairs row indices for
+	// each column; COLUMN scope pairs column indices for each row.
+	//
+	// Output — MATRIX payload, pair × opposite-axis grid of scalar
+	// two-sided p-values. The PAIR axis is one dimension of the emitted
+	// MatrixPayload (one entry per evaluated `(i, j)` index pair, key =
+	// the 2-tuple of the compared legs' axis-key values for display); the
+	// OPPOSITE axis is the host's other axis verbatim. Cell `(pair, opp)`
+	// carries the pair's p-value at that opposite-axis position, or is
+	// absent when either leg was unreadable / degenerate. Pairs are
+	// emitted in canonical order (every `(i, j)` with `i < j`, bucketed
+	// when `Params.pair_along_dim` is set) so consumers zip the grid
+	// against their own re-derived pair list positionally.
+	//
+	// Division of labour: this family emits RAW p-values only. Direction
+	// (which leg is greater), significance thresholds, min-n flags, and
+	// any domain-specific row/column exclusion are presentation concerns
+	// the embedder applies — every input needed for them (the host cells,
+	// the per-cell n) is already on the response, so the overlay does not
+	// re-encode them.
+	//
+	// Params (`OverlaySpec.Params`, all optional):
+	//   - pair_along_dim (int): restrict pairs to "all dims agree except
+	//     this one" buckets on the pair axis (e.g. pair audiences within
+	//     each wave×card-pref bucket). Omitted = every pair-axis index vs
+	//     every other.
+	//   - n_source (string): where the sample-size leg is read —
+	//     "cell_n_unweighted" (default; CellComponents["n"]),
+	//     "cell_value_weighted" (cell value as count),
+	//     "row_margin_n" / "column_margin_n" (margin counts),
+	//     "n_within" (CellCounts slab over n_within_depth),
+	//     "cell_weight_sum" (CellComponents["sum_weights"]).
+	//   - n_within_depth (int): with n_source=n_within, fixes the first
+	//     depth+1 pair-axis dims in the denominator (mirrors
+	//     CrosstabSpec.NormalizeWithin).
+	//   - p_source (string): "cell_value_pct" (default; cell value is a
+	//     0..100 percentage, divided by 100) or "cell_value" (already a
+	//     0..1 proportion). Ignored by the Welford-input kinds.
+	//
+	// Components requirement: every kind reads Response.Components.Crosstab
+	// (cell n, weight sums, Welford triples, margin counts). A host built
+	// with components disabled fires PULSE_OVERLAY_COMPONENTS_REQUIRED.
+	//
+	// Buffered. Inferential overlays stay buffered until a streamable-test
+	// path is plumbed (PRD §2 Non-Goals).
+
+	// OverlayKindPairwiseProbitT is the intra-matrix axis-pairwise probit
+	// t-test (syndicated meaningfulness / uniqueness family). Per opposite-
+	// axis position it transforms each leg's proportion through Φ⁻¹ and
+	// tests the difference: t = (Φ⁻¹(p_i) - Φ⁻¹(p_j)) / sqrt(1/n_i + 1/n_j)
+	// against Student-t with df = n_i + n_j - 2, two-sided. Reuses the
+	// Student-t survival helper backing TEST_T. Reads proportion + n per
+	// leg (p_source / n_source). See the OVERLAY_PAIRWISE_* family note.
+	OverlayKindPairwiseProbitT OverlayKind = "OVERLAY_PAIRWISE_PROBIT_T"
+
+	// OverlayKindPairwisePropZ is the intra-matrix axis-pairwise pooled-SE
+	// two-proportion z-test (custom / A&U / syndicated top2box family). Per
+	// opposite-axis position it tests leg i vs leg j via the same
+	// twoProportionZ helper backing OVERLAY_PROP_Z_CELL, so p-values match
+	// byte-for-byte. Reads proportion + n per leg (p_source / n_source).
+	// See the OVERLAY_PAIRWISE_* family note.
+	OverlayKindPairwisePropZ OverlayKind = "OVERLAY_PAIRWISE_PROP_Z"
+
+	// OverlayKindPairwiseTwoMeansZ is the intra-matrix axis-pairwise
+	// two-means z-test on AGG_WELFORD cells (AU Q137/Q140/Q141 family). Per
+	// opposite-axis position it tests mean_i vs mean_j using the Welford
+	// triple {mean, variance, n} on CellComponents with a normal-CDF tail
+	// (no df adjustment): z = (m_i - m_j) / sqrt(v_i/n_i + v_j/n_j). Reuses
+	// standardNormalCDF. A non-Welford host fails fast with
+	// PULSE_OVERLAY_SHAPE_MISMATCH. See the OVERLAY_PAIRWISE_* family note.
+	OverlayKindPairwiseTwoMeansZ OverlayKind = "OVERLAY_PAIRWISE_TWO_MEANS_Z"
+
+	// OverlayKindPairwiseWelchT is the intra-matrix axis-pairwise
+	// Welch–Satterthwaite t-test on AGG_WELFORD cells (AU Q99 family). Per
+	// opposite-axis position it tests mean_i vs mean_j using the Welford
+	// triple {mean, variance, n} with the Welch SE and Satterthwaite df,
+	// two-sided via the Student-t survival helper backing TEST_T /
+	// TEST_WELCH. A non-Welford host fails fast with
+	// PULSE_OVERLAY_SHAPE_MISMATCH. See the OVERLAY_PAIRWISE_* family note.
+	OverlayKindPairwiseWelchT OverlayKind = "OVERLAY_PAIRWISE_WELCH_T"
+
 	// OverlayKindPanelIndexVsRef is the COMPOSE-host multi-reference
 	// dual-shape ratio index — indexes EVERY target slot against the
 	// SHARED reference slot and emits ONE OverlayLayer per target. The
@@ -2296,6 +2383,10 @@ func AllOverlayKinds() []OverlayKind {
 		OverlayKindIndexVsStage,
 		OverlayKindIndexVsTotal,
 		OverlayKindKSVsPop,
+		OverlayKindPairwiseProbitT,
+		OverlayKindPairwisePropZ,
+		OverlayKindPairwiseTwoMeansZ,
+		OverlayKindPairwiseWelchT,
 		OverlayKindPanelIndexVsRef,
 		OverlayKindPropZCell,
 		OverlayKindPropZPanel,

--- a/types/overlay_pairwise.go
+++ b/types/overlay_pairwise.go
@@ -1,0 +1,111 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PairwiseOverlayParams is the decoded OverlaySpec.Params shape for the
+// OVERLAY_PAIRWISE_* family. Every field is optional; the zero value
+// (no params) means "every pair-axis index vs every other, cell n
+// unweighted, cell value as a 0..100 percentage". Axis (row vs column
+// pairing) rides on OverlaySpec.Scope, not here.
+type PairwiseOverlayParams struct {
+	// PairAlongDim, when non-nil, restricts pair generation to pair-axis
+	// indexes whose key tuples agree on every dim position EXCEPT this
+	// one ("all dims agree except this one" buckets). nil = every pair.
+	// Must be >= 0 and < the pair-axis dim count.
+	PairAlongDim *int `json:"pair_along_dim,omitempty"`
+
+	// NSource selects where the sample-size leg is read. One of the
+	// PairwiseNSource* constants. Empty = cell_n_unweighted. Ignored by
+	// the Welford-input kinds (welch / two-means read n from the triple).
+	NSource string `json:"n_source,omitempty"`
+
+	// NWithinDepth, with NSource=n_within, fixes the first NWithinDepth+1
+	// pair-axis dim positions in the denominator (mirrors
+	// CrosstabSpec.NormalizeWithin). Must be >= 0.
+	NWithinDepth int `json:"n_within_depth,omitempty"`
+
+	// PSource selects how the proportion leg is derived for the
+	// proportion-input kinds (prop-Z, probit-t). One of the
+	// PairwisePSource* constants. Empty = cell_value_pct. Ignored by the
+	// Welford-input kinds.
+	PSource string `json:"p_source,omitempty"`
+}
+
+// Pairwise sample-size source modes (PairwiseOverlayParams.NSource).
+const (
+	PairwiseNSourceCellNUnweighted = "cell_n_unweighted"
+	PairwiseNSourceCellValueWeight = "cell_value_weighted"
+	PairwiseNSourceRowMarginN      = "row_margin_n"
+	PairwiseNSourceColumnMarginN   = "column_margin_n"
+	PairwiseNSourceNWithin         = "n_within"
+	PairwiseNSourceCellWeightSum   = "cell_weight_sum"
+)
+
+// Pairwise proportion source modes (PairwiseOverlayParams.PSource).
+const (
+	PairwisePSourceCellValuePct = "cell_value_pct"
+	PairwisePSourceCellValue    = "cell_value"
+)
+
+// ValidPairwiseNSource reports whether s names a supported NSource mode.
+// Empty counts as valid (defaults to cell_n_unweighted).
+func ValidPairwiseNSource(s string) bool {
+	switch s {
+	case "",
+		PairwiseNSourceCellNUnweighted,
+		PairwiseNSourceCellValueWeight,
+		PairwiseNSourceRowMarginN,
+		PairwiseNSourceColumnMarginN,
+		PairwiseNSourceNWithin,
+		PairwiseNSourceCellWeightSum:
+		return true
+	}
+	return false
+}
+
+// ValidPairwisePSource reports whether s names a supported PSource mode.
+// Empty counts as valid (defaults to cell_value_pct).
+func ValidPairwisePSource(s string) bool {
+	switch s {
+	case "", PairwisePSourceCellValuePct, PairwisePSourceCellValue:
+		return true
+	}
+	return false
+}
+
+// DecodePairwiseParams decodes a raw OverlaySpec.Params blob into a
+// PairwiseOverlayParams. A nil / empty blob yields the zero value (all
+// defaults). Malformed JSON returns an error so callers surface a clean
+// predict-time / runtime diagnostic rather than panicking.
+func DecodePairwiseParams(raw json.RawMessage) (PairwiseOverlayParams, error) {
+	var p PairwiseOverlayParams
+	if len(raw) == 0 {
+		return p, nil
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return p, fmt.Errorf("decode pairwise overlay params: %w", err)
+	}
+	return p, nil
+}
+
+// IsPairwiseOverlayKind reports whether kind is a member of the
+// OVERLAY_PAIRWISE_* family.
+func IsPairwiseOverlayKind(kind OverlayKind) bool {
+	switch kind {
+	case OverlayKindPairwisePropZ,
+		OverlayKindPairwiseProbitT,
+		OverlayKindPairwiseWelchT,
+		OverlayKindPairwiseTwoMeansZ:
+		return true
+	}
+	return false
+}
+
+// PairwiseKindUsesWelford reports whether kind reads the Welford triple
+// {mean, variance, n} (welch / two-means) rather than a proportion + n.
+func PairwiseKindUsesWelford(kind OverlayKind) bool {
+	return kind == OverlayKindPairwiseWelchT || kind == OverlayKindPairwiseTwoMeansZ
+}

--- a/types/overlay_streamability.go
+++ b/types/overlay_streamability.go
@@ -278,6 +278,15 @@ var OverlayStreamability = map[OverlayKind]bool{
 	// barrier in service.Compose / service.ComposeParallel (the same
 	// chassis precedent every COMPOSE kind uses).
 	OverlayKindPanelIndexVsRef: true,
+	// The OVERLAY_PAIRWISE_* family is inherently buffered — per-Request
+	// intra-matrix axis-pairwise significance tests that fold the host's
+	// materialised cells, per-cell components (n / Welford triples), and
+	// margin counts. Inferential kinds stay buffered per PRD §2 Non-Goals
+	// regardless of host streamability.
+	OverlayKindPairwiseProbitT:   false,
+	OverlayKindPairwisePropZ:     false,
+	OverlayKindPairwiseTwoMeansZ: false,
+	OverlayKindPairwiseWelchT:    false,
 	// OVERLAY_PROP_Z_CELL is inherently buffered — COMPOSE-only kind,
 	// per-cell two-proportion z-test against the reference slot's
 	// matching cell. Reuses the standardNormalCDF helper backing

--- a/types/overlay_streamability_test.go
+++ b/types/overlay_streamability_test.go
@@ -80,12 +80,16 @@ func TestStreamability_OverlaysKnown(t *testing.T) {
 		// grand-total accumulator is one f64 alongside the per-group
 		// accumulators inside the streaming Process fold; no second pass
 		// over records.
-		OverlayKindIndexVsTotal:    true,
-		OverlayKindKSVsPop:         false,
-		OverlayKindPanelIndexVsRef: true,
-		OverlayKindPropZCell:       false,
-		OverlayKindPropZPanel:      false,
-		OverlayKindRank:            false,
+		OverlayKindIndexVsTotal:      true,
+		OverlayKindKSVsPop:           false,
+		OverlayKindPanelIndexVsRef:   true,
+		OverlayKindPairwiseProbitT:   false,
+		OverlayKindPairwisePropZ:     false,
+		OverlayKindPairwiseTwoMeansZ: false,
+		OverlayKindPairwiseWelchT:    false,
+		OverlayKindPropZCell:         false,
+		OverlayKindPropZPanel:        false,
+		OverlayKindRank:              false,
 		// SHARE_OF_COL shares INDEX_VS_MARGIN's buffered footprint — its
 		// column-margin denominator is recomputed by the buffered
 		// crosstab orchestrator before ApplyOverlays runs.


### PR DESCRIPTION
Adds four per-Request overlay kinds that test one host-matrix slot against another **along a single axis of the same crosstab** (row-vs-row per column under ROW scope; column-vs-column per row under COLUMN scope) — the intra-matrix counterpart to the slot-axis `OVERLAY_PROP_Z_PANEL`:

| Kind | Test |
|---|---|
| `OVERLAY_PAIRWISE_PROP_Z` | pooled-SE two-proportion z (reuses `twoProportionZ`) |
| `OVERLAY_PAIRWISE_PROBIT_T` | probit t-test (Φ⁻¹ + Student-t tail) |
| `OVERLAY_PAIRWISE_WELCH_T` | Welch–Satterthwaite t on `AGG_WELFORD` cells |
| `OVERLAY_PAIRWISE_TWO_MEANS_Z` | two-means z on `AGG_WELFORD` cells |

**Output:** MATRIX payload — a `pair × opposite-axis` grid of raw two-sided p-values. The family emits p-values only; direction / thresholds / min-n flags are the embedder's presentation concern.

**Surfaces touched:** `CrosstabHostView` components arm (`NewCrosstabHostViewWithComponents` + cell-n / weight-sum / Welford-triple / margin / n_within accessors), `types.PairwiseOverlayParams`, predict validation, dispatch + handler + kernels, new `PULSE_OVERLAY_COMPONENTS_REQUIRED` code, capabilities, streamability (buffered), 4 atomic skills, 2 examples, tests. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)